### PR TITLE
Support v2 iceberg tables with gzip

### DIFF
--- a/catalog/format/iceberg-fixturegen/src/main/java/org/projectnessie/catalog/formats/iceberg/fixtures/IcebergGenerateFixtures.java
+++ b/catalog/format/iceberg-fixturegen/src/main/java/org/projectnessie/catalog/formats/iceberg/fixtures/IcebergGenerateFixtures.java
@@ -76,10 +76,19 @@ public class IcebergGenerateFixtures {
       gzip.flush();
       data = bytes.toByteArray();
     }
-    return writer.write(
-        URI.create(
-            "table-metadata-simple-no-manifest/table-metadata-simple-compressed-no-manifest.json.gz"),
-        data);
+    String metadataPath = "table-metadata-simple-no-manifest/";
+    switch (icebergSpecVersion) {
+      case 1:
+        metadataPath += "table-metadata-simple-compressed-no-manifest.metadata.json.gz";
+        break;
+      case 2:
+        metadataPath += "table-metadata-simple-compressed-no-manifest.gz.metadata.json";
+        break;
+      default:
+        metadataPath += "table-metadata-simple-compressed-no-manifest.json.gz";
+        break;
+    }
+    return writer.write(URI.create(metadataPath), data);
   }
 
   public static String generateSimpleMetadata(ObjectWriter writer, int icebergSpecVersion)

--- a/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/ImportSnapshotWorker.java
+++ b/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/ImportSnapshotWorker.java
@@ -109,7 +109,7 @@ final class ImportSnapshotWorker {
       StorageUri metadataLocation = StorageUri.of(content.getMetadataLocation());
       try {
         InputStream input = taskRequest.objectIO().readObject(metadataLocation);
-        if (metadataLocation.requiredPath().endsWith(".gz")) {
+        if (metadataLocation.requiredPath().endsWith("metadata.json.gz") || metadataLocation.requiredPath().endsWith(".gz.metadata.json")) {
           input = new GZIPInputStream(input);
         }
         tableMetadata = IcebergJson.objectMapper().readValue(input, IcebergTableMetadata.class);

--- a/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/ImportSnapshotWorker.java
+++ b/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/ImportSnapshotWorker.java
@@ -109,7 +109,8 @@ final class ImportSnapshotWorker {
       StorageUri metadataLocation = StorageUri.of(content.getMetadataLocation());
       try {
         InputStream input = taskRequest.objectIO().readObject(metadataLocation);
-        if (metadataLocation.requiredPath().endsWith("metadata.json.gz") || metadataLocation.requiredPath().endsWith(".gz.metadata.json")) {
+        if (metadataLocation.requiredPath().endsWith(".gz")
+            || metadataLocation.requiredPath().endsWith(".gz.metadata.json")) {
           input = new GZIPInputStream(input);
         }
         tableMetadata = IcebergJson.objectMapper().readValue(input, IcebergTableMetadata.class);

--- a/catalog/service/impl/src/test/java/org/projectnessie/catalog/service/impl/TestIcebergStuff.java
+++ b/catalog/service/impl/src/test/java/org/projectnessie/catalog/service/impl/TestIcebergStuff.java
@@ -122,7 +122,9 @@ public class TestIcebergStuff {
   static Stream<Arguments> icebergTableImports() throws Exception {
     IcebergGenerateFixtures.ObjectWriter objectWriter = objectWriterForPath(tempDir);
     return Stream.of(
-        arguments("compressed table-metadata", generateCompressedMetadata(objectWriter, 2)),
+        arguments("compressed table-metadata generic", generateCompressedMetadata(objectWriter, 0)),
+        arguments("compressed table-metadata v1", generateCompressedMetadata(objectWriter, 1)),
+        arguments("compressed table-metadata v2", generateCompressedMetadata(objectWriter, 2)),
         arguments("simple table-metadata", generateSimpleMetadata(objectWriter, 2)));
   }
 }


### PR DESCRIPTION
Iceberg saves metadata with "gz.metadata.json" suffix when compressed with gzip for v2 tables and with "metadata.json.gz" for v1 tables. Current implementation recognizes only v1 gz tables and fails for v2. 