### PR TITLE
Implement early access-checks for Iceberg REST operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ as necessary. Empty sections will not end in the release notes.
 
 - Catalog/GCS: Support using the default application credentials
 - Catalog/S3: Allow custom key+trust stores
+- Catalog: Check privileges earlier
 
 ### Changes
 

--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/api/CatalogService.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/api/CatalogService.java
@@ -39,12 +39,16 @@ public interface CatalogService {
    *     more.
    * @param key content key of the table or view
    * @param expectedType The expected content-type.
+   * @param forWrite indicates whether access checks shall be performed for a write/update request
    * @return The response is either a response object or callback to produce the result. The latter
    *     is useful to return results that are quite big, for example Iceberg manifest lists or
    *     manifest files.
    */
   CompletionStage<SnapshotResponse> retrieveSnapshot(
-      SnapshotReqParams reqParams, ContentKey key, @Nullable Content.Type expectedType)
+      SnapshotReqParams reqParams,
+      ContentKey key,
+      @Nullable Content.Type expectedType,
+      boolean forWrite)
       throws NessieNotFoundException;
 
   Stream<Supplier<CompletionStage<SnapshotResponse>>> retrieveSnapshots(

--- a/catalog/service/impl/build.gradle.kts
+++ b/catalog/service/impl/build.gradle.kts
@@ -66,6 +66,11 @@ dependencies {
   testFixturesApi(project(":nessie-catalog-secrets-api"))
   testFixturesApi(project(":nessie-object-storage-mock"))
   testFixturesApi(project(":nessie-combined-cs"))
+  testFixturesApi(project(":nessie-services"))
+  testFixturesApi(project(":nessie-services-config"))
+  testFixturesApi(project(":nessie-versioned-spi"))
+  testFixturesApi(project(":nessie-versioned-storage-store"))
+  testFixturesApi(project(":nessie-rest-services"))
 
   testImplementation(platform(libs.awssdk.bom))
   testImplementation("software.amazon.awssdk:s3")

--- a/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/CatalogServiceImpl.java
+++ b/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/CatalogServiceImpl.java
@@ -183,7 +183,10 @@ public class CatalogServiceImpl implements CatalogService {
 
   @Override
   public CompletionStage<SnapshotResponse> retrieveSnapshot(
-      SnapshotReqParams reqParams, ContentKey key, @Nullable Content.Type expectedType)
+      SnapshotReqParams reqParams,
+      ContentKey key,
+      @Nullable Content.Type expectedType,
+      boolean forWrite)
       throws NessieNotFoundException {
 
     ParsedReference reference = reqParams.ref();
@@ -199,6 +202,7 @@ public class CatalogServiceImpl implements CatalogService {
             .getContent()
             .refName(reference.name())
             .hashOnRef(reference.hashWithRelativeSpec())
+            .forWrite(forWrite)
             .getSingle(key);
     Content content = contentResponse.getContent();
     if (expectedType != null && !content.getType().equals(expectedType)) {
@@ -332,7 +336,8 @@ public class CatalogServiceImpl implements CatalogService {
         nessieApi
             .getContent()
             .refName(reference.name())
-            .hashOnRef(reference.hashWithRelativeSpec());
+            .hashOnRef(reference.hashWithRelativeSpec())
+            .forWrite(true);
     commit.getOperations().forEach(op -> contentRequest.key(op.getKey()));
     GetMultipleContentsResponse contentsResponse = contentRequest.getWithResponse();
 

--- a/catalog/service/impl/src/test/java/org/projectnessie/catalog/service/impl/TestCatalogServiceImpl.java
+++ b/catalog/service/impl/src/test/java/org/projectnessie/catalog/service/impl/TestCatalogServiceImpl.java
@@ -15,16 +15,47 @@
  */
 package org.projectnessie.catalog.service.impl;
 
+import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.projectnessie.api.v2.params.ParsedReference.parsedReference;
+import static org.projectnessie.catalog.service.api.SnapshotReqParams.forSnapshotHttpReq;
+import static org.projectnessie.model.Content.Type.ICEBERG_TABLE;
+import static org.projectnessie.services.authz.Check.CheckType.COMMIT_CHANGE_AGAINST_REFERENCE;
+import static org.projectnessie.services.authz.Check.CheckType.READ_ENTITY_VALUE;
+import static org.projectnessie.services.authz.Check.CheckType.UPDATE_ENTITY;
+import static org.projectnessie.services.authz.Check.CheckType.VIEW_REFERENCE;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.assertj.core.api.AbstractThrowableAssert;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.api.v2.params.ParsedReference;
+import org.projectnessie.catalog.formats.iceberg.meta.IcebergJson;
+import org.projectnessie.catalog.formats.iceberg.meta.IcebergTableMetadata;
+import org.projectnessie.catalog.formats.iceberg.nessie.NessieModelIceberg;
+import org.projectnessie.catalog.model.snapshot.NessieTableSnapshot;
 import org.projectnessie.catalog.service.api.CatalogCommit;
+import org.projectnessie.catalog.service.api.CatalogService;
+import org.projectnessie.catalog.service.api.SnapshotReqParams;
+import org.projectnessie.catalog.service.api.SnapshotResponse;
+import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.Reference;
+import org.projectnessie.services.authz.AbstractBatchAccessChecker;
+import org.projectnessie.services.authz.AccessCheckException;
+import org.projectnessie.services.authz.Check;
+import org.projectnessie.services.authz.Check.CheckType;
+import org.projectnessie.storage.uri.StorageUri;
 
 public class TestCatalogServiceImpl extends AbstractCatalogService {
 
+  /** Check that a non-modifying catalog-commit is a no-op. */
   @Test
   public void noCommitOps() throws Exception {
     Reference main = api.getReference().refName("main").get();
@@ -39,6 +70,7 @@ public class TestCatalogServiceImpl extends AbstractCatalogService {
     soft.assertThat(afterCommit).isEqualTo(main);
   }
 
+  /** Verifies that a single table create catalog-commit passes. */
   @Test
   public void singleTableCreate() throws Exception {
     Reference main = api.getReference().refName("main").get();
@@ -51,5 +83,123 @@ public class TestCatalogServiceImpl extends AbstractCatalogService {
         .isNotEqualTo(main)
         .extracting(Reference::getName, Reference::getHash)
         .containsExactly(committed.name(), committed.hashWithRelativeSpec());
+
+    SnapshotResponse snap =
+        catalogService
+            .retrieveSnapshot(
+                forSnapshotHttpReq(committed, "ICEBERG", "2"), key, ICEBERG_TABLE, false)
+            .toCompletableFuture()
+            .get(5, MINUTES);
+
+    soft.assertThat(snap)
+        .extracting(
+            SnapshotResponse::contentKey,
+            SnapshotResponse::contentType,
+            SnapshotResponse::effectiveReference)
+        .containsExactly(key, "application/json", afterCommit);
+
+    soft.assertThat(snap.content())
+        .extracting(IcebergTable.class::cast)
+        .extracting(IcebergTable::getMetadataLocation, STRING)
+        .endsWith(".metadata.json");
+    soft.assertThat(snap.entityObject()).containsInstanceOf(IcebergTableMetadata.class);
+
+    IcebergTableMetadata icebergMetadataEntity =
+        (IcebergTableMetadata) snap.entityObject().orElseThrow();
+
+    IcebergTableMetadata icebergMetadata =
+        NessieModelIceberg.nessieTableSnapshotToIceberg(
+            (NessieTableSnapshot) snap.nessieSnapshot(),
+            Optional.empty(),
+            m -> m.putAll(icebergMetadataEntity.properties()));
+
+    soft.assertThat(snap.entityObject()).contains(icebergMetadata);
+
+    String expectedJson =
+        IcebergJson.objectMapper()
+            .writeValueAsString(
+                IcebergTableMetadata.builder()
+                    .from(icebergMetadataEntity)
+                    .properties(Map.of())
+                    .build());
+    soft.assertThat(
+            objectIO.readObject(
+                StorageUri.of(((IcebergTable) snap.content()).getMetadataLocation())))
+        .hasContent(expectedJson);
+  }
+
+  /**
+   * Verify behavior of {@link CatalogService#retrieveSnapshot(SnapshotReqParams, ContentKey,
+   * Content.Type, boolean)} against related Nessie {@link CheckType check types} for read and write
+   * intents.
+   */
+  @Test
+  public void retrieveSnapshotAccessChecks() throws Exception {
+    Reference main = api.getReference().refName("main").get();
+    ContentKey key = ContentKey.of("mytable");
+
+    ParsedReference committed = commitSingle(main, key);
+
+    AtomicReference<CheckType> failingCheckType = new AtomicReference<>();
+    batchAccessCheckerFactory =
+        x ->
+            new AbstractBatchAccessChecker() {
+              @Override
+              public Map<Check, String> check() {
+                return getChecks().stream()
+                    .filter(c -> failingCheckType.get() == c.type())
+                    .collect(Collectors.toMap(Function.identity(), Object::toString));
+              }
+            };
+
+    List<CheckType> checks =
+        asList(
+            VIEW_REFERENCE,
+            COMMIT_CHANGE_AGAINST_REFERENCE,
+            READ_ENTITY_VALUE,
+            UPDATE_ENTITY,
+            null);
+    for (CheckType checkType : checks) {
+      boolean readFail = checkType == VIEW_REFERENCE || checkType == READ_ENTITY_VALUE;
+      boolean writeFail =
+          readFail || checkType == COMMIT_CHANGE_AGAINST_REFERENCE || checkType == UPDATE_ENTITY;
+      failingCheckType.set(checkType);
+
+      AbstractThrowableAssert<?, ? extends Throwable> read =
+          soft.assertThatCode(
+                  () ->
+                      catalogService
+                          .retrieveSnapshot(
+                              forSnapshotHttpReq(committed, "ICEBERG", "2"),
+                              key,
+                              ICEBERG_TABLE,
+                              false)
+                          .toCompletableFuture()
+                          .get(5, MINUTES))
+              .describedAs("forRead with %s", checkType);
+      if (readFail) {
+        read.isInstanceOf(AccessCheckException.class);
+      } else {
+        read.doesNotThrowAnyException();
+      }
+
+      AbstractThrowableAssert<?, ? extends Throwable> write =
+          soft.assertThatCode(
+                  () ->
+                      catalogService
+                          .retrieveSnapshot(
+                              forSnapshotHttpReq(committed, "ICEBERG", "2"),
+                              key,
+                              ICEBERG_TABLE,
+                              true)
+                          .toCompletableFuture()
+                          .get(5, MINUTES))
+              .describedAs("forWrite with %s", checkType);
+      if (writeFail) {
+        write.isInstanceOf(AccessCheckException.class);
+      } else {
+        write.doesNotThrowAnyException();
+      }
+    }
   }
 }

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/AbstractCatalogResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/AbstractCatalogResource.java
@@ -54,7 +54,8 @@ abstract class AbstractCatalogResource {
       ContentKey key, SnapshotReqParams snapshotReqParams, Content.Type expectedType)
       throws NessieNotFoundException {
     return Uni.createFrom()
-        .completionStage(catalogService.retrieveSnapshot(snapshotReqParams, key, expectedType));
+        .completionStage(
+            catalogService.retrieveSnapshot(snapshotReqParams, key, expectedType, false));
   }
 
   private static Response snapshotToResponse(SnapshotResponse snapshot) {

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ResourceBase.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ResourceBase.java
@@ -303,6 +303,7 @@ abstract class IcebergApiV1ResourceBase extends AbstractCatalogResource {
             .refName(ref.name())
             .hashOnRef(ref.hashWithRelativeSpec())
             .key(tableRef.contentKey())
+            .forWrite(true)
             .getWithResponse();
     if (!contentResponse.getContents().isEmpty()) {
       Content existing = contentResponse.getContents().get(0).getContent();
@@ -313,7 +314,7 @@ abstract class IcebergApiV1ResourceBase extends AbstractCatalogResource {
   }
 
   ContentResponse fetchIcebergEntity(
-      TableRef tableRef, Content.Type expectedType, String expectedTypeName)
+      TableRef tableRef, Content.Type expectedType, String expectedTypeName, boolean forWrite)
       throws NessieNotFoundException {
     ParsedReference ref = requireNonNull(tableRef.reference());
     ContentResponse content =
@@ -321,6 +322,7 @@ abstract class IcebergApiV1ResourceBase extends AbstractCatalogResource {
             .getContent()
             .refName(ref.name())
             .hashOnRef(ref.hashWithRelativeSpec())
+            .forWrite(forWrite)
             .getSingle(tableRef.contentKey());
     checkArgument(
         content.getContent().getType().equals(expectedType),

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1TableResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1TableResource.java
@@ -178,8 +178,9 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
         .build();
   }
 
-  private ContentResponse fetchIcebergTable(TableRef tableRef) throws NessieNotFoundException {
-    return fetchIcebergEntity(tableRef, ICEBERG_TABLE, "table");
+  private ContentResponse fetchIcebergTable(TableRef tableRef, boolean forWrite)
+      throws NessieNotFoundException {
+    return fetchIcebergEntity(tableRef, ICEBERG_TABLE, "table", forWrite);
   }
 
   @POST
@@ -275,7 +276,7 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
     TableRef tableRef = decodeTableRef(prefix, namespace, registerTableRequest.name());
 
     try {
-      ContentResponse response = fetchIcebergTable(tableRef);
+      ContentResponse response = fetchIcebergTable(tableRef, false);
       throw new CatalogEntityAlreadyExistsException(
           false, ICEBERG_TABLE, tableRef.contentKey(), response.getContent().getType());
     } catch (NessieContentNotFoundException e) {
@@ -296,7 +297,7 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
 
       TableRef ctr = catalogTableRef.get();
 
-      ContentResponse contentResponse = fetchIcebergTable(ctr);
+      ContentResponse contentResponse = fetchIcebergTable(ctr, true);
       // It's technically a new table for Nessie, so need to clear the content-ID.
       Content newContent = contentResponse.getContent().withId(null);
 
@@ -379,7 +380,7 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
       throws IOException {
     TableRef tableRef = decodeTableRef(prefix, namespace, table);
 
-    ContentResponse resp = fetchIcebergTable(tableRef);
+    ContentResponse resp = fetchIcebergTable(tableRef, false);
     Branch ref = checkBranch(resp.getEffectiveReference());
 
     nessieApi
@@ -435,7 +436,7 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
       throws IOException {
     TableRef tableRef = decodeTableRef(prefix, namespace, table);
 
-    fetchIcebergTable(tableRef);
+    fetchIcebergTable(tableRef, false);
   }
 
   @POST

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ViewResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ViewResource.java
@@ -145,7 +145,7 @@ public class IcebergApiV1ViewResource extends IcebergApiV1ResourceBase {
       throws IOException {
     TableRef tableRef = decodeTableRef(prefix, namespace, view);
 
-    ContentResponse resp = fetchIcebergView(tableRef);
+    ContentResponse resp = fetchIcebergView(tableRef, false);
     Branch ref = checkBranch(resp.getEffectiveReference());
 
     nessieApi
@@ -156,8 +156,9 @@ public class IcebergApiV1ViewResource extends IcebergApiV1ResourceBase {
         .commitWithResponse();
   }
 
-  private ContentResponse fetchIcebergView(TableRef tableRef) throws NessieNotFoundException {
-    return fetchIcebergEntity(tableRef, ICEBERG_VIEW, "view");
+  private ContentResponse fetchIcebergView(TableRef tableRef, boolean forWrite)
+      throws NessieNotFoundException {
+    return fetchIcebergEntity(tableRef, ICEBERG_VIEW, "view", forWrite);
   }
 
   @GET
@@ -229,7 +230,7 @@ public class IcebergApiV1ViewResource extends IcebergApiV1ResourceBase {
       throws IOException {
     TableRef tableRef = decodeTableRef(prefix, namespace, view);
 
-    fetchIcebergView(tableRef);
+    fetchIcebergView(tableRef, false);
   }
 
   @POST

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergS3SignParams.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergS3SignParams.java
@@ -102,11 +102,13 @@ abstract class IcebergS3SignParams {
 
   private Uni<SnapshotResponse> fetchSnapshot() {
     try {
-      // TODO pass write() to CatalogServiceImpl.retrieveSnapshot() once #8768 is merged
       CompletionStage<SnapshotResponse> stage =
           catalogService()
               .retrieveSnapshot(
-                  SnapshotReqParams.forSnapshotHttpReq(ref(), "iceberg", null), key(), null);
+                  SnapshotReqParams.forSnapshotHttpReq(ref(), "iceberg", null),
+                  key(),
+                  null,
+                  write());
       // consider an import failure as a non-existing content:
       // signing will be authorized for the future location only.
       return Uni.createFrom().completionStage(stage).onFailure().recoverWithNull();

--- a/catalog/service/rest/src/test/java/org/projectnessie/catalog/service/rest/TestIcebergS3SignParams.java
+++ b/catalog/service/rest/src/test/java/org/projectnessie/catalog/service/rest/TestIcebergS3SignParams.java
@@ -119,7 +119,8 @@ class TestIcebergS3SignParams {
   @ParameterizedTest
   @ValueSource(strings = {"GET", "HEAD", "OPTIONS", "TRACE"})
   void verifyAndSignSuccessRead(String method) throws Exception {
-    when(catalogService.retrieveSnapshot(any(), eq(key), isNull())).thenReturn(successStage);
+    when(catalogService.retrieveSnapshot(any(), eq(key), isNull(), eq(false)))
+        .thenReturn(successStage);
     when(signer.sign(any())).thenReturn(signingResponse);
     IcebergS3SignParams icebergSigner =
         newBuilder()
@@ -132,7 +133,8 @@ class TestIcebergS3SignParams {
   @ParameterizedTest
   @ValueSource(strings = {"PUT", "POST", "DELETE", "PATCH"})
   void verifyAndSignSuccessWrite(String method) throws Exception {
-    when(catalogService.retrieveSnapshot(any(), eq(key), isNull())).thenReturn(successStage);
+    when(catalogService.retrieveSnapshot(any(), eq(key), isNull(), eq(true)))
+        .thenReturn(successStage);
     when(signer.sign(any())).thenReturn(signingResponse);
     IcebergS3SignParams icebergSigner =
         newBuilder()
@@ -164,7 +166,7 @@ class TestIcebergS3SignParams {
             key,
             view,
             nessieViewSnapshot);
-    when(catalogService.retrieveSnapshot(any(), eq(key), isNull()))
+    when(catalogService.retrieveSnapshot(any(), eq(key), isNull(), eq(true)))
         .thenReturn(CompletableFuture.completedStage(snapshotResponse));
     when(signer.sign(any())).thenReturn(signingResponse);
     IcebergS3SignParams icebergSigner = newBuilder().build();
@@ -174,7 +176,7 @@ class TestIcebergS3SignParams {
 
   @Test
   void verifyAndSignSuccessContentNotFound() throws Exception {
-    when(catalogService.retrieveSnapshot(any(), eq(key), isNull()))
+    when(catalogService.retrieveSnapshot(any(), eq(key), isNull(), eq(true)))
         .thenThrow(new NessieContentNotFoundException(key, "main"));
     when(signer.sign(any())).thenReturn(signingResponse);
     IcebergS3SignParams icebergSigner = newBuilder().build();
@@ -184,7 +186,7 @@ class TestIcebergS3SignParams {
 
   @Test
   void verifyAndSignFailureReferenceNotFound() throws Exception {
-    when(catalogService.retrieveSnapshot(any(), eq(key), isNull()))
+    when(catalogService.retrieveSnapshot(any(), eq(key), isNull(), eq(true)))
         .thenThrow(new NessieReferenceNotFoundException("ref not found"));
     IcebergS3SignParams icebergSigner = newBuilder().build();
     Uni<IcebergS3SignResponse> response = icebergSigner.verifyAndSign();
@@ -195,7 +197,8 @@ class TestIcebergS3SignParams {
   void verifyAndSignSuccessImportFailed() throws Exception {
     CompletionStage<SnapshotResponse> importFailedStage =
         CompletableFuture.failedStage(new RuntimeException("import failed"));
-    when(catalogService.retrieveSnapshot(any(), eq(key), isNull())).thenReturn(importFailedStage);
+    when(catalogService.retrieveSnapshot(any(), eq(key), isNull(), eq(true)))
+        .thenReturn(importFailedStage);
     when(signer.sign(any())).thenReturn(signingResponse);
     IcebergS3SignParams icebergSigner = newBuilder().build();
     Uni<IcebergS3SignResponse> response = icebergSigner.verifyAndSign();
@@ -205,7 +208,8 @@ class TestIcebergS3SignParams {
   @ParameterizedTest
   @ValueSource(strings = {"GET", "HEAD", "OPTIONS", "TRACE"})
   void verifyAndSignSuccessReadMetadataLocation(String method) throws Exception {
-    when(catalogService.retrieveSnapshot(any(), eq(key), isNull())).thenReturn(successStage);
+    when(catalogService.retrieveSnapshot(any(), eq(key), isNull(), eq(false)))
+        .thenReturn(successStage);
     when(signer.sign(any())).thenReturn(signingResponse);
     IcebergS3SignParams icebergSigner =
         newBuilder()
@@ -218,7 +222,8 @@ class TestIcebergS3SignParams {
   @ParameterizedTest
   @ValueSource(strings = {"PUT", "POST", "DELETE", "PATCH"})
   void verifyAndSignFailureWriteMetadataLocation(String method) throws Exception {
-    when(catalogService.retrieveSnapshot(any(), eq(key), isNull())).thenReturn(successStage);
+    when(catalogService.retrieveSnapshot(any(), eq(key), isNull(), eq(true)))
+        .thenReturn(successStage);
     IcebergS3SignParams icebergSigner =
         newBuilder()
             .request(
@@ -235,7 +240,8 @@ class TestIcebergS3SignParams {
   @ParameterizedTest
   @ValueSource(strings = {"GET", "HEAD", "OPTIONS", "TRACE"})
   void verifyAndSignSuccessReadAncientLocation(String method) throws Exception {
-    when(catalogService.retrieveSnapshot(any(), eq(key), isNull())).thenReturn(successStage);
+    when(catalogService.retrieveSnapshot(any(), eq(key), isNull(), eq(false)))
+        .thenReturn(successStage);
     when(signer.sign(any())).thenReturn(signingResponse);
     IcebergS3SignParams icebergSigner =
         newBuilder()
@@ -253,7 +259,8 @@ class TestIcebergS3SignParams {
   @ParameterizedTest
   @ValueSource(strings = {"PUT", "POST", "DELETE", "PATCH"})
   void verifyAndSignFailureWriteAncientLocation(String method) throws Exception {
-    when(catalogService.retrieveSnapshot(any(), eq(key), isNull())).thenReturn(successStage);
+    when(catalogService.retrieveSnapshot(any(), eq(key), isNull(), eq(true)))
+        .thenReturn(successStage);
     IcebergS3SignParams icebergSigner =
         newBuilder()
             .request(
@@ -269,7 +276,8 @@ class TestIcebergS3SignParams {
 
   @Test
   void verifyAndSignFailureWrongBaseLocation() throws Exception {
-    when(catalogService.retrieveSnapshot(any(), eq(key), isNull())).thenReturn(successStage);
+    when(catalogService.retrieveSnapshot(any(), eq(key), isNull(), eq(true)))
+        .thenReturn(successStage);
     IcebergS3SignParams icebergSigner =
         newBuilder().baseLocation("s3://wrong-bucket/warehouse/ns/table1_cafebabee").build();
     Uni<IcebergS3SignResponse> response = icebergSigner.verifyAndSign();


### PR DESCRIPTION
This change adds "early" access checks to the "more complex" committing operations in the Iceberg REST endpoints. In particular: update-table/view (via `CatalogServiceImpl.commit()`), create-table/view and register-table.

The Nessie get-content(s) API gets a new "for-write" parameter, that, if set to `true`, checks for update/create privileges in addition to the read privilege. To implement the "for-write", the version-store's get-value(s) operations get a new "returnNotFound" parameter.

Fixes #8736 