### PR TITLE
OAuth2Client: introduce proper support for token exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ as necessary. Empty sections will not end in the release notes.
 
 ### New Features
 
+- Support for token exchange in the Nessie client has been completely redesigned. The new API and
+  configuration options are described in the [Nessie authentication settings]. If this feature is
+  enabled, each time a new access token is obtained, the client will exchange it for another one by
+  performing a token exchange with the authorization server. We hope that this new feature will
+  unlock many advanced use cases for Nessie users, such as impersonation and delegation. Please note
+  that token exchange is considered in beta state and both the API and configuration options are
+  subject to change at any time; we appreciate early feedback, comments and suggestions.
+
+[Nessie authentication settings]: https://projectnessie.org/tools/client_config/#authentication-settings
+
 ### Changes
 
 ### Deprecations
@@ -44,15 +54,6 @@ as necessary. Empty sections will not end in the release notes.
   on our web site projectnessie.org for more information.
 - CEL access check scripts now receive the variable `roles` that can be used to check whether the current
   principal has a role assigned using a CEL expression like `'rolename' in roles`.
-- Support for token exchange in the Nessie client has been completely redesigned. The new API and
-  configuration options are described in the [Nessie authentication settings]. If this feature is
-  enabled, each time a new access token is obtained, the client will exchange it for another one by
-  performing a token exchange with the authorization server. We hope that this new feature will 
-  unlock many advanced use cases for Nessie users, such as impersonation and delegation. Please note 
-  that token exchange is considered in beta state and both the API and configuration options are 
-  subject to change at any time; we appreciate early feedback, comments and suggestions.
-
-[Nessie authentication settings]: https://projectnessie.org/tools/client_config/#authentication-settings
 
 ### Deprecations
 
@@ -64,14 +65,14 @@ as necessary. Empty sections will not end in the release notes.
   specified explicitly in the JDBC URL.
   - `nessie.version.store.persist.jdbc.catalog`
   - `nessie.version.store.persist.jdbc.schema`
-- As mentioned above, token exchange in the Nessie client has been redesigned. As part of this
-  refactoring, _token exchange is not being used anymore to refresh tokens, because this is not its
-  recommended usage_. As a consequence, the `nessie.authentication.oauth2.token-exchange-enabled`
-  configuration property is now deprecated and has no effect; it will be removed soon. From now on,
-  if a refresh token is provided by the authorization server, the Nessie client will always use the
-  `refresh_token` grant type to obtain a new access token; if a refresh token is not provided, the
-  client will always fall back to the configured initial grant type in order to fetch a new access
-  token. _This change should thus be transparent to all users._
+- OAuth2 client: _token exchange is not being used anymore to refresh tokens, because this is not
+  its recommended usage_. As a consequence, the
+  `nessie.authentication.oauth2.token-exchange-enabled` configuration property is now deprecated and
+  has no effect; it will be removed soon. From now on, if a refresh token is provided by the
+  authorization server, the Nessie client will always use the `refresh_token` grant type to obtain a
+  new access token; if a refresh token is not provided, the client will always fall back to the
+  configured initial grant type in order to fetch a new access token. _This change should thus be
+  transparent to all users._
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,14 +65,13 @@ as necessary. Empty sections will not end in the release notes.
   specified explicitly in the JDBC URL.
   - `nessie.version.store.persist.jdbc.catalog`
   - `nessie.version.store.persist.jdbc.schema`
-- OAuth2 client: _token exchange is not being used anymore to refresh tokens, because this is not
-  its recommended usage_. As a consequence, the
-  `nessie.authentication.oauth2.token-exchange-enabled` configuration property is now deprecated and
-  has no effect; it will be removed soon. From now on, if a refresh token is provided by the
-  authorization server, the Nessie client will always use the `refresh_token` grant type to obtain a
-  new access token; if a refresh token is not provided, the client will always fall back to the
-  configured initial grant type in order to fetch a new access token. _This change should thus be
-  transparent to all users._
+- Support for token exchange in the Nessie client, in its current form, is now deprecated. The token
+  exchange flow was being used to exchange a refresh token for an access token, but this is not its
+  recommended usage. From now on, if a refresh token is provided by the authorization server, the
+  Nessie client will use the `refresh_token` grant type to obtain a new access token; if a refresh
+  token is not provided, the client will use the configured initial grant type to fetch a new access
+  token. _This change should thus be transparent to all users._ The `token_exchange` flow will be
+  redesigned in a future release to support more advanced use cases.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,15 @@ as necessary. Empty sections will not end in the release notes.
   on our web site projectnessie.org for more information.
 - CEL access check scripts now receive the variable `roles` that can be used to check whether the current
   principal has a role assigned using a CEL expression like `'rolename' in roles`.
