### PR TITLE
Fix release-publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -344,6 +344,7 @@ jobs:
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4
         with:
           path: current-release-artifacts
+          merge-multiple: true
 
       - name: Create release notes file for GitHub release
         run: |


### PR DESCRIPTION
[Last release](https://github.com/projectnessie/nessie/actions/runs/9506018095/job/26203309260) failed late with `cat: current-release-artifacts/nessie-changelog-0.90.4.md: No such file or directory`, because the three artifacts are extracted into multiple directories, not merged into the target one.