### PR TITLE
Persist: introduce type-safe bulk-fetch functions

### DIFF
--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraBackend.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraBackend.java
@@ -213,10 +213,12 @@ public final class CassandraBackend implements Backend {
                 try {
                   for (Row row : rs.currentPage()) {
                     R resultItem = rowToResult.apply(row);
-                    K id = idExtractor.apply(resultItem);
-                    int i = idToIndex.getValue(id);
-                    if (i != -1) {
-                      result.set(i, resultItem);
+                    if (resultItem != null) {
+                      K id = idExtractor.apply(resultItem);
+                      int i = idToIndex.getValue(id);
+                      if (i != -1) {
+                        result.set(i, resultItem);
+                      }
                     }
                   }
 

--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBasePersistTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBasePersistTests.java
@@ -833,6 +833,12 @@ public class AbstractBasePersistTests {
         .extracting(ObjNotFoundException::objIds, list(ObjId.class))
         .containsExactly(id);
 
+    soft.assertThatThrownBy(() -> persist.fetchTypedObj(id, null, Obj.class))
+        .isInstanceOf(ObjNotFoundException.class)
+        .asInstanceOf(type(ObjNotFoundException.class))
+        .extracting(ObjNotFoundException::objIds, list(ObjId.class))
+        .containsExactly(id);
+
     soft.assertThatThrownBy(() -> persist.fetchObjs(new ObjId[] {EMPTY_OBJ_ID, id}))
         .isInstanceOf(ObjNotFoundException.class)
         .asInstanceOf(type(ObjNotFoundException.class))
@@ -840,6 +846,10 @@ public class AbstractBasePersistTests {
         .containsExactly(EMPTY_OBJ_ID, id);
 
     soft.assertThat(persist.fetchObjsIfExist(new ObjId[] {EMPTY_OBJ_ID, id}))
+        .hasSize(2)
+        .containsOnlyNulls();
+
+    soft.assertThat(persist.fetchTypedObjsIfExist(new ObjId[] {EMPTY_OBJ_ID, id}, null, Obj.class))
         .hasSize(2)
         .containsOnlyNulls();
 

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogicImpl.java
@@ -16,7 +16,6 @@
 package org.projectnessie.versioned.storage.common.logic;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Maps.newHashMapWithExpectedSize;
 import static com.google.common.collect.Sets.newHashSetWithExpectedSize;
 import static java.util.Collections.emptyIterator;
@@ -880,17 +879,9 @@ final class CommitLogicImpl implements CommitLogic {
 
     CommitObj[] r = new CommitObj[2];
     if (startCommitId != null || endCommitId != null) {
-      Obj[] objs = persist.fetchObjs(new ObjId[] {startCommitId, endCommitId});
-      r[0] = castToCommitObj(objs[0]);
-      r[1] = castToCommitObj(objs[1]);
+      r = persist.fetchTypedObjs(new ObjId[] {startCommitId, endCommitId}, COMMIT, CommitObj.class);
     }
     return r;
-  }
-
-  private static CommitObj castToCommitObj(Obj obj) {
-    checkState(
-        obj == null || obj instanceof CommitObj, "Expected a Commit object, but got %s", obj);
-    return (CommitObj) obj;
   }
 
   @Nonnull

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IndexesLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IndexesLogicImpl.java
@@ -270,13 +270,12 @@ final class IndexesLogicImpl implements IndexesLogic {
 
   private StoreIndex<CommitOp>[] loadIndexSegments(@Nonnull ObjId[] indexes) {
     try {
-      Obj[] objs = persist.fetchObjs(indexes);
+      IndexObj[] objs = persist.fetchTypedObjs(indexes, INDEX, IndexObj.class);
       @SuppressWarnings("unchecked")
       StoreIndex<CommitOp>[] r = new StoreIndex[indexes.length];
       for (int i = 0; i < objs.length; i++) {
-        Obj obj = objs[i];
-        if (obj != null) {
-          IndexObj index = (IndexObj) obj;
+        IndexObj index = objs[i];
+        if (index != null) {
           r[i] = deserializeIndex(index.index()).setObjId(indexes[i]);
         }
       }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObservingPersist.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObservingPersist.java
@@ -160,8 +160,8 @@ public class ObservingPersist implements Persist {
   @Counted(PREFIX)
   @Timed(value = PREFIX, histogram = true)
   @Nonnull
-  public <T extends Obj> T fetchTypedObj(@Nonnull ObjId id, ObjType type, Class<T> typeClass)
-      throws ObjNotFoundException {
+  public <T extends Obj> T fetchTypedObj(
+      @Nonnull ObjId id, ObjType type, @Nonnull Class<T> typeClass) throws ObjNotFoundException {
     return delegate.fetchTypedObj(id, type, typeClass);
   }
 
@@ -190,6 +190,26 @@ public class ObservingPersist implements Persist {
   @Nonnull
   public Obj[] fetchObjsIfExist(@Nonnull ObjId[] ids) {
     return delegate.fetchObjsIfExist(ids);
+  }
+
+  @WithSpan
+  @Override
+  @Counted(PREFIX)
+  @Timed(value = PREFIX, histogram = true)
+  @Nonnull
+  public <T extends Obj> T[] fetchTypedObjs(
+      @Nonnull ObjId[] ids, ObjType type, @Nonnull Class<T> typeClass) throws ObjNotFoundException {
+    return delegate.fetchTypedObjs(ids, type, typeClass);
+  }
+
+  @WithSpan
+  @Override
+  @Counted(PREFIX)
+  @Timed(value = PREFIX, histogram = true)
+  @Nonnull
+  public <T extends Obj> T[] fetchTypedObjsIfExist(
+      @Nonnull ObjId[] ids, ObjType type, @Nonnull Class<T> typeClass) {
+    return delegate.fetchTypedObjsIfExist(ids, type, typeClass);
   }
 
   @WithSpan

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcPersist.java
@@ -186,14 +186,8 @@ class JdbcPersist extends AbstractJdbcPersist {
 
   @Override
   @Nonnull
-  public Obj fetchObj(@Nonnull ObjId id) throws ObjNotFoundException {
-    return withConnectionException(true, conn -> super.fetchObj(conn, id));
-  }
-
-  @Override
-  @Nonnull
-  public <T extends Obj> T fetchTypedObj(@Nonnull ObjId id, ObjType type, Class<T> typeClass)
-      throws ObjNotFoundException {
+  public <T extends Obj> T fetchTypedObj(
+      @Nonnull ObjId id, ObjType type, @Nonnull Class<T> typeClass) throws ObjNotFoundException {
     return withConnectionException(true, conn -> super.fetchTypedObj(conn, id, type, typeClass));
   }
 
@@ -204,15 +198,10 @@ class JdbcPersist extends AbstractJdbcPersist {
   }
 
   @Override
-  @Nonnull
-  public Obj[] fetchObjs(@Nonnull ObjId[] ids) throws ObjNotFoundException {
-    return withConnectionException(true, conn -> super.fetchObjs(conn, ids));
-  }
-
-  @Override
-  @Nonnull
-  public Obj[] fetchObjsIfExist(@Nonnull ObjId[] ids) {
-    return withConnectionException(true, conn -> super.fetchObjsIfExist(conn, ids));
+  public <T extends Obj> T[] fetchTypedObjsIfExist(
+      @Nonnull ObjId[] ids, ObjType type, @Nonnull Class<T> typeClass) {
+    return withConnectionException(
+        true, conn -> super.fetchTypedObjsIfExist(conn, ids, type, typeClass));
   }
 
   @Override

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/RepositoryConfigBackend.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/RepositoryConfigBackend.java
@@ -22,6 +22,7 @@ import static org.projectnessie.versioned.storage.common.logic.Logics.commitLogi
 import static org.projectnessie.versioned.storage.common.logic.Logics.indexesLogic;
 import static org.projectnessie.versioned.storage.common.logic.Logics.referenceLogic;
 import static org.projectnessie.versioned.storage.common.logic.Logics.stringLogic;
+import static org.projectnessie.versioned.storage.common.objtypes.StandardObjType.STRING;
 import static org.projectnessie.versioned.storage.common.util.Ser.SHARED_OBJECT_MAPPER;
 import static org.projectnessie.versioned.storage.versionstore.RefMapping.referenceConflictException;
 
@@ -53,7 +54,6 @@ import org.projectnessie.versioned.storage.common.logic.StringLogic.StringValue;
 import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
 import org.projectnessie.versioned.storage.common.objtypes.CommitOp;
 import org.projectnessie.versioned.storage.common.objtypes.StringObj;
-import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 import org.projectnessie.versioned.storage.common.persist.Persist;
 import org.projectnessie.versioned.storage.common.persist.Reference;
@@ -79,18 +79,19 @@ class RepositoryConfigBackend {
       CommitObj head = commitLogic(p).headCommit(reference);
       StoreIndex<CommitOp> index = indexesLogic.buildCompleteIndexOrEmpty(head);
 
-      Obj[] objs =
-          p.fetchObjs(
+      StringObj[] objs =
+          p.fetchTypedObjs(
               repositoryConfigTypes.stream()
                   .map(RepositoryConfigBackend::repositoryConfigTypeToStoreKey)
                   .map(storeKey -> valueObjIdFromIndex(index, storeKey))
-                  .toArray(ObjId[]::new));
+                  .toArray(ObjId[]::new),
+              STRING,
+              StringObj.class);
 
       StringLogic stringLogic = stringLogic(p);
 
       return Arrays.stream(objs)
           .filter(Objects::nonNull)
-          .map(StringObj.class::cast)
           .map(
               s -> {
                 try {

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/PersistDelegate.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/PersistDelegate.java
@@ -126,8 +126,8 @@ public class PersistDelegate implements Persist {
 
   @Override
   @Nonnull
-  public <T extends Obj> T fetchTypedObj(@Nonnull ObjId id, ObjType type, Class<T> typeClass)
-      throws ObjNotFoundException {
+  public <T extends Obj> T fetchTypedObj(
+      @Nonnull ObjId id, ObjType type, @Nonnull Class<T> typeClass) throws ObjNotFoundException {
     return delegate.fetchTypedObj(id, type, typeClass);
   }
 
@@ -146,6 +146,19 @@ public class PersistDelegate implements Persist {
   @Override
   public Obj[] fetchObjsIfExist(@Nonnull ObjId[] ids) {
     return delegate.fetchObjsIfExist(ids);
+  }
+
+  @Override
+  @Nonnull
+  public <T extends Obj> T[] fetchTypedObjs(
+      @Nonnull ObjId[] ids, ObjType type, @Nonnull Class<T> typeClass) throws ObjNotFoundException {
+    return delegate.fetchTypedObjs(ids, type, typeClass);
+  }
+
+  @Override
+  public <T extends Obj> T[] fetchTypedObjsIfExist(
+      @Nonnull ObjId[] ids, ObjType type, @Nonnull Class<T> typeClass) {
+    return delegate.fetchTypedObjsIfExist(ids, type, typeClass);
   }
 
   @Override

--- a/versioned/transfer/src/testFixtures/java/org/projectnessie/versioned/transfer/AbstractExportImport.java
+++ b/versioned/transfer/src/testFixtures/java/org/projectnessie/versioned/transfer/AbstractExportImport.java
@@ -344,7 +344,8 @@ public abstract class AbstractExportImport {
           @Nonnull
           @Override
           public <T extends Obj> T fetchTypedObj(
-              @Nonnull ObjId id, ObjType type, Class<T> typeClass) throws ObjNotFoundException {
+              @Nonnull ObjId id, ObjType type, @Nonnull Class<T> typeClass)
+              throws ObjNotFoundException {
             return inmemory.fetchTypedObj(id, type, typeClass);
           }
 
@@ -362,8 +363,23 @@ public abstract class AbstractExportImport {
 
           @Nonnull
           @Override
+          public <T extends Obj> T[] fetchTypedObjs(
+              @Nonnull ObjId[] ids, ObjType type, @Nonnull Class<T> typeClass)
+              throws ObjNotFoundException {
+            return inmemory.fetchTypedObjs(ids, type, typeClass);
+          }
+
+          @Nonnull
+          @Override
           public Obj[] fetchObjsIfExist(@Nonnull ObjId[] ids) {
             return inmemory.fetchObjsIfExist(ids);
+          }
+
+          @Nonnull
+          @Override
+          public <T extends Obj> T[] fetchTypedObjsIfExist(
+              @Nonnull ObjId[] ids, ObjType type, @Nonnull Class<T> typeClass) {
+            return inmemory.fetchTypedObjsIfExist(ids, type, typeClass);
           }
 
           @Override


### PR DESCRIPTION
This change introduces `Persist.fetchTypedObjs()` and `Persist.fetchTypedObjsIfExist()` as bulk-couterparts to `Persist.fetchTypedObj()`.
    
Also refactor the code paths to let the untyped functions use the typed functions to unify/keep common code paths.