+- Support for token exchange in the Nessie client has been completely redesigned. The new API and
+  configuration options are described in the [Nessie authentication settings]. If this feature is
+  enabled, each time a new access token is obtained, the client will exchange it for another one by
+  performing a token exchange with the authorization server. We hope that this new feature will 
+  unlock many advanced use cases for Nessie users, such as impersonation and delegation. Please note 
+  that token exchange is considered in beta state and both the API and configuration options are 
+  subject to change at any time; we appreciate early feedback, comments and suggestions.
+
+[Nessie authentication settings]: https://projectnessie.org/tools/client_config/#authentication-settings
 
 ### Deprecations
 
@@ -55,13 +64,14 @@ as necessary. Empty sections will not end in the release notes.
   specified explicitly in the JDBC URL.
   - `nessie.version.store.persist.jdbc.catalog`
   - `nessie.version.store.persist.jdbc.schema`
-- Support for token exchange in the Nessie client, in its current form, is now deprecated. The token
-  exchange flow was being used to exchange a refresh token for an access token, but this is not its
-  recommended usage. From now on, if a refresh token is provided by the authorization server, the
-  Nessie client will use the `refresh_token` grant type to obtain a new access token; if a refresh
-  token is not provided, the client will use the configured initial grant type to fetch a new access
-  token. _This change should thus be transparent to all users._ The `token_exchange` flow will be
-  redesigned in a future release to support more advanced use cases.
+- As mentioned above, token exchange in the Nessie client has been redesigned. As part of this
+  refactoring, _token exchange is not being used anymore to refresh tokens, because this is not its
+  recommended usage_. As a consequence, the `nessie.authentication.oauth2.token-exchange-enabled`
+  configuration property is now deprecated and has no effect; it will be removed soon. From now on,
+  if a refresh token is provided by the authorization server, the Nessie client will always use the
+  `refresh_token` grant type to obtain a new access token; if a refresh token is not provided, the
+  client will always fall back to the configured initial grant type in order to fetch a new access
+  token. _This change should thus be transparent to all users._
 
 ### Fixes
 

