### PR TITLE
API compatibility filter: don't share authentication with main client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Fixes
 
+- A bug in the API compatibility filter has been discovered and fixed: when OAuth2 authentication is
+  being used, the filter causes the OAuth2 client to close prematurely, thus triggering unauthorized
+  errors. A workaround is to simply disable the filter (set `nessie.enable-api-compatibility-check` 
+  to `false`), but this is no longer necessary.
+
 ### Commits
 
 ## [0.83.2] Release (2024-05-23)

--- a/api/client/src/main/java/org/projectnessie/client/auth/NessieAuthentication.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/NessieAuthentication.java
@@ -36,4 +36,8 @@ public interface NessieAuthentication extends AutoCloseable {
   default void close() {
     // no-op
   }
+
+  default NessieAuthentication copy() {
+    return this;
+  }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2AuthenticationProvider.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2AuthenticationProvider.java
@@ -94,6 +94,11 @@ public class OAuth2AuthenticationProvider implements NessieAuthenticationProvide
     }
 
     @Override
+    public HttpAuthentication copy() {
+      return new OAuth2Authentication(authenticator.copy());
+    }
+
+    @Override
     public void applyToHttpClient(HttpClient.Builder client) {
       client.addRequestFilter(this::applyToHttpRequest);
     }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Authenticator.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Authenticator.java
@@ -48,4 +48,6 @@ public interface OAuth2Authenticator extends AutoCloseable {
    */
   @Override
   void close();
+
+  OAuth2Authenticator copy();
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
@@ -78,6 +78,11 @@ abstract class OAuth2ClientConfig implements OAuth2AuthenticatorConfig {
     return ImmutableOAuth2ClientConfig.builder();
   }
 
+  @Value.Derived
+  String getClientName() {
+    return "nessie-oauth2-client-" + OAuth2Utils.randomAlphaNumString(4);
+  }
+
   @Value.Default
   Duration getMinDefaultAccessTokenLifespan() {
     return Duration.ofSeconds(10);

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpAuthentication.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpAuthentication.java
@@ -43,4 +43,9 @@ public interface HttpAuthentication extends NessieAuthentication {
     throw new UnsupportedOperationException(
         "This authentication method does not support per-request authentication");
   }
+
+  @Override
+  default HttpAuthentication copy() {
+    return this;
+  }
 }

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
@@ -77,13 +77,13 @@ final class HttpClientBuilderImpl implements HttpClient.Builder {
 
   HttpClientBuilderImpl(HttpClientBuilderImpl other) {
     this.baseUri = other.baseUri;
-    this.mapper = other.mapper;
+    this.mapper = other.mapper == null ? null : other.mapper.copy();
     this.jsonView = other.jsonView;
     this.responseFactory = other.responseFactory;
     this.sslNoCertificateVerification = other.sslNoCertificateVerification;
     this.sslContext = other.sslContext;
     this.sslParameters = other.sslParameters;
-    this.authentication = other.authentication;
+    this.authentication = other.authentication == null ? null : other.authentication.copy();
     this.readTimeoutMillis = other.readTimeoutMillis;
     this.connectionTimeoutMillis = other.connectionTimeoutMillis;
     this.disableCompression = other.disableCompression;

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
@@ -269,6 +269,7 @@ class TestOAuth2ClientConfig {
       assertThat(actual)
           .usingRecursiveComparison()
           .ignoringFields(
+              "clientName",
               "clientSecret",
               "password",
               "objectMapper",


### PR DESCRIPTION
This PR:

* Introduces a new `NessieAuthentication.copy()` method, called when calling `HttpClientBuilder.copy()`.
* Introduces a new (private) OAuth2 config option: client name, set to a random name, to facilitate debugging when more than one client is active. The client name is printed with all debug messages.
* Introduces minor changes in `OAuth2TokenRefreshExecutor` to also print the client name.