### PR TITLE
Catalog tests: disable token refresh

### DIFF
--- a/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/auth/ITBearerTokenIcebergCatalogS3.java
+++ b/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/auth/ITBearerTokenIcebergCatalogS3.java
@@ -46,6 +46,7 @@ public class ITBearerTokenIcebergCatalogS3 extends AbstractAuthEnabledTests {
     Map<String, String> options = new HashMap<>();
     options.put(OAuth2Properties.SCOPE, "email");
     options.put(OAuth2Properties.TOKEN, accessToken.getPayload());
+    options.put(OAuth2Properties.TOKEN_REFRESH_ENABLED, "false");
     return options;
   }
 

--- a/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/auth/ITBearerTokenIcebergCatalogS3N.java
+++ b/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/auth/ITBearerTokenIcebergCatalogS3N.java
@@ -46,6 +46,7 @@ public class ITBearerTokenIcebergCatalogS3N extends AbstractAuthEnabledTests {
     Map<String, String> options = new HashMap<>();
     options.put(OAuth2Properties.SCOPE, "email");
     options.put(OAuth2Properties.TOKEN, accessToken.getPayload());
+    options.put(OAuth2Properties.TOKEN_REFRESH_ENABLED, "false");
     return options;
   }
 

--- a/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/auth/ITOAuthIcebergCatalogS3.java
+++ b/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/auth/ITOAuthIcebergCatalogS3.java
@@ -31,6 +31,7 @@ public class ITOAuthIcebergCatalogS3 extends AbstractAuthEnabledTests {
     options.put(OAuth2Properties.SCOPE, "email");
     options.put(OAuth2Properties.OAUTH2_SERVER_URI, tokenEndpoint.toString());
     options.put(OAuth2Properties.CREDENTIAL, clientId + ":" + clientSecret);
+    options.put(OAuth2Properties.TOKEN_REFRESH_ENABLED, "false");
     return options;
   }
 

--- a/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/auth/ITOAuthIcebergCatalogS3N.java
+++ b/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/auth/ITOAuthIcebergCatalogS3N.java
@@ -31,6 +31,7 @@ public class ITOAuthIcebergCatalogS3N extends AbstractAuthEnabledTests {
     options.put(OAuth2Properties.SCOPE, "email");
     options.put(OAuth2Properties.OAUTH2_SERVER_URI, tokenEndpoint.toString());
     options.put(OAuth2Properties.CREDENTIAL, clientId + ":" + clientSecret);
+    options.put(OAuth2Properties.TOKEN_REFRESH_ENABLED, "false");
     return options;
   }
 


### PR DESCRIPTION
... because it's useless for tests, and broken anyways.