--- a/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2ClientKeycloak.java
+++ b/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2ClientKeycloak.java
@@ -148,7 +148,18 @@ public class ITOAuth2ClientKeycloak {
             new KeycloakDeviceCodeResourceOwnerEmulator("Alice", "s3cr3t")) {
 
       OAuth2ClientConfig config1 =
-          clientConfig("Private1", true, false).grantType(CLIENT_CREDENTIALS).build();
+          clientConfig("Private1", true, false)
+              .grantType(CLIENT_CREDENTIALS)
+              .tokenExchangeConfig(
+                  TokenExchangeConfig.builder()
+                      .enabled(true)
+                      .clientId("Private1")
+                      .clientSecret("s3cr3t")
+                      .issuerUrl(issuerUrl)
+                      .audience("Private1")
+                      .scope("exchange")
+                      .build())
+              .build();
       OAuth2ClientConfig config2 =
           clientConfig("Private2", true, false).grantType(PASSWORD).build();
       OAuth2ClientConfig config3 =

--- a/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -310,7 +310,7 @@ public final class NessieConfigConstants {
    * For token exchanges only. The root URL of an alternate OpenID Connect identity issuer provider,
    * to use when exchanging tokens only.
    *
-   * <p>If neither this property nor {@value #CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ISSUER_URL} are
+   * <p>If neither this property nor {@value #CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_TOKEN_ENDPOINT} are
    * defined, the global token endpoint will be used. This means that the same authorization server
    * will be used for both the initial token request and the token exchange.
    *

--- a/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -294,8 +294,135 @@ public final class NessieConfigConstants {
    */
   @Deprecated
   @ConfigItem(section = "OAuth2 Authentication")
-  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ENABLED =
+  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ENABLED_OLD =
       "nessie.authentication.oauth2.token-exchange-enabled";
+
+  /**
+   * Enable OAuth2 token exchange. If enabled, each access token obtained from the OAuth2 server
+   * will be exchanged for a new token, using the token endpoint and the token exchange grant type,
+   * as defined in <a href="https://datatracker.ietf.org/doc/html/rfc8693">RFC 8693</a>.
+   */
+  @ConfigItem(section = "OAuth2 Authentication")
+  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ENABLED =
+      "nessie.authentication.oauth2.token-exchange.enabled";
+
+  /**
+   * For token exchanges only. The root URL of an alternate OpenID Connect identity issuer provider,
+   * to use when exchanging tokens only.
+   *
+   * <p>If neither this property nor {@value #CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ISSUER_URL} are
+   * defined, the global token endpoint will be used. This means that the same authorization server
+   * will be used for both the initial token request and the token exchange.
+   *
+   * <p>Endpoint discovery is performed using the OpenID Connect Discovery metadata published by the
+   * issuer. See <a href="https://openid.net/specs/openid-connect-discovery-1_0.html">OpenID Connect
+   * Discovery 1.0</a> for more information.
+   *
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ISSUER_URL
+   */
+  @ConfigItem(section = "OAuth2 Authentication")
+  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ISSUER_URL =
+      "nessie.authentication.oauth2.token-exchange.issuer-url";
+
+  /**
+   * For token exchanges only. The URL of an alternate OAuth2 token endpoint to use when exchanging
+   * tokens only.
+   *
+   * <p>If neither this property nor {@value #CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ISSUER_URL} are
+   * defined, the global token endpoint will be used. This means that the same authorization server
+   * will be used for both the initial token request and the token exchange.
+   */
+  @ConfigItem(section = "OAuth2 Authentication")
+  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_TOKEN_ENDPOINT =
+      "nessie.authentication.oauth2.token-exchange.token-endpoint";
+
+  /**
+   * For token exchanges only. An alternate client ID to use. If not provided, the global client ID
+   * will be used. If provided, and if the client is confidential, then its secret must be provided
+   * as well with {@value #CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_SECRET} – the global client
+   * secret will NOT be used.
+   */
+  @ConfigItem(section = "OAuth2 Authentication")
+  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_ID =
+      "nessie.authentication.oauth2.token-exchange.client-id";
+
+  /**
+   * For token exchanges only. The client secret to use, if {@value
+   * #CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_ID} is defined and the token exchange client is
+   * confidential.
+   */
+  @ConfigItem(section = "OAuth2 Authentication")
+  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_SECRET =
+      "nessie.authentication.oauth2.token-exchange.client-secret";
+
+  /**
+   * For token exchanges only. A URI that indicates the target service or resource where the client
+   * intends to use the requested security token. Optional.
+   */
+  @ConfigItem(section = "OAuth2 Authentication")
+  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_RESOURCE =
+      "nessie.authentication.oauth2.token-exchange.resource";
+
+  /**
+   * For token exchanges only. The logical name of the target service where the client intends to
+   * use the requested security token. This serves a purpose similar to the resource parameter but
+   * with the client providing a logical name for the target service.
+   */
+  @ConfigItem(section = "OAuth2 Authentication")
+  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_AUDIENCE =
+      "nessie.authentication.oauth2.token-exchange.audience";
+
+  /**
+   * For token exchanges only. Space-separated list of scopes to include in each token exchange
+   * request to the OAuth2 server. Optional. If undefined, the global scopes configured through
+   * {@link #CONF_NESSIE_OAUTH2_CLIENT_SCOPES} will be used. If defined and null or empty, no scopes
+   * will be used.
+   *
+   * <p>The scope names will not be validated by the Nessie client; make sure they are valid
+   * according to <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-3.3">RFC 6749
+   * Section 3.3</a>.
+   */
+  @ConfigItem(section = "OAuth2 Authentication")
+  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SCOPES =
+      "nessie.authentication.oauth2.token-exchange.scopes";
+
+  /**
+   * For token exchanges only. The subject token to exchange.
+   *
+   * <p>By default, the client will use its current access token as the subject token. But if this
+   * property is set, the client will use the static token provided here instead.
+   */
+  @ConfigItem(section = "OAuth2 Authentication")
+  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN =
+      "nessie.authentication.oauth2.token-exchange.subject-token";
+
+  /**
+   * For token exchanges only. The type of the subject token. By default, {@code
+   * urn:ietf:params:oauth:token-type:access_token}. Only used if {@value
+   * #CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN} is defined, ignored otherwise.
+   */
+  @ConfigItem(section = "OAuth2 Authentication")
+  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN_TYPE =
+      "nessie.authentication.oauth2.token-exchange.subject-token-type";
+
+  /**
+   * For token exchanges only. The actor token to exchange.
+   *
+   * <p>By default, the client will not use an actor token. But if this property is set, the client
+   * will use the static token provided here as the actor token.
+   */
+  @ConfigItem(section = "OAuth2 Authentication")
+  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ACTOR_TOKEN =
+      "nessie.authentication.oauth2.token-exchange.actor-token";
+
+  /**
+   * For token exchanges only. The type of the actor token. By default, {@code
+   * urn:ietf:params:oauth:token-type:access_token}. Only used if {@value
+   * #CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ACTOR_TOKEN} is defined, ignored otherwise.
+   */
+  @ConfigItem(section = "OAuth2 Authentication")
+  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ACTOR_TOKEN_TYPE =
+      "nessie.authentication.oauth2.token-exchange.actor-token-type";
 
   /**
    * Port of the OAuth2 authorization code flow web server.

--- a/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -291,6 +291,7 @@ public final class NessieConfigConstants {
    * This setting is no longer used and will be removed in 1.0.0.
    *
    * @deprecated This setting is no longer used and will be removed in 1.0.0.
+   * @hidden
    */
   @Deprecated
   @ConfigItem(section = "OAuth2 Authentication")

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AbstractFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AbstractFlow.java
@@ -15,11 +15,9 @@
  */
 package org.projectnessie.client.auth.oauth2;
 
-import static org.projectnessie.client.auth.oauth2.OAuth2ClientUtils.tokenExpirationTime;
-
 import java.net.URI;
-import java.time.Duration;
-import java.time.Instant;
+import java.util.Optional;
+import org.projectnessie.client.http.HttpAuthentication;
 import org.projectnessie.client.http.HttpRequest;
 import org.projectnessie.client.http.HttpResponse;
 
@@ -57,37 +55,51 @@ abstract class AbstractFlow implements Flow {
 
   <REQ extends TokensRequestBase, RESP extends TokensResponseBase> Tokens invokeTokenEndpoint(
       TokensRequestBase.Builder<REQ> request, Class<? extends RESP> responseClass) {
-    config.getScope().ifPresent(request::scope);
+    getScope().ifPresent(request::scope);
     maybeAddClientId(request);
-    return invokeEndpoint(config.getResolvedTokenEndpoint(), request.build(), responseClass)
+    return invokeEndpoint(getResolvedTokenEndpoint(), request.build(), responseClass)
         .asTokens(config.getClock());
   }
 
   DeviceCodeResponse invokeDeviceAuthEndpoint() {
     DeviceCodeRequest.Builder request = DeviceCodeRequest.builder();
-    config.getScope().ifPresent(request::scope);
+    getScope().ifPresent(request::scope);
     maybeAddClientId(request);
     return invokeEndpoint(
         config.getResolvedDeviceAuthEndpoint(), request.build(), DeviceCodeResponse.class);
   }
 
+  Optional<String> getScope() {
+    return config.getScope();
+  }
+
+  URI getResolvedTokenEndpoint() {
+    return config.getResolvedTokenEndpoint();
+  }
+
+  String getClientId() {
+    return config.getClientId();
+  }
+
+  boolean isPublicClient() {
+    return config.isPublicClient();
+  }
+
+  Optional<HttpAuthentication> getBasicAuthentication() {
+    return config.getBasicAuthentication();
+  }
+
   private void maybeAddClientId(Object request) {
-    if (config.isPublicClient() && request instanceof PublicClientRequest.Builder) {
-      ((PublicClientRequest.Builder<?>) request).clientId(config.getClientId());
+    if (isPublicClient() && request instanceof PublicClientRequest.Builder) {
+      ((PublicClientRequest.Builder<?>) request).clientId(getClientId());
     }
   }
 
   private <REQ, RESP> RESP invokeEndpoint(
       URI endpoint, REQ request, Class<? extends RESP> responseClass) {
     HttpRequest req = config.getHttpClient().newRequest(endpoint);
-    config.getBasicAuthentication().ifPresent(req::authentication);
+    getBasicAuthentication().ifPresent(req::authentication);
     HttpResponse response = req.postForm(request);
     return response.readEntity(responseClass);
-  }
-
-  protected boolean isAboutToExpire(Token token, Duration defaultLifespan) {
-    Instant now = config.getClock().get();
-    Instant expirationTime = tokenExpirationTime(now, token, defaultLifespan);
-    return expirationTime.isBefore(now.plus(config.getRefreshSafetyWindow()));
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2AuthenticatorConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2AuthenticatorConfig.java
@@ -137,6 +137,8 @@ public interface OAuth2AuthenticatorConfig {
         CONF_NESSIE_OAUTH2_DEVICE_CODE_FLOW_POLL_INTERVAL,
         builder::deviceCodeFlowPollInterval,
         Duration::parse);
+    TokenExchangeConfig tokenExchangeConfig = TokenExchangeConfig.fromConfigSupplier(config);
+    builder.tokenExchangeConfig(tokenExchangeConfig);
     return builder.build();
   }
 
@@ -225,6 +227,12 @@ public interface OAuth2AuthenticatorConfig {
   @Value.Default
   default boolean getTokenExchangeEnabled() {
     return true;
+  }
+
+  /** The token exchange configuration. Optional. */
+  @Value.Default
+  default TokenExchangeConfig getTokenExchangeConfig() {
+    return TokenExchangeConfig.DISABLED;
   }
 
   /**
@@ -407,9 +415,10 @@ public interface OAuth2AuthenticatorConfig {
 
     @Deprecated
     @CanIgnoreReturnValue
-    default Builder tokenExchangeEnabled(boolean tokenExchangeEnabled) {
-      return this;
-    }
+    Builder tokenExchangeEnabled(boolean tokenExchangeEnabled);
+
+    @CanIgnoreReturnValue
+    Builder tokenExchangeConfig(TokenExchangeConfig tokenExchangeConfig);
 
     @CanIgnoreReturnValue
     Builder defaultAccessTokenLifespan(Duration defaultAccessTokenLifespan);

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.client.auth.oauth2;
 
+import static org.projectnessie.client.auth.oauth2.OAuth2ClientUtils.tokenExpirationTime;
+
 import java.io.Closeable;
 import java.time.Duration;
 import java.time.Instant;
@@ -73,7 +75,10 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
         config.getGrantType().requiresUserInteraction()
             ? CompletableFuture.allOf(started, used)
             : started;
-    currentTokensStage = ready.thenApplyAsync((v) -> fetchNewTokens(), executor);
+    currentTokensStage =
+        ready
+            .thenApplyAsync((v) -> fetchNewTokens(), executor)
+            .thenApply(this::maybeExchangeTokens);
     currentTokensStage
         .whenComplete((tokens, error) -> log(error))
         .whenComplete((tokens, error) -> maybeScheduleTokensRenewal(tokens));
@@ -222,7 +227,8 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
             // try refreshing the current tokens (if they exist)
             .thenApply(this::refreshTokens)
             // if that fails, of if tokens weren't available, try fetching brand-new tokens
-            .exceptionally(error -> fetchNewTokens());
+            .exceptionally(error -> fetchNewTokens())
+            .thenApply(this::maybeExchangeTokens);
     currentTokensStage
         .whenComplete((tokens, error) -> log(error))
         .whenComplete((tokens, error) -> maybeScheduleTokensRenewal(tokens));
@@ -258,10 +264,29 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
     if (currentTokens.getRefreshToken() == null) {
       throw new MustFetchNewTokensException("No refresh token available");
     }
+    if (isAboutToExpire(currentTokens.getRefreshToken(), config.getDefaultRefreshTokenLifespan())) {
+      throw new MustFetchNewTokensException("Refresh token is about to expire");
+    }
     LOGGER.debug("[{}] Refreshing tokens", config.getClientName());
     try (Flow flow = GrantType.REFRESH_TOKEN.newFlow(config)) {
       return flow.fetchNewTokens(currentTokens);
     }
+  }
+
+  Tokens maybeExchangeTokens(Tokens currentTokens) {
+    if (config.getTokenExchangeConfig().isEnabled()) {
+      LOGGER.debug("[{}] Exchanging tokens", config.getClientName());
+      try (Flow flow = GrantType.TOKEN_EXCHANGE.newFlow(config)) {
+        return flow.fetchNewTokens(currentTokens);
+      }
+    }
+    return currentTokens;
+  }
+
+  private boolean isAboutToExpire(Token token, Duration defaultLifespan) {
+    Instant now = config.getClock().get();
+    Instant expirationTime = tokenExpirationTime(now, token, defaultLifespan);
+    return expirationTime.isBefore(now.plus(config.getRefreshSafetyWindow()));
   }
 
   /**
@@ -273,10 +298,10 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
       return minRefreshDelay;
     }
     Instant accessExpirationTime =
-        OAuth2ClientUtils.tokenExpirationTime(
+        tokenExpirationTime(
             now, currentTokens.getAccessToken(), config.getDefaultAccessTokenLifespan());
     Instant refreshExpirationTime =
-        OAuth2ClientUtils.tokenExpirationTime(
+        tokenExpirationTime(
             now, currentTokens.getRefreshToken(), config.getDefaultRefreshTokenLifespan());
     return OAuth2ClientUtils.shortestDelay(
         now,

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/RefreshTokensFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/RefreshTokensFlow.java
@@ -32,9 +32,6 @@ class RefreshTokensFlow extends AbstractFlow {
   public Tokens fetchNewTokens(@Nullable Tokens currentTokens) {
     Objects.requireNonNull(currentTokens);
     Objects.requireNonNull(currentTokens.getRefreshToken());
-    if (isAboutToExpire(currentTokens.getRefreshToken(), config.getDefaultRefreshTokenLifespan())) {
-      throw new MustFetchNewTokensException("Refresh token is about to expire");
-    }
     RefreshTokensRequest.Builder request =
         RefreshTokensRequest.builder().refreshToken(currentTokens.getRefreshToken().getPayload());
     return invokeTokenEndpoint(request, RefreshTokensResponse.class);

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokenExchangeConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokenExchangeConfig.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.auth.oauth2;
+
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ACTOR_TOKEN;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ACTOR_TOKEN_TYPE;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_AUDIENCE;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_ID;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_SECRET;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ENABLED;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ISSUER_URL;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_RESOURCE;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SCOPES;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN_TYPE;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_TOKEN_ENDPOINT;
+import static org.projectnessie.client.auth.oauth2.OAuth2ClientConfig.applyConfigOption;
+import static org.projectnessie.client.auth.oauth2.TypedToken.URN_ACCESS_TOKEN;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.net.URI;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.immutables.value.Value;
+import org.projectnessie.client.NessieConfigConstants;
+
+/**
+ * Configuration for OAuth2 token exchange.
+ *
+ * <p>STILL IN BETA. API MAY CHANGE.
+ */
+@Value.Immutable
+public interface TokenExchangeConfig {
+
+  TokenExchangeConfig DISABLED = builder().enabled(false).build();
+
+  String SCOPES_INHERIT = "\\inherit\\";
+
+  static TokenExchangeConfig fromConfigSupplier(Function<String, String> config) {
+    String enabled = config.apply(CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ENABLED);
+    if (!Boolean.parseBoolean(enabled)) {
+      return DISABLED;
+    }
+    TokenExchangeConfig.Builder builder = TokenExchangeConfig.builder().enabled(true);
+    applyConfigOption(config, CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_ID, builder::clientId);
+    applyConfigOption(
+        config, CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_SECRET, builder::clientSecret);
+    applyConfigOption(
+        config, CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ISSUER_URL, builder::issuerUrl, URI::create);
+    applyConfigOption(
+        config,
+        CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_TOKEN_ENDPOINT,
+        builder::tokenEndpoint,
+        URI::create);
+    applyConfigOption(
+        config, CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_RESOURCE, builder::resource, URI::create);
+    applyConfigOption(config, CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SCOPES, builder::scope);
+    applyConfigOption(config, CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_AUDIENCE, builder::audience);
+    String subjectToken = config.apply(CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN);
+    if (subjectToken != null) {
+      String subjectTokenType = config.apply(CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN_TYPE);
+      builder.subjectToken(
+          TypedToken.of(
+              subjectToken,
+              subjectTokenType == null ? URN_ACCESS_TOKEN : URI.create(subjectTokenType)));
+    }
+    String actorToken = config.apply(CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ACTOR_TOKEN);
+    if (actorToken != null) {
+      String actorTokenType = config.apply(CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ACTOR_TOKEN_TYPE);
+      builder.actorToken(
+          TypedToken.of(
+              actorToken, actorTokenType == null ? URN_ACCESS_TOKEN : URI.create(actorTokenType)));
+    }
+    return builder.build();
+  }
+
+  /**
+   * Whether token exchange is enabled. If enabled, the access token obtained from the OAuth2 server
+   * will be exchanged for a new token, using the token endpoint and the token exchange grant type,
+   * as defined in <a href="https://datatracker.ietf.org/doc/html/rfc8693">RFC 8693</a>.
+   *
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ENABLED
+   */
+  @Value.Default
+  default boolean isEnabled() {
+    return false;
+  }
+
+  /**
+   * An alternate client ID to use for token exchanges only. If not provided, the global client ID
+   * will be used. If provided, and if the client is confidential, then its secret must be provided
+   * with {@link #getClientSecret()} – the global client secret will NOT be used.
+   *
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_ID
+   */
+  Optional<String> getClientId();
+
+  /**
+   * An alternate client secret to use for token exchanges only. Required if the alternate client
+   * obtained from {@link #getClientId()} is confidential.
+   *
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_SECRET
+   */
+  Optional<Secret> getClientSecret();
+
+  /**
+   * The root URL of an alternate OpenID Connect identity issuer provider, which will be used for
+   * discovering supported endpoints and their locations, for token exchange only.
+   *
+   * <p>If neither this property nor {@link #getTokenEndpoint()} are defined, the global token
+   * endpoint will be used. This means that the same authorization server will be used for both the
+   * initial token request and the token exchange.
+   *
+   * <p>Endpoint discovery is performed using the OpenID Connect Discovery metadata published by the
+   * issuer. See <a href="https://openid.net/specs/openid-connect-discovery-1_0.html">OpenID Connect
+   * Discovery 1.0</a> for more information.
+   *
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ISSUER_URL
+   */
+  Optional<URI> getIssuerUrl();
+
+  /**
+   * An alternate OAuth2 token endpoint, for token exchange only.
+   *
+   * <p>If neither this property nor {@link #getIssuerUrl()} are defined, the global token endpoint
+   * will be used. This means that the same authorization server will be used for both the initial
+   * token request and the token exchange.
+   *
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_TOKEN_ENDPOINT
+   */
+  Optional<URI> getTokenEndpoint();
+
+  /**
+   * The type of the requested security token. By default, {@link TypedToken#URN_ACCESS_TOKEN}.
+   *
+   * <p>Currently, it is not possible to request any other token type, so this property is not
+   * configurable through system properties.
+   */
+  @Value.Default
+  default URI getRequestedTokenType() {
+    return URN_ACCESS_TOKEN;
+  }
+
+  /**
+   * A URI that indicates the target service or resource where the client intends to use the
+   * requested security token.
+   *
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_RESOURCE
+   */
+  Optional<URI> getResource();
+
+  /**
+   * The logical name of the target service where the client intends to use the requested security
+   * token. This serves a purpose similar to the resource parameter but with the client providing a
+   * logical name for the target service.
+   *
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_AUDIENCE
+   */
+  Optional<String> getAudience();
+
+  /**
+   * The OAuth2 scope. Optional.
+   *
+   * <p>The special value {@link #SCOPES_INHERIT} (default) means that the scope will be inherited
+   * from the global OAuth2 configuration.
+   *
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SCOPES
+   */
+  @Value.Default
+  default String getScope() {
+    return SCOPES_INHERIT;
+  }
+
+  /**
+   * The subject token provider. The provider will be invoked with the current access token (never
+   * null) and the current refresh token, or null if none available; and should return a {@link
+   * TypedToken} representing the subject token. It must NOT return null.
+   *
+   * <p>By default, the provider will return the access token itself. This should be suitable for
+   * most cases.
+   *
+   * <p>This property cannot be set through configuration, but only programmatically. The
+   * configuration exposes two options: the subject token and its type. These options allow to pass
+   * a static subject token only.
+   *
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN_TYPE
+   */
+  @Value.Default
+  @Value.Auxiliary
+  default BiFunction<AccessToken, RefreshToken, TypedToken> getSubjectTokenProvider() {
+    return (accessToken, refreshToken) -> TypedToken.fromAccessToken(accessToken);
+  }
+
+  /**
+   * The actor token provider. The provider will be invoked with the current access token (never
+   * null) and the current refresh token, or null if none available; and should return a {@link
+   * TypedToken} representing the actor token. If the provider returns null, then no actor token
+   * will be used.
+   *
+   * <p>Actor tokens are useful in delegation scenarios. By default, no actor token is used.
+   *
+   * <p>This property cannot be set through configuration, but only programmatically. The
+   * configuration exposes two options: the actor token and its type. These options allow to pass a
+   * static actor token only.
+   *
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ACTOR_TOKEN
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ACTOR_TOKEN_TYPE
+   */
+  @Value.Default
+  @Value.Auxiliary
+  default BiFunction<AccessToken, RefreshToken, TypedToken> getActorTokenProvider() {
+    return (accessToken, refreshToken) -> null;
+  }
+
+  static TokenExchangeConfig.Builder builder() {
+    return ImmutableTokenExchangeConfig.builder();
+  }
+
+  interface Builder {
+
+    @CanIgnoreReturnValue
+    Builder enabled(boolean enabled);
+
+    @CanIgnoreReturnValue
+    Builder clientId(String clientId);
+
+    @CanIgnoreReturnValue
+    Builder clientSecret(Secret clientSecret);
+
+    @CanIgnoreReturnValue
+    default Builder clientSecret(String clientSecret) {
+      return clientSecret(new Secret(clientSecret));
+    }
+
+    @CanIgnoreReturnValue
+    Builder issuerUrl(URI issuerUrl);
+
+    @CanIgnoreReturnValue
+    Builder tokenEndpoint(URI tokenEndpoint);
+
+    @CanIgnoreReturnValue
+    Builder requestedTokenType(URI tokenType);
+
+    @CanIgnoreReturnValue
+    Builder resource(URI resource);
+
+    @CanIgnoreReturnValue
+    Builder audience(String audience);
+
+    @CanIgnoreReturnValue
+    Builder scope(String scope);
+
+    @CanIgnoreReturnValue
+    Builder subjectTokenProvider(BiFunction<AccessToken, RefreshToken, TypedToken> provider);
+
+    @CanIgnoreReturnValue
+    Builder actorTokenProvider(BiFunction<AccessToken, RefreshToken, TypedToken> provider);
+
+    @CanIgnoreReturnValue
+    default Builder subjectToken(TypedToken token) {
+      return subjectTokenProvider((accessToken, refreshToken) -> token);
+    }
+
+    @CanIgnoreReturnValue
+    default Builder actorToken(TypedToken token) {
+      return actorTokenProvider((accessToken, refreshToken) -> token);
+    }
+
+    TokenExchangeConfig build();
+  }
+}

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokenExchangeFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokenExchangeFlow.java
@@ -39,14 +39,15 @@ class TokenExchangeFlow extends AbstractFlow {
 
     TokenExchangeConfig tokenExchangeConfig = config.getTokenExchangeConfig();
 
+    AccessToken accessToken = currentTokens.getAccessToken();
+    RefreshToken refreshToken = currentTokens.getRefreshToken();
+
     TypedToken subjectToken =
-        tokenExchangeConfig
-            .getSubjectTokenProvider()
-            .apply(currentTokens.getAccessToken(), currentTokens.getRefreshToken());
+        tokenExchangeConfig.getSubjectTokenProvider().apply(accessToken, refreshToken);
     TypedToken actorToken =
-        tokenExchangeConfig
-            .getActorTokenProvider()
-            .apply(currentTokens.getAccessToken(), currentTokens.getRefreshToken());
+        tokenExchangeConfig.getActorTokenProvider().apply(accessToken, refreshToken);
+
+    Objects.requireNonNull(subjectToken);
 
     TokensExchangeRequest.Builder request =
         TokensExchangeRequest.builder()

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokenExchangeFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokenExchangeFlow.java
@@ -17,6 +17,8 @@ package org.projectnessie.client.auth.oauth2;
 
 import java.net.URI;
 import java.util.Objects;
+import java.util.Optional;
+import org.projectnessie.client.http.HttpAuthentication;
 
 /**
  * An implementation of the <a href="https://datatracker.ietf.org/doc/html/rfc8693">Token
@@ -27,8 +29,6 @@ import java.util.Objects;
  */
 class TokenExchangeFlow extends AbstractFlow {
 
-  static final URI ACCESS_TOKEN_ID = URI.create("urn:ietf:params:oauth:token-type:access_token");
-
   TokenExchangeFlow(OAuth2ClientConfig config) {
     super(config);
   }
@@ -36,17 +36,53 @@ class TokenExchangeFlow extends AbstractFlow {
   @Override
   public Tokens fetchNewTokens(Tokens currentTokens) {
     Objects.requireNonNull(currentTokens);
+
+    TokenExchangeConfig tokenExchangeConfig = config.getTokenExchangeConfig();
+
+    TypedToken subjectToken =
+        tokenExchangeConfig
+            .getSubjectTokenProvider()
+            .apply(currentTokens.getAccessToken(), currentTokens.getRefreshToken());
+    TypedToken actorToken =
+        tokenExchangeConfig
+            .getActorTokenProvider()
+            .apply(currentTokens.getAccessToken(), currentTokens.getRefreshToken());
+
     TokensExchangeRequest.Builder request =
         TokensExchangeRequest.builder()
-            .subjectToken(currentTokens.getAccessToken().getPayload())
-            .subjectTokenType(ACCESS_TOKEN_ID)
-            .requestedTokenType(ACCESS_TOKEN_ID);
-    Tokens response = invokeTokenEndpoint(request, TokensExchangeResponse.class);
-    // Keycloak may return the same access token instead of a new one,
-    // so we need to check if the access token is about to expire.
-    if (isAboutToExpire(response.getAccessToken(), config.getDefaultAccessTokenLifespan())) {
-      throw new MustFetchNewTokensException("Access token is about to expire");
-    }
-    return response;
+            .subjectToken(subjectToken.getPayload())
+            .subjectTokenType(subjectToken.getTokenType())
+            .actorToken(actorToken == null ? null : actorToken.getPayload())
+            .actorTokenType(actorToken == null ? null : actorToken.getTokenType())
+            .resource(tokenExchangeConfig.getResource().orElse(null))
+            .audience(tokenExchangeConfig.getAudience().orElse(null))
+            .requestedTokenType(tokenExchangeConfig.getRequestedTokenType());
+
+    return invokeTokenEndpoint(request, TokensExchangeResponse.class);
+  }
+
+  @Override
+  Optional<String> getScope() {
+    return config.getScopeForTokenExchange();
+  }
+
+  @Override
+  URI getResolvedTokenEndpoint() {
+    return config.getResolvedTokenEndpointForTokenExchange();
+  }
+
+  @Override
+  String getClientId() {
+    return config.getClientIdForTokenExchange();
+  }
+
+  @Override
+  boolean isPublicClient() {
+    return config.isPublicClientForTokenExchange();
+  }
+
+  @Override
+  Optional<HttpAuthentication> getBasicAuthentication() {
+    return config.getBasicAuthenticationForTokenExchange();
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TypedToken.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TypedToken.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.auth.oauth2;
+
+import java.net.URI;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface TypedToken extends Token {
+
+  /**
+   * Indicates that the token is an OAuth 2.0 access token issued by the given authorization server.
+   */
+  URI URN_ACCESS_TOKEN = URI.create("urn:ietf:params:oauth:token-type:access_token");
+
+  /**
+   * Indicates that the token is an OAuth 2.0 refresh token issued by the given authorization
+   * server.
+   */
+  URI URN_REFRESH_TOKEN = URI.create("urn:ietf:params:oauth:token-type:refresh_token");
+
+  /** Indicates that the token is an ID Token as defined in Section 2 of [OpenID.Core]. */
+  URI URN_ID_TOKEN = URI.create("urn:ietf:params:oauth:token-type:id_token");
+
+  /** Indicates that the token is a base64url-encoded SAML 1.1 [OASIS.saml-core-1.1] assertion. */
+  URI URN_SAML1 = URI.create("urn:ietf:params:oauth:token-type:saml1");
+
+  /**
+   * Indicates that the token is a base64url-encoded SAML 2.0 [OASIS.saml-core-2.0-os] assertion.
+   */
+  URI URN_SAML2 = URI.create("urn:ietf:params:oauth:token-type:saml2");
+
+  /**
+   * The value urn:ietf:params:oauth:token-type:jwt, which is defined in Section 9 of [JWT],
+   * indicates that the token is a JWT.
+   */
+  URI URN_JWT = URI.create("urn:ietf:params:oauth:token-type:jwt");
+
+  /** The type of the token, by default {@link #URN_ACCESS_TOKEN}. */
+  @Value.Default
+  default URI getTokenType() {
+    return URN_ACCESS_TOKEN;
+  }
+
+  static TypedToken of(String payload, URI type) {
+    return ImmutableTypedToken.builder().payload(payload).tokenType(type).build();
+  }
+
+  static TypedToken fromAccessToken(AccessToken accessToken) {
+    return ImmutableTypedToken.builder().from(accessToken).build();
+  }
+}

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/package-info.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@Value.Style(
+    depluralize = true,
+    get = {"get*", "is*"})
+package org.projectnessie.client.auth.oauth2;
+
+import org.immutables.value.Value;


### PR DESCRIPTION
This PR introduces a generic support for token exchanges. The idea is that if enabled, each access token obtained will be exchanged for a another one.

I tried to keep the new `TokenExchangeConfig` API as flexible as possible, in order to allow even complex usages of token exchange, such as impersonation and delegation.

It is possible to use an alternate IdP for exchanging tokens, as well as alternate client ID/client secret. The default is to use the global IdP and credentials.