### PR TITLE
 OAuth2Client: differentiate token exchange from impersonation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Breaking changes
 
+- We have improved Nessie client's support for impersonation scenarios using the token exchange
+  grant type. A few options starting with `nessie.authentication.oauth2.token-exchange.*` were
+  renamed to `nessie.authentication.oauth2.impersonation.*`. Check the [Nessie authentication
+  settings] for details. Please note that token exchange and impersonation are both considered in
+  beta state. Their APIs and configuration options are subject to change at any time.
+
 ### New Features
 
 ### Changes

--- a/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2ClientKeycloak.java
+++ b/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2ClientKeycloak.java
@@ -17,17 +17,17 @@ package org.projectnessie.client.auth.oauth2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_IMPERSONATION_ENABLED;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ACTOR_TOKEN;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ACTOR_TOKEN_TYPE;
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ENABLED;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN_TYPE;
+import static org.projectnessie.client.NessieConfigConstants.CURRENT_ACCESS_TOKEN;
+import static org.projectnessie.client.NessieConfigConstants.CURRENT_REFRESH_TOKEN;
 import static org.projectnessie.client.auth.oauth2.GrantType.AUTHORIZATION_CODE;
 import static org.projectnessie.client.auth.oauth2.GrantType.CLIENT_CREDENTIALS;
 import static org.projectnessie.client.auth.oauth2.GrantType.DEVICE_CODE;
 import static org.projectnessie.client.auth.oauth2.GrantType.PASSWORD;
-import static org.projectnessie.client.auth.oauth2.TokenExchangeConfig.CURRENT_ACCESS_TOKEN;
-import static org.projectnessie.client.auth.oauth2.TokenExchangeConfig.CURRENT_REFRESH_TOKEN;
 import static org.projectnessie.client.auth.oauth2.TypedToken.URN_ID_TOKEN;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -159,13 +159,13 @@ public class ITOAuth2ClientKeycloak {
       OAuth2ClientConfig config1 =
           clientConfig("Private1", true, false)
               .grantType(CLIENT_CREDENTIALS)
-              .tokenExchangeConfig(
-                  TokenExchangeConfig.builder()
+              .tokenExchangeConfig(TokenExchangeConfig.builder().audience("Private1").build())
+              .impersonationConfig(
+                  ImpersonationConfig.builder()
                       .enabled(true)
                       .clientId("Private1")
                       .clientSecret("s3cr3t")
                       .issuerUrl(issuerUrl)
-                      .audience("Private1")
                       .addScope("exchange")
                       .build())
               .build();
@@ -396,7 +396,7 @@ public class ITOAuth2ClientKeycloak {
     }
     Map<String, String> config =
         ImmutableMap.of(
-            CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ENABLED,
+            CONF_NESSIE_OAUTH2_IMPERSONATION_ENABLED,
             "true",
             CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN,
             subjectToken.getPayload(),
@@ -429,7 +429,7 @@ public class ITOAuth2ClientKeycloak {
     }
     Map<String, String> config =
         ImmutableMap.of(
-            CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ENABLED,
+            CONF_NESSIE_OAUTH2_IMPERSONATION_ENABLED,
             "true",
             CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN,
             CURRENT_ACCESS_TOKEN,
@@ -457,7 +457,7 @@ public class ITOAuth2ClientKeycloak {
   void testOAuth2ClientTokenExchangeDelegation3() {
     Map<String, String> config =
         ImmutableMap.of(
-            CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ENABLED,
+            CONF_NESSIE_OAUTH2_IMPERSONATION_ENABLED,
             "true",
             CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN,
             CURRENT_REFRESH_TOKEN,
@@ -488,7 +488,7 @@ public class ITOAuth2ClientKeycloak {
     }
     Map<String, String> config =
         ImmutableMap.of(
-            CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ENABLED,
+            CONF_NESSIE_OAUTH2_IMPERSONATION_ENABLED,
             "true",
             CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN,
             subjectToken.getPayload(),
@@ -514,7 +514,7 @@ public class ITOAuth2ClientKeycloak {
   void testOAuth2ClientTokenExchangeImpersonation2() {
     Map<String, String> config =
         ImmutableMap.of(
-            CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ENABLED,
+            CONF_NESSIE_OAUTH2_IMPERSONATION_ENABLED,
             "true",
             CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN,
             CURRENT_ACCESS_TOKEN);

--- a/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -90,7 +90,7 @@ public final class NessieConfigConstants {
    * will be discovered from the {@link #CONF_NESSIE_OAUTH2_ISSUER_URL issuer URL}, using the OpenID
    * Connect Discovery metadata published by the issuer.
    */
-  @ConfigItem(section = "OAuth2 Authentication")
+  @ConfigItem(section = "OAuth2 Authentication Authorization Code")
   public static final String CONF_NESSIE_OAUTH2_AUTH_ENDPOINT =
       "nessie.authentication.oauth2.auth-endpoint";
 
@@ -101,7 +101,7 @@ public final class NessieConfigConstants {
    * <p>If using the "Device Code" grant type, either this property or {@link
    * #CONF_NESSIE_OAUTH2_ISSUER_URL} must be set.
    */
-  @ConfigItem(section = "OAuth2 Authentication")
+  @ConfigItem(section = "OAuth2 Authentication Device Code")
   public static final String CONF_NESSIE_OAUTH2_DEVICE_AUTH_ENDPOINT =
       "nessie.authentication.oauth2.device-auth-endpoint";
 
@@ -115,6 +115,8 @@ public final class NessieConfigConstants {
 
   public static final String CONF_NESSIE_OAUTH2_GRANT_TYPE_DEVICE_CODE = "device_code";
 
+  public static final String CONF_NESSIE_OAUTH2_GRANT_TYPE_TOKEN_EXCHANGE = "token_exchange";
+
   /**
    * The grant type to use when authenticating against the OAuth2 server. Valid values are:
    *
@@ -123,56 +125,10 @@ public final class NessieConfigConstants {
    *   <li>{@value #CONF_NESSIE_OAUTH2_GRANT_TYPE_PASSWORD}
    *   <li>{@value #CONF_NESSIE_OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE}
    *   <li>{@value #CONF_NESSIE_OAUTH2_GRANT_TYPE_DEVICE_CODE}
+   *   <li>{@value #CONF_NESSIE_OAUTH2_GRANT_TYPE_TOKEN_EXCHANGE}
    * </ul>
    *
    * Optional, defaults to {@value #CONF_NESSIE_OAUTH2_GRANT_TYPE_CLIENT_CREDENTIALS}.
-   *
-   * <p>Depending on the grant type, different properties must be provided.
-   *
-   * <p>For the "client_credentials" grant type, the following properties must be provided:
-   *
-   * <ul>
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT token endpoint} or {@linkplain
-   *       #CONF_NESSIE_OAUTH2_ISSUER_URL issuer URL}
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_ID client ID}
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_SECRET client secret} (if required)
-   * </ul>
-   *
-   * <p>For the "password" grant type, the following properties must be provided:
-   *
-   * <ul>
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT token endpoint} or {@linkplain
-   *       #CONF_NESSIE_OAUTH2_ISSUER_URL issuer URL}
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_ID client ID}
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_SECRET client secret} (if required)
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_USERNAME username}
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_PASSWORD password}
-   * </ul>
-   *
-   * <p>For the "authorization_code" grant type, the following properties must be provided:
-   *
-   * <ul>
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT token endpoint} or {@linkplain
-   *       #CONF_NESSIE_OAUTH2_ISSUER_URL issuer URL}
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_AUTH_ENDPOINT authorization endpoint} or {@linkplain
-   *       #CONF_NESSIE_OAUTH2_ISSUER_URL issuer URL}
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_ID client ID}
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_SECRET client secret} (if required)
-   * </ul>
-   *
-   * <p>For the "device_code" grant type, the following properties must be provided:
-   *
-   * <ul>
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT token endpoint} or {@linkplain
-   *       #CONF_NESSIE_OAUTH2_ISSUER_URL issuer URL}
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_DEVICE_AUTH_ENDPOINT device authorization endpoint} or
-   *       {@linkplain #CONF_NESSIE_OAUTH2_ISSUER_URL issuer URL}
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_ID client ID}
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_SECRET client secret} (if required)
-   * </ul>
-   *
-   * <p>Both client and user must be properly configured with appropriate permissions in the OAuth2
-   * server for the authentication to succeed.
    */
   @ConfigItem(section = "OAuth2 Authentication")
   public static final String CONF_NESSIE_OAUTH2_GRANT_TYPE =
@@ -198,14 +154,14 @@ public final class NessieConfigConstants {
    * Username to use when authenticating against the OAuth2 server. Required if using OAuth2
    * authentication and "password" grant type, ignored otherwise.
    */
-  @ConfigItem(section = "OAuth2 Authentication")
+  @ConfigItem(section = "OAuth2 Authentication Password")
   public static final String CONF_NESSIE_OAUTH2_USERNAME = "nessie.authentication.oauth2.username";
 
   /**
    * Password to use when authenticating against the OAuth2 server. Required if using OAuth2
    * authentication and the "password" grant type, ignored otherwise.
    */
-  @ConfigItem(section = "OAuth2 Authentication")
+  @ConfigItem(section = "OAuth2 Authentication Password")
   public static final String CONF_NESSIE_OAUTH2_PASSWORD = "nessie.authentication.oauth2.password";
 
   public static final String DEFAULT_DEFAULT_ACCESS_TOKEN_LIFESPAN = "PT1M";
@@ -217,7 +173,7 @@ public final class NessieConfigConstants {
    * <p>Optional, defaults to {@value #DEFAULT_DEFAULT_ACCESS_TOKEN_LIFESPAN}. Must be a valid <a
    * href="https://en.wikipedia.org/wiki/ISO_8601#Durations">ISO-8601 duration</a>.
    */
-  @ConfigItem(section = "OAuth2 Authentication")
+  @ConfigItem(section = "OAuth2 Authentication Token Refresh")
   public static final String CONF_NESSIE_OAUTH2_DEFAULT_ACCESS_TOKEN_LIFESPAN =
       "nessie.authentication.oauth2.default-access-token-lifespan";
 
@@ -230,7 +186,7 @@ public final class NessieConfigConstants {
    * <p>Optional, defaults to {@value #DEFAULT_DEFAULT_REFRESH_TOKEN_LIFESPAN}. Must be a valid <a
    * href="https://en.wikipedia.org/wiki/ISO_8601#Durations">ISO-8601 duration</a>.
    */
-  @ConfigItem(section = "OAuth2 Authentication")
+  @ConfigItem(section = "OAuth2 Authentication Token Refresh")
   public static final String CONF_NESSIE_OAUTH2_DEFAULT_REFRESH_TOKEN_LIFESPAN =
       "nessie.authentication.oauth2.default-refresh-token-lifespan";
 
@@ -242,7 +198,7 @@ public final class NessieConfigConstants {
    * #DEFAULT_REFRESH_SAFETY_WINDOW}. Must be a valid <a
    * href="https://en.wikipedia.org/wiki/ISO_8601#Durations">ISO-8601 duration</a>.
    */
-  @ConfigItem(section = "OAuth2 Authentication")
+  @ConfigItem(section = "OAuth2 Authentication Token Refresh")
   public static final String CONF_NESSIE_OAUTH2_REFRESH_SAFETY_WINDOW =
       "nessie.authentication.oauth2.refresh-safety-window";
 
@@ -256,7 +212,7 @@ public final class NessieConfigConstants {
    * Optional, defaults to {@value #DEFAULT_PREEMPTIVE_TOKEN_REFRESH_IDLE_TIMEOUT}. Must be a valid
    * <a href="https://en.wikipedia.org/wiki/ISO_8601#Durations">ISO-8601 duration</a>.
    */
-  @ConfigItem(section = "OAuth2 Authentication")
+  @ConfigItem(section = "OAuth2 Authentication Token Refresh")
   public static final String CONF_NESSIE_OAUTH2_PREEMPTIVE_TOKEN_REFRESH_IDLE_TIMEOUT =
       "nessie.authentication.oauth2.preemptive-token-refresh-idle-timeout";
 
@@ -271,7 +227,7 @@ public final class NessieConfigConstants {
    * restarted too often. Must be a valid <a
    * href="https://en.wikipedia.org/wiki/ISO_8601#Durations">ISO-8601 duration</a>.
    */
-  @ConfigItem(section = "OAuth2 Authentication")
+  @ConfigItem(section = "OAuth2 Authentication Token Refresh")
   public static final String CONF_NESSIE_OAUTH2_BACKGROUND_THREAD_IDLE_TIMEOUT =
       "nessie.authentication.oauth2.background-thread-idle-timeout";
 
@@ -299,62 +255,6 @@ public final class NessieConfigConstants {
       "nessie.authentication.oauth2.token-exchange-enabled";
 
   /**
-   * Enable OAuth2 token exchange. If enabled, each access token obtained from the OAuth2 server
-   * will be exchanged for a new token, using the token endpoint and the token exchange grant type,
-   * as defined in <a href="https://datatracker.ietf.org/doc/html/rfc8693">RFC 8693</a>.
-   */
-  @ConfigItem(section = "OAuth2 Authentication Token Exchange")
-  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ENABLED =
-      "nessie.authentication.oauth2.token-exchange.enabled";
-
-  /**
-   * For token exchanges only. The root URL of an alternate OpenID Connect identity issuer provider,
-   * to use when exchanging tokens only.
-   *
-   * <p>If neither this property nor {@value #CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_TOKEN_ENDPOINT} are
-   * defined, the global token endpoint will be used. This means that the same authorization server
-   * will be used for both the initial token request and the token exchange.
-   *
-   * <p>Endpoint discovery is performed using the OpenID Connect Discovery metadata published by the
-   * issuer. See <a href="https://openid.net/specs/openid-connect-discovery-1_0.html">OpenID Connect
-   * Discovery 1.0</a> for more information.
-   */
-  @ConfigItem(section = "OAuth2 Authentication Token Exchange")
-  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ISSUER_URL =
-      "nessie.authentication.oauth2.token-exchange.issuer-url";
-
-  /**
-   * For token exchanges only. The URL of an alternate OAuth2 token endpoint to use when exchanging
-   * tokens only.
-   *
-   * <p>If neither this property nor {@value #CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ISSUER_URL} are
-   * defined, the global token endpoint will be used. This means that the same authorization server
-   * will be used for both the initial token request and the token exchange.
-   */
-  @ConfigItem(section = "OAuth2 Authentication Token Exchange")
-  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_TOKEN_ENDPOINT =
-      "nessie.authentication.oauth2.token-exchange.token-endpoint";
-
-  /**
-   * For token exchanges only. An alternate client ID to use. If not provided, the global client ID
-   * will be used. If provided, and if the client is confidential, then its secret must be provided
-   * as well with {@value #CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_SECRET} – the global client
-   * secret will NOT be used.
-   */
-  @ConfigItem(section = "OAuth2 Authentication Token Exchange")
-  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_ID =
-      "nessie.authentication.oauth2.token-exchange.client-id";
-
-  /**
-   * For token exchanges only. The client secret to use, if {@value
-   * #CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_ID} is defined and the token exchange client is
-   * confidential.
-   */
-  @ConfigItem(section = "OAuth2 Authentication Token Exchange")
-  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_SECRET =
-      "nessie.authentication.oauth2.token-exchange.client-secret";
-
-  /**
    * For token exchanges only. A URI that indicates the target service or resource where the client
    * intends to use the requested security token. Optional.
    */
@@ -371,35 +271,25 @@ public final class NessieConfigConstants {
   public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_AUDIENCE =
       "nessie.authentication.oauth2.token-exchange.audience";
 
-  /**
-   * For token exchanges only. Space-separated list of scopes to include in each token exchange
-   * request to the OAuth2 server. Optional. If undefined, the global scopes configured through
-   * {@value #CONF_NESSIE_OAUTH2_CLIENT_SCOPES} will be used. If defined and null or empty, no
-   * scopes will be used.
-   *
-   * <p>The scope names will not be validated by the Nessie client; make sure they are valid
-   * according to <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-3.3">RFC 6749
-   * Section 3.3</a>.
-   */
-  @ConfigItem(section = "OAuth2 Authentication Token Exchange")
-  public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SCOPES =
-      "nessie.authentication.oauth2.token-exchange.scopes";
+  public static final String CURRENT_ACCESS_TOKEN = "current_access_token";
+  public static final String CURRENT_REFRESH_TOKEN = "current_refresh_token";
+  public static final String NO_TOKEN = "no_token";
 
   /**
    * For token exchanges only. The subject token to exchange. This can take 3 kinds of values:
    *
    * <ul>
-   *   <li>The value {@value
-   *       org.projectnessie.client.auth.oauth2.TokenExchangeConfig#CURRENT_ACCESS_TOKEN}, if the
-   *       client should use its current access token;
-   *   <li>The value {@value
-   *       org.projectnessie.client.auth.oauth2.TokenExchangeConfig#CURRENT_REFRESH_TOKEN}, if the
-   *       client should use its current refresh token (if available);
+   *   <li>The value {@value #CURRENT_ACCESS_TOKEN}, if the client should use its current access
+   *       token;
+   *   <li>The value {@value #CURRENT_REFRESH_TOKEN}, if the client should use its current refresh
+   *       token (if available);
    *   <li>An arbitrary token: in this case, the client will always use the static token provided
    *       here.
    * </ul>
    *
-   * The default is to use the current access token.
+   * The default is to use the current access token. Note: when using token exchange as the initial
+   * grant type, no current access token will eb available: in this case, a valid, static subject
+   * token to exchange must be provided via configuration.
    */
   @ConfigItem(section = "OAuth2 Authentication Token Exchange")
   public static final String CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN =
@@ -422,14 +312,12 @@ public final class NessieConfigConstants {
    * For token exchanges only. The actor token to exchange. This can take 4 kinds of values:
    *
    * <ul>
-   *   <li>The value {@value org.projectnessie.client.auth.oauth2.TokenExchangeConfig#NO_TOKEN}, if
-   *       the client should not include any actor token in the exchange request;
-   *   <li>The value {@value
-   *       org.projectnessie.client.auth.oauth2.TokenExchangeConfig#CURRENT_ACCESS_TOKEN}, if the
-   *       client should use its current access token;
-   *   <li>The value {@value
-   *       org.projectnessie.client.auth.oauth2.TokenExchangeConfig#CURRENT_REFRESH_TOKEN}, if the
-   *       client should use its current refresh token (if available);
+   *   <li>The value {@value #NO_TOKEN}, if the client should not include any actor token in the
+   *       exchange request;
+   *   <li>The value {@value #CURRENT_ACCESS_TOKEN}, if the client should use its current access
+   *       token;
+   *   <li>The value {@value #CURRENT_REFRESH_TOKEN}, if the client should use its current refresh
+   *       token (if available);
    *   <li>An arbitrary token: in this case, the client will always use the static token provided
    *       here.
    * </ul>
@@ -454,6 +342,76 @@ public final class NessieConfigConstants {
       "nessie.authentication.oauth2.token-exchange.actor-token-type";
 
   /**
+   * Whether to enable "impersonation" mode. If enabled, each access token obtained from the OAuth2
+   * server using the configured initial grant type will be exchanged for a new token, using the
+   * token exchange grant type.
+   */
+  @ConfigItem(section = "OAuth2 Authentication Impersonation")
+  public static final String CONF_NESSIE_OAUTH2_IMPERSONATION_ENABLED =
+      "nessie.authentication.oauth2.impersonation.enabled";
+
+  /**
+   * For impersonation only. The root URL of an alternate OpenID Connect identity issuer provider,
+   * to use when exchanging tokens only.
+   *
+   * <p>If neither this property nor {@value #CONF_NESSIE_OAUTH2_IMPERSONATION_TOKEN_ENDPOINT} are
+   * defined, the global token endpoint will be used. This means that the same authorization server
+   * will be used for both the initial token request and the token exchange.
+   *
+   * <p>Endpoint discovery is performed using the OpenID Connect Discovery metadata published by the
+   * issuer. See <a href="https://openid.net/specs/openid-connect-discovery-1_0.html">OpenID Connect
+   * Discovery 1.0</a> for more information.
+   */
+  @ConfigItem(section = "OAuth2 Authentication Impersonation")
+  public static final String CONF_NESSIE_OAUTH2_IMPERSONATION_ISSUER_URL =
+      "nessie.authentication.oauth2.impersonation.issuer-url";
+
+  /**
+   * For impersonation only. The URL of an alternate OAuth2 token endpoint to use when exchanging
+   * tokens only.
+   *
+   * <p>If neither this property nor {@value #CONF_NESSIE_OAUTH2_IMPERSONATION_ISSUER_URL} are
+   * defined, the global token endpoint will be used. This means that the same authorization server
+   * will be used for both the initial token request and the token exchange.
+   */
+  @ConfigItem(section = "OAuth2 Authentication Impersonation")
+  public static final String CONF_NESSIE_OAUTH2_IMPERSONATION_TOKEN_ENDPOINT =
+      "nessie.authentication.oauth2.impersonation.token-endpoint";
+
+  /**
+   * For impersonation only. An alternate client ID to use. If not provided, the global client ID
+   * will be used. If provided, and if the client is confidential, then its secret must be provided
+   * as well with {@value #CONF_NESSIE_OAUTH2_IMPERSONATION_CLIENT_SECRET} – the global client
+   * secret will NOT be used.
+   */
+  @ConfigItem(section = "OAuth2 Authentication Impersonation")
+  public static final String CONF_NESSIE_OAUTH2_IMPERSONATION_CLIENT_ID =
+      "nessie.authentication.oauth2.impersonation.client-id";
+
+  /**
+   * For impersonation only. The client secret to use, if {@value
+   * #CONF_NESSIE_OAUTH2_IMPERSONATION_CLIENT_ID} is defined and the token exchange client is
+   * confidential.
+   */
+  @ConfigItem(section = "OAuth2 Authentication Impersonation")
+  public static final String CONF_NESSIE_OAUTH2_IMPERSONATION_CLIENT_SECRET =
+      "nessie.authentication.oauth2.impersonation.client-secret";
+
+  /**
+   * For impersonation only. Space-separated list of scopes to include in each token exchange
+   * request to the OAuth2 server. Optional. If undefined, the global scopes configured through
+   * {@value #CONF_NESSIE_OAUTH2_CLIENT_SCOPES} will be used. If defined and null or empty, no
+   * scopes will be used.
+   *
+   * <p>The scope names will not be validated by the Nessie client; make sure they are valid
+   * according to <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-3.3">RFC 6749
+   * Section 3.3</a>.
+   */
+  @ConfigItem(section = "OAuth2 Authentication Impersonation")
+  public static final String CONF_NESSIE_OAUTH2_IMPERSONATION_SCOPES =
+      "nessie.authentication.oauth2.impersonation.scopes";
+
+  /**
    * Port of the OAuth2 authorization code flow web server.
    *
    * <p>When running a client inside a container make sure to specify a port and forward the port to
@@ -465,7 +423,7 @@ public final class NessieConfigConstants {
    *
    * <p>Optional; if not present, a random port will be used.
    */
-  @ConfigItem(section = "OAuth2 Authentication")
+  @ConfigItem(section = "OAuth2 Authentication Authorization Code")
   public static final String CONF_NESSIE_OAUTH2_AUTHORIZATION_CODE_FLOW_WEB_PORT =
       "nessie.authentication.oauth2.auth-code-flow.web-port";
 
@@ -475,7 +433,7 @@ public final class NessieConfigConstants {
    * #CONF_NESSIE_OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE}. Optional, defaults to {@value
    * #DEFAULT_AUTHORIZATION_CODE_FLOW_TIMEOUT}.
    */
-  @ConfigItem(section = "OAuth2 Authentication")
+  @ConfigItem(section = "OAuth2 Authentication Authorization Code")
   public static final String CONF_NESSIE_OAUTH2_AUTHORIZATION_CODE_FLOW_TIMEOUT =
       "nessie.authentication.oauth2.auth-code-flow.timeout";
 
@@ -486,7 +444,7 @@ public final class NessieConfigConstants {
    * if the grant type to use is {@value #CONF_NESSIE_OAUTH2_GRANT_TYPE_DEVICE_CODE}. Optional,
    * defaults to {@value #DEFAULT_DEVICE_CODE_FLOW_TIMEOUT}.
    */
-  @ConfigItem(section = "OAuth2 Authentication")
+  @ConfigItem(section = "OAuth2 Authentication Device Code")
   public static final String CONF_NESSIE_OAUTH2_DEVICE_CODE_FLOW_TIMEOUT =
       "nessie.authentication.oauth2.device-code-flow.timeout";
 
@@ -498,7 +456,7 @@ public final class NessieConfigConstants {
    * #CONF_NESSIE_OAUTH2_GRANT_TYPE_DEVICE_CODE}. Optional, defaults to {@value
    * #DEFAULT_DEVICE_CODE_FLOW_POLL_INTERVAL}.
    */
-  @ConfigItem(section = "OAuth2 Authentication")
+  @ConfigItem(section = "OAuth2 Authentication Device Code")
   public static final String CONF_NESSIE_OAUTH2_DEVICE_CODE_FLOW_POLL_INTERVAL =
       "nessie.authentication.oauth2.device-code-flow.poll-interval";
 

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/GrantType.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/GrantType.java
@@ -19,9 +19,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Locale;
 
 public enum GrantType {
-
-  // initial grant types
-
   CLIENT_CREDENTIALS(Constants.CLIENT_CREDENTIALS) {
     @Override
     Flow newFlow(OAuth2ClientConfig config) {
@@ -46,9 +43,6 @@ public enum GrantType {
       return new DeviceCodeFlow(config);
     }
   },
-
-  // non-initial grant types (cannot be used for initial token acquisition)
-
   REFRESH_TOKEN(Constants.REFRESH_TOKEN) {
     @Override
     Flow newFlow(OAuth2ClientConfig config) {
@@ -91,10 +85,7 @@ public enum GrantType {
   }
 
   public boolean isInitial() {
-    return this == CLIENT_CREDENTIALS
-        || this == PASSWORD
-        || this == AUTHORIZATION_CODE
-        || this == DEVICE_CODE;
+    return this != REFRESH_TOKEN;
   }
 
   public static class Constants {

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ImpersonationConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ImpersonationConfig.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.auth.oauth2;
+
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_IMPERSONATION_CLIENT_ID;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_IMPERSONATION_CLIENT_SECRET;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_IMPERSONATION_ENABLED;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_IMPERSONATION_ISSUER_URL;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_IMPERSONATION_SCOPES;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_IMPERSONATION_TOKEN_ENDPOINT;
+import static org.projectnessie.client.auth.oauth2.OAuth2ClientConfig.applyConfigOption;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.immutables.value.Value;
+import org.projectnessie.client.NessieConfigConstants;
+
+/**
+ * Configuration for OAuth2 impersonation.
+ *
+ * <p>STILL IN BETA. API MAY CHANGE.
+ */
+@Value.Immutable
+public interface ImpersonationConfig {
+
+  List<String> SCOPES_INHERIT = Collections.singletonList("\\inherit\\");
+
+  static ImpersonationConfig fromConfigSupplier(Function<String, String> config) {
+    ImpersonationConfig.Builder builder = ImpersonationConfig.builder();
+    applyConfigOption(
+        config, CONF_NESSIE_OAUTH2_IMPERSONATION_ENABLED, builder::enabled, Boolean::parseBoolean);
+    applyConfigOption(config, CONF_NESSIE_OAUTH2_IMPERSONATION_CLIENT_ID, builder::clientId);
+    applyConfigOption(
+        config, CONF_NESSIE_OAUTH2_IMPERSONATION_CLIENT_SECRET, builder::clientSecret);
+    applyConfigOption(
+        config, CONF_NESSIE_OAUTH2_IMPERSONATION_ISSUER_URL, builder::issuerUrl, URI::create);
+    applyConfigOption(
+        config,
+        CONF_NESSIE_OAUTH2_IMPERSONATION_TOKEN_ENDPOINT,
+        builder::tokenEndpoint,
+        URI::create);
+    applyConfigOption(
+        config,
+        CONF_NESSIE_OAUTH2_IMPERSONATION_SCOPES,
+        scope -> Arrays.stream(scope.split(" ")).forEach(builder::addScope));
+    return builder.build();
+  }
+
+  /**
+   * Whether "impersonation" is enabled. If enabled, the access token obtained from the OAuth2
+   * server with the configured initial grant will be exchanged for a new token, using the token
+   * exchange grant type.
+   *
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_IMPERSONATION_ENABLED
+   */
+  @Value.Default
+  default boolean isEnabled() {
+    return false;
+  }
+
+  /**
+   * An alternate client ID to use for impersonations only. If not provided, the global client ID
+   * will be used. If provided, and if the client is confidential, then its secret must be provided
+   * with {@link #getClientSecret()} – the global client secret will NOT be used.
+   *
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_IMPERSONATION_CLIENT_ID
+   */
+  Optional<String> getClientId();
+
+  /**
+   * An alternate client secret to use for impersonations only. Required if the alternate client
+   * obtained from {@link #getClientId()} is confidential.
+   *
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_IMPERSONATION_CLIENT_SECRET
+   */
+  Optional<Secret> getClientSecret();
+
+  /**
+   * The root URL of an alternate OpenID Connect identity issuer provider, which will be used for
+   * discovering supported endpoints and their locations, but only for impersonation.
+   *
+   * <p>If neither this property nor {@link #getTokenEndpoint()} are defined, the global token
+   * endpoint will be used for impersonation. This means that the same authorization server will be
+   * used for both the initial token request and the impersonation token exchange.
+   *
+   * <p>Endpoint discovery is performed using the OpenID Connect Discovery metadata published by the
+   * issuer. See <a href="https://openid.net/specs/openid-connect-discovery-1_0.html">OpenID Connect
+   * Discovery 1.0</a> for more information.
+   *
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_IMPERSONATION_ISSUER_URL
+   */
+  Optional<URI> getIssuerUrl();
+
+  /**
+   * An alternate OAuth2 token endpoint, for impersonation only.
+   *
+   * <p>If neither this property nor {@link #getIssuerUrl()} are defined, the global token endpoint
+   * will be used for impersonation. This means that the same authorization server will be used for
+   * both the initial token request and the impersonation token exchange.
+   *
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_IMPERSONATION_TOKEN_ENDPOINT
+   */
+  Optional<URI> getTokenEndpoint();
+
+  /**
+   * Custom OAuth2 scopes for impersonation only. Optional.
+   *
+   * <p>The special value {@link #SCOPES_INHERIT} (default) means that the scopes will be inherited
+   * from the global OAuth2 configuration.
+   *
+   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_IMPERSONATION_SCOPES
+   */
+  @Value.Default
+  default List<String> getScopes() {
+    return SCOPES_INHERIT;
+  }
+
+  static ImpersonationConfig.Builder builder() {
+    return ImmutableImpersonationConfig.builder();
+  }
+
+  interface Builder {
+
+    @CanIgnoreReturnValue
+    Builder enabled(boolean enabled);
+
+    @CanIgnoreReturnValue
+    Builder clientId(String clientId);
+
+    @CanIgnoreReturnValue
+    Builder clientSecret(Secret clientSecret);
+
+    @CanIgnoreReturnValue
+    default Builder clientSecret(String clientSecret) {
+      return clientSecret(new Secret(clientSecret));
+    }
+
+    @CanIgnoreReturnValue
+    Builder issuerUrl(URI issuerUrl);
+
+    @CanIgnoreReturnValue
+    Builder tokenEndpoint(URI tokenEndpoint);
+
+    @CanIgnoreReturnValue
+    Builder addScope(String scope);
+
+    @CanIgnoreReturnValue
+    Builder addScopes(String... scopes);
+
+    @CanIgnoreReturnValue
+    Builder scopes(Iterable<String> scopes);
+
+    ImpersonationConfig build();
+  }
+}

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ImpersonationFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ImpersonationFlow.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.auth.oauth2;
+
+import java.net.URI;
+import java.util.Optional;
+import org.projectnessie.client.http.HttpAuthentication;
+
+/**
+ * A specialized {@link TokenExchangeFlow} that is performed after the initial token fetch flow, in
+ * order to obtain a more fine-grained token through impersonation (or delegation).
+ */
+class ImpersonationFlow extends TokenExchangeFlow {
+
+  private final ImpersonationConfig impersonationConfig;
+
+  ImpersonationFlow(OAuth2ClientConfig config) {
+    super(config);
+    impersonationConfig = config.getImpersonationConfig();
+  }
+
+  @Override
+  public Tokens fetchNewTokens(Tokens currentTokens) {
+    Tokens newTokens = super.fetchNewTokens(currentTokens);
+    return Tokens.of(newTokens.getAccessToken(), currentTokens.getRefreshToken());
+  }
+
+  @Override
+  Optional<String> getScope() {
+    if (!impersonationConfig.getScopes().equals(ImpersonationConfig.SCOPES_INHERIT)) {
+      return impersonationConfig.getScopes().stream().reduce((a, b) -> a + " " + b);
+    }
+    return super.getScope();
+  }
+
+  @Override
+  URI getResolvedTokenEndpoint() {
+    if (impersonationConfig.getIssuerUrl().isPresent()
+        || impersonationConfig.getTokenEndpoint().isPresent()) {
+      return config.getResolvedImpersonationTokenEndpoint();
+    }
+    return super.getResolvedTokenEndpoint();
+  }
+
+  @Override
+  String getClientId() {
+    if (impersonationConfig.getClientId().isPresent()) {
+      return impersonationConfig.getClientId().get();
+    }
+    return super.getClientId();
+  }
+
+  @Override
+  boolean isPublicClient() {
+    if (impersonationConfig.getClientId().isPresent()) {
+      return !impersonationConfig.getClientSecret().isPresent();
+    }
+    return super.isPublicClient();
+  }
+
+  @Override
+  Optional<HttpAuthentication> getBasicAuthentication() {
+    if (impersonationConfig.getClientId().isPresent()) {
+      return config.getImpersonationBasicAuthentication();
+    }
+    return super.getBasicAuthentication();
+  }
+}

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2AuthenticatorConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2AuthenticatorConfig.java
@@ -142,8 +142,8 @@ public interface OAuth2AuthenticatorConfig {
         CONF_NESSIE_OAUTH2_DEVICE_CODE_FLOW_POLL_INTERVAL,
         builder::deviceCodeFlowPollInterval,
         Duration::parse);
-    TokenExchangeConfig tokenExchangeConfig = TokenExchangeConfig.fromConfigSupplier(config);
-    builder.tokenExchangeConfig(tokenExchangeConfig);
+    builder.tokenExchangeConfig(TokenExchangeConfig.fromConfigSupplier(config));
+    builder.impersonationConfig(ImpersonationConfig.fromConfigSupplier(config));
     return builder.build();
   }
 
@@ -243,7 +243,13 @@ public interface OAuth2AuthenticatorConfig {
   /** The token exchange configuration. Optional. */
   @Value.Default
   default TokenExchangeConfig getTokenExchangeConfig() {
-    return TokenExchangeConfig.DISABLED;
+    return TokenExchangeConfig.builder().build();
+  }
+
+  /** The impersonation configuration. Optional. */
+  @Value.Default
+  default ImpersonationConfig getImpersonationConfig() {
+    return ImpersonationConfig.builder().build();
   }
 
   /**
@@ -443,6 +449,9 @@ public interface OAuth2AuthenticatorConfig {
 
     @CanIgnoreReturnValue
     Builder tokenExchangeConfig(TokenExchangeConfig tokenExchangeConfig);
+
+    @CanIgnoreReturnValue
+    Builder impersonationConfig(ImpersonationConfig tokenExchangeConfig);
 
     @CanIgnoreReturnValue
     Builder defaultAccessTokenLifespan(Duration defaultAccessTokenLifespan);

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokenExchangeConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokenExchangeConfig.java
@@ -18,24 +18,18 @@ package org.projectnessie.client.auth.oauth2;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ACTOR_TOKEN;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ACTOR_TOKEN_TYPE;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_AUDIENCE;
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_ID;
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_SECRET;
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ENABLED;
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ISSUER_URL;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_RESOURCE;
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SCOPES;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN_TYPE;
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_TOKEN_ENDPOINT;
+import static org.projectnessie.client.NessieConfigConstants.CURRENT_ACCESS_TOKEN;
+import static org.projectnessie.client.NessieConfigConstants.CURRENT_REFRESH_TOKEN;
+import static org.projectnessie.client.NessieConfigConstants.NO_TOKEN;
 import static org.projectnessie.client.auth.oauth2.OAuth2ClientConfig.applyConfigOption;
 import static org.projectnessie.client.auth.oauth2.TypedToken.URN_ACCESS_TOKEN;
 import static org.projectnessie.client.auth.oauth2.TypedToken.URN_REFRESH_TOKEN;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.net.URI;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -50,36 +44,10 @@ import org.projectnessie.client.NessieConfigConstants;
 @Value.Immutable
 public interface TokenExchangeConfig {
 
-  List<String> SCOPES_INHERIT = Collections.singletonList("\\inherit\\");
-
-  TokenExchangeConfig DISABLED = builder().enabled(false).build();
-
-  String CURRENT_ACCESS_TOKEN = "current_access_token";
-  String CURRENT_REFRESH_TOKEN = "current_refresh_token";
-  String NO_TOKEN = "no_token";
-
   static TokenExchangeConfig fromConfigSupplier(Function<String, String> config) {
-    String enabled = config.apply(CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ENABLED);
-    if (!Boolean.parseBoolean(enabled)) {
-      return DISABLED;
-    }
-    TokenExchangeConfig.Builder builder = TokenExchangeConfig.builder().enabled(true);
-    applyConfigOption(config, CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_ID, builder::clientId);
-    applyConfigOption(
-        config, CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_SECRET, builder::clientSecret);
-    applyConfigOption(
-        config, CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ISSUER_URL, builder::issuerUrl, URI::create);
-    applyConfigOption(
-        config,
-        CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_TOKEN_ENDPOINT,
-        builder::tokenEndpoint,
-        URI::create);
+    TokenExchangeConfig.Builder builder = TokenExchangeConfig.builder();
     applyConfigOption(
         config, CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_RESOURCE, builder::resource, URI::create);
-    applyConfigOption(
-        config,
-        CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SCOPES,
-        scope -> Arrays.stream(scope.split(" ")).forEach(builder::addScope));
     applyConfigOption(config, CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_AUDIENCE, builder::audience);
 
     String subjectToken = config.apply(CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SUBJECT_TOKEN);
@@ -119,65 +87,8 @@ public interface TokenExchangeConfig {
         builder.actorToken(TypedToken.of(actorToken, actorTokenType.orElse(URN_ACCESS_TOKEN)));
       }
     }
-
     return builder.build();
   }
-
-  /**
-   * Whether token exchange is enabled. If enabled, the access token obtained from the OAuth2 server
-   * will be exchanged for a new token, using the token endpoint and the token exchange grant type,
-   * as defined in <a href="https://datatracker.ietf.org/doc/html/rfc8693">RFC 8693</a>.
-   *
-   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ENABLED
-   */
-  @Value.Default
-  default boolean isEnabled() {
-    return false;
-  }
-
-  /**
-   * An alternate client ID to use for token exchanges only. If not provided, the global client ID
-   * will be used. If provided, and if the client is confidential, then its secret must be provided
-   * with {@link #getClientSecret()} – the global client secret will NOT be used.
-   *
-   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_ID
-   */
-  Optional<String> getClientId();
-
-  /**
-   * An alternate client secret to use for token exchanges only. Required if the alternate client
-   * obtained from {@link #getClientId()} is confidential.
-   *
-   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_CLIENT_SECRET
-   */
-  Optional<Secret> getClientSecret();
-
-  /**
-   * The root URL of an alternate OpenID Connect identity issuer provider, which will be used for
-   * discovering supported endpoints and their locations, for token exchange only.
-   *
-   * <p>If neither this property nor {@link #getTokenEndpoint()} are defined, the global token
-   * endpoint will be used. This means that the same authorization server will be used for both the
-   * initial token request and the token exchange.
-   *
-   * <p>Endpoint discovery is performed using the OpenID Connect Discovery metadata published by the
-   * issuer. See <a href="https://openid.net/specs/openid-connect-discovery-1_0.html">OpenID Connect
-   * Discovery 1.0</a> for more information.
-   *
-   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ISSUER_URL
-   */
-  Optional<URI> getIssuerUrl();
-
-  /**
-   * An alternate OAuth2 token endpoint, for token exchange only.
-   *
-   * <p>If neither this property nor {@link #getIssuerUrl()} are defined, the global token endpoint
-   * will be used. This means that the same authorization server will be used for both the initial
-   * token request and the token exchange.
-   *
-   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_TOKEN_ENDPOINT
-   */
-  Optional<URI> getTokenEndpoint();
 
   /**
    * The type of the requested security token. By default, {@link TypedToken#URN_ACCESS_TOKEN}.
@@ -206,19 +117,6 @@ public interface TokenExchangeConfig {
    * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_AUDIENCE
    */
   Optional<String> getAudience();
-
-  /**
-   * The OAuth2 scopes. Optional.
-   *
-   * <p>The special value {@link #SCOPES_INHERIT} (default) means that the scopes will be inherited
-   * from the global OAuth2 configuration.
-   *
-   * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_SCOPES
-   */
-  @Value.Default
-  default List<String> getScopes() {
-    return SCOPES_INHERIT;
-  }
 
   /**
    * The subject token provider. The provider will be invoked with the current access token (never
@@ -269,26 +167,6 @@ public interface TokenExchangeConfig {
   interface Builder {
 
     @CanIgnoreReturnValue
-    Builder enabled(boolean enabled);
-
-    @CanIgnoreReturnValue
-    Builder clientId(String clientId);
-
-    @CanIgnoreReturnValue
-    Builder clientSecret(Secret clientSecret);
-
-    @CanIgnoreReturnValue
-    default Builder clientSecret(String clientSecret) {
-      return clientSecret(new Secret(clientSecret));
-    }
-
-    @CanIgnoreReturnValue
-    Builder issuerUrl(URI issuerUrl);
-
-    @CanIgnoreReturnValue
-    Builder tokenEndpoint(URI tokenEndpoint);
-
-    @CanIgnoreReturnValue
     Builder requestedTokenType(URI tokenType);
 
     @CanIgnoreReturnValue
@@ -296,15 +174,6 @@ public interface TokenExchangeConfig {
 
     @CanIgnoreReturnValue
     Builder audience(String audience);
-
-    @CanIgnoreReturnValue
-    Builder addScope(String scope);
-
-    @CanIgnoreReturnValue
-    Builder addScopes(String... scopes);
-
-    @CanIgnoreReturnValue
-    Builder scopes(Iterable<String> scopes);
 
     @CanIgnoreReturnValue
     Builder subjectTokenProvider(BiFunction<AccessToken, RefreshToken, TypedToken> provider);

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokenResponseBase.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokenResponseBase.java
@@ -55,19 +55,7 @@ interface TokenResponseBase {
                 .expirationTime(refreshExpiresIn == null ? null : now.plusSeconds(refreshExpiresIn))
                 .build();
 
-    return new Tokens() {
-
-      @Override
-      public AccessToken getAccessToken() {
-        return accessToken;
-      }
-
-      @Nullable
-      @Override
-      public RefreshToken getRefreshToken() {
-        return refreshToken;
-      }
-    };
+    return Tokens.of(accessToken, refreshToken);
   }
 
   /**

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/Tokens.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/Tokens.java
@@ -16,9 +16,15 @@
 package org.projectnessie.client.auth.oauth2;
 
 import javax.annotation.Nullable;
+import org.immutables.value.Value;
 
 /** Represents a pair of access and refresh tokens, issued by an authorization server. */
+@Value.Immutable
 interface Tokens {
+
+  static Tokens of(AccessToken accessToken, RefreshToken refreshToken) {
+    return ImmutableTokens.builder().accessToken(accessToken).refreshToken(refreshToken).build();
+  }
 
   AccessToken getAccessToken();
 

--- a/site/in-dev/client_config.md
+++ b/site/in-dev/client_config.md
@@ -31,19 +31,51 @@ See also [Authentication Settings](#authentication-settings) below.
 
 ### OAuth2 settings
 
-See also [Authentication Settings](#authentication-settings) below.
+General OAuth2 settings. See also [Authentication Settings](#authentication-settings) below.
 
 {% include './generated-docs/client-config-OAuth2_Authentication.md' %}
 
-#### OAuth2 Token Exchange settings
+#### OAuth2 Resource Owner Password Credentials settings
 
-The Nessie client now supports token exchange, which allows the client to exchange an access token
-for another access token.
+OAuth2 settings relevant when using the `password` grant type. See [below](#authentication-settings) for details.
+
+{% include './generated-docs/client-config-OAuth2_Authentication_Password.md' %}
+
+#### OAuth2 Authorization Code Grant settings
+
+OAuth2 settings relevant when using the `authorization_code` grant type. See [below](#authentication-settings) for details.
+
+{% include './generated-docs/client-config-OAuth2_Authentication_Authorization_Code.md' %}
+
+#### OAuth2 Device Authorization Grant settings
+
+OAuth2 settings relevant when using the `device_code` grant type. See [below](#authentication-settings) for details.
+
+{% include './generated-docs/client-config-OAuth2_Authentication_Device_Code.md' %}
+
+#### OAuth2 Token Exchange Grant settings
+
+OAuth2 settings relevant when using the `token_exchange` grant type. See [below](#authentication-settings) for details.
 
 !!! warning
-    The feature is still experimental and subject to change.
+    The feature is experimental and subject to change.
 
 {% include './generated-docs/client-config-OAuth2_Authentication_Token_Exchange.md' %}
+
+#### OAuth2 impersonation settings
+
+OAuth2 settings relevant when using impersonation. See [below](#authentication-settings) for details.
+
+!!! warning
+    The feature is experimental and subject to change.
+
+{% include './generated-docs/client-config-OAuth2_Authentication_Impersonation.md' %}
+
+#### OAuth2 token refresh settings
+
+OAuth2 settings related to token refreshes. You should rarely need to change the defaults.
+
+{% include './generated-docs/client-config-OAuth2_Authentication_Token_Refresh.md' %}
 
 ### AWS authentication settings
 
@@ -178,40 +210,116 @@ nessie.server.authentication.enabled=true
 quarkus.oidc.auth-server-url=https://<keycloak-server>/realms/<realm-name>
 ```
 
-The most important property is `authentication.oauth2.grant-type`, which defines the grant type to
-use when authenticating against the OAuth2 server. Valid values are: 
+OAuth is a complex framework and usually requires many configuration settings on the client side.
+The full list of available settings is [shown above](#oauth2-settings), but here are some general
+configuration guidelines:
+
+#### Configuring endpoints
+
+The Nessie client interacts with the OAuth2 server by contacting its _endpoints_, in order to
+authenticate and obtain access tokens, using various _grants_. The main endpoint is the _token
+endpoint_ and is always required, but other endpoints may also be required, depending on the grant
+type being used. 
+
+The endpoints can be provided with the following properties:
+
+* Token endpoint: `nessie.authentication.oauth2.token-endpoint` (always required);
+* Authorization endpoint: `nessie.authentication.oauth2.auth-endpoint` (required when using the
+  `authorization_code` grant);
+* Device authorization endpoint: `nessie.authentication.oauth2.device-auth-endpoint` (required when 
+  using the `device_code` grant).
+
+However, instead of specifying the endpoints individually, it is recommended to use the all-in-one
+property `nessie.authentication.oauth2.issuer-url` whenever possible. When this property is
+provided, the client is capable of discovering all the required endpoints automatically by querying
+the authorization server well-known metadata endpoint.
+
+#### Configuring grant types
+
+Another important property is `authentication.oauth2.grant-type`, which defines the grant type to
+use when authenticating against the OAuth2 server. Valid values are:
 
 * `client_credentials` : enables the [Client Credentials grant] (default);
 * `password` : enables the [Resource Owner Password Credentials grant];
 * `authorization_code` : enables the [Authorization Code grant];
-* `device_code` : enables the [Device Authorization grant].
+* `device_code` : enables the [Device Authorization grant];
+* `token_exchange` : enables the [Token Exchange grant].
 
 [Client Credentials grant]: https://datatracker.ietf.org/doc/html/rfc6749#section-4.4
 [Resource Owner Password Credentials grant]: https://datatracker.ietf.org/doc/html/rfc6749#section-4.3
 [Authorization Code grant]: https://datatracker.ietf.org/doc/html/rfc6749#section-4.1
 [Device Authorization grant]: https://datatracker.ietf.org/doc/html/rfc8628
+[Token Exchange grant]: https://datatracker.ietf.org/doc/html/rfc8693
 
-The full list of available properties is shown above.
+!!! note
+    The Device Authorization grant can also be specified using its canonical URN: 
+    `urn:ietf:params:oauth:grant-type:device_code`.
 
-#### Which grant type to use?
+!!! note
+    The Token Exchange grant can also be specified using its canonical URN: 
+    `urn:ietf:params:oauth:grant-type:token-exchange`.
 
-The "client_credentials" grant type is the simplest one, but it requires the client to be granted
+The `client_credentials` grant type is the simplest one, but it requires the client to be granted
 enough permissions to access the Nessie server on behalf of the user. This is not always possible,
-and should be avoided if the resource owner (the user) is a human.
+and should be avoided if the session is interactive (that is, when the client is being controlled
+by a human).
 
-The "password" grant type is also simple, but it requires passing the user's password to the client,
-which may not be acceptable in some cases for security reasons.
+For this grant type, the following properties must be provided:
+
+* `nessie.authentication.oauth2.issuer-url` or `nessie.authentication.oauth2.token-endpoint`;
+* `nessie.authentication.oauth2.client-id`;
+* `nessie.authentication.oauth2.client-secret` (unless the client is public).
+
+The `password` grant type is also simple, but it requires passing the user's password to the client,
+which may not be acceptable in some cases for security reasons. Many identity providers forbid its
+usage. 
+
+All the properties required for `client_credentials` are also required for this grant type, as well
+as the following ones:
+
+* `nessie.authentication.oauth2.username`;
+* `nessie.authentication.oauth2.password`.
 
 For real users trying to authenticate within a terminal session, such as a Spark shell, the
-"authorization_code" grant type is recommended. It requires the user to authenticate in a browser
-window, thus sparing the need to provide the user's password directly to the client. The user will 
-be prompted to authenticate in a separate browser window, and the Nessie client will be notified 
-when the authentication is complete.
+`authorization_code` grant type is recommended. It requires the user to authenticate in a browser
+window, thus sparing the need to provide the user's password directly to the client. The user will
+be prompted to authenticate in a separate browser window, and the Nessie client will be notified
+when the authentication is complete. 
+
+All the properties required for `client_credentials` are also required for this grant type. As
+explained above, if `nessie.authentication.oauth2.issuer-url` is provided, then no further
+configuration is required. Otherwise, in addition to the token endpoint, the authorization endpoint
+must also be provided (`nessie.authentication.oauth2.auth-endpoint`).
 
 If the terminal session is running remotely however, on inside an embedded device, then the
-"authorization_code" grant type may not be suitable, as the browser and the terminal session must 
-be running on the same machine. In this case, the "device_code" grant type is recommended. Similar 
-to the "authorization_code" grant type, it requires the user to authenticate in a browser window, 
-but it does not require the browser and the terminal session to be running on the same machine. The 
-user will be prompted to authenticate in a local browser window, and the remote Nessie client will
-poll the OAuth2 server for the authentication status, until the authentication is complete.
+`authorization_code` grant type may not be suitable, as the browser and the terminal session must be
+running on the same machine. In this case, the `device_code` grant type is recommended. Similar to
+the `authorization_code` grant type, it requires the user to authenticate in a browser window, but
+it does not require the browser and the terminal session to be running on the same machine. The user
+will be prompted to authenticate in a local browser window, and the remote Nessie client will poll
+the OAuth2 server for the authentication status, until the authentication is complete. 
+
+All the properties required for `client_credentials` are also required for this grant type. As
+explained above, if `nessie.authentication.oauth2.issuer-url` is provided, then no further
+configuration is required. Otherwise, in addition to the token endpoint, the device authorization
+endpoint must also be provided (`nessie.authentication.oauth2.device-auth-endpoint`).
+
+Finally, the `token_exchange` grant type is the most complex one. In-depth configuration of a token
+exchange grant is outside the scope of this document but in general, two use cases can be envisaged:
+
+1. Initial token exchange: enabled when `authentication.oauth2.grant-type` is `token_exchange`. In
+   this scenario, the client will use token exchange as the primary grant. A subject token must be
+   provided with `nessie.authentication.oauth2.token-exchange.subject-token`. Other properties under
+   `nessie.authentication.oauth2.token-exchange.*` may also be required.
+
+2. Impersonation or delegation: this is the most typical usage, enabled when
+   `nessie.authentication.oauth2.impersonation.enabled` is `true`. Here, the client will first
+   obtain an initial token using another grant type, then exchange the received access token for
+   another access token, possibly from a second OAuth2 server. If a second OAuth2 server must be
+   contacted, use the properties under `nessie.authentication.oauth2.impersonation.*`. And finally,
+   since impersonation uses the token exchange grant type behind the scenes, properties under
+   `nessie.authentication.oauth2.token-exchange.*` may also be relevant.
+
+!!! warning
+    When using impersonation, the property `authentication.oauth2.grant-type` _must_ be another
+    grant type than `token_exchange`.


### PR DESCRIPTION
Ready for review.

I am proposing that we distinguish properties specific to the token exchange grant type, from properties that are only relevant in the context of impersonation/delegation.

Docs were updated accordingly.