### PR TITLE
Use `search` in `resolv.conf` to resolve service names

### DIFF
--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/ResolvConf.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/ResolvConf.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.quarkus.providers.storage;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+// Code mostly copied from io.netty.resolver.dns.ResolvConf, but with the addition to extract
+// the 'search' option values.
+
+/**
+ * Looks up the {@code nameserver}s and {@code search} domains from the {@code /etc/resolv.conf}
+ * file, intended for Linux and macOS.
+ */
+final class ResolvConf {
+  private final List<InetSocketAddress> nameservers;
+  private final List<String> searchList;
+
+  /**
+   * Reads from the given reader and extracts the {@code nameserver}s and {@code search} domains
+   * using the syntax of the {@code /etc/resolv.conf} file, see {@code man resolv.conf}.
+   *
+   * @param reader contents of {@code resolv.conf} are read from this {@link BufferedReader}, up to
+   *     the caller to close it
+   */
+  static ResolvConf fromReader(BufferedReader reader) throws IOException {
+    return new ResolvConf(reader);
+  }
+
+  /**
+   * Reads the given file and extracts the {@code nameserver}s and {@code search} domains using the
+   * syntax of the {@code /etc/resolv.conf} file, see {@code man resolv.conf}.
+   */
+  static ResolvConf fromFile(String file) throws IOException {
+    try (FileReader fileReader = new FileReader(file);
+        BufferedReader reader = new BufferedReader(fileReader)) {
+      return fromReader(reader);
+    }
+  }
+
+  /**
+   * Returns the {@code nameserver}s and {@code search} domains from the {@code /etc/resolv.conf}
+   * file. The file is only read once during the lifetime of this class.
+   */
+  static ResolvConf system() {
+    ResolvConf resolvConv = ResolvConf.ResolvConfLazy.machineResolvConf;
+    if (resolvConv != null) {
+      return resolvConv;
+    }
+    throw new IllegalStateException("/etc/resolv.conf could not be read");
+  }
+
+  private ResolvConf(BufferedReader reader) throws IOException {
+    List<InetSocketAddress> nameservers = new ArrayList<>();
+    List<String> searchList = new ArrayList<>();
+    String ln;
+    while ((ln = reader.readLine()) != null) {
+      ln = ln.trim();
+      if (ln.isEmpty()) {
+        continue;
+      }
+
+      if (ln.startsWith("nameserver")) {
+        ln = ln.substring("nameserver".length()).trim();
+        nameservers.add(new InetSocketAddress(ln, 53));
+      }
+      if (ln.startsWith("search")) {
+        ln = ln.substring("search".length()).trim();
+        searchList.addAll(Arrays.asList(ln.split(" ")));
+      }
+    }
+    this.nameservers = Collections.unmodifiableList(nameservers);
+    this.searchList = Collections.unmodifiableList(searchList);
+  }
+
+  List<InetSocketAddress> getNameservers() {
+    return nameservers;
+  }
+
+  List<String> getSearchList() {
+    return searchList;
+  }
+
+  private static final class ResolvConfLazy {
+    static final ResolvConf machineResolvConf;
+
+    static {
+      ResolvConf resolvConf;
+      try {
+        resolvConf = ResolvConf.fromFile("/etc/resolv.conf");
+      } catch (IOException e) {
+        resolvConf = null;
+      }
+      machineResolvConf = resolvConf;
+    }
+  }
+}

--- a/servers/quarkus-common/src/test/java/org/projectnessie/quarkus/providers/storage/TestResolvConf.java
+++ b/servers/quarkus-common/src/test/java/org/projectnessie/quarkus/providers/storage/TestResolvConf.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.quarkus.providers.storage;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.io.BufferedReader;
+import java.io.StringReader;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestResolvConf {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @ParameterizedTest
+  @MethodSource
+  public void resolve(
+      String resolvConfContent, List<InetSocketAddress> nameservers, List<String> searchList)
+      throws Exception {
+    ResolvConf resolvConf =
+        ResolvConf.fromReader(new BufferedReader(new StringReader(resolvConfContent)));
+    soft.assertThat(resolvConf)
+        .extracting(ResolvConf::getNameservers, ResolvConf::getSearchList)
+        .containsExactly(nameservers, searchList);
+  }
+
+  @Test
+  public void system() {
+    ResolvConf resolvConf = ResolvConf.system();
+    soft.assertThat(resolvConf.getNameservers()).isNotEmpty();
+    soft.assertThat(resolvConf.getSearchList()).isNotEmpty();
+  }
+
+  static Stream<Arguments> resolve() {
+    return Stream.of(
+        arguments(
+            "# See man:systemd-resolved.service(8) for details about the supported modes of\n"
+                + "# operation for /etc/resolv.conf.\n"
+                + "\n"
+                + "nameserver 127.0.0.1\n"
+                + "search search.domain\n",
+            List.of(new InetSocketAddress("127.0.0.1", 53)),
+            List.of("search.domain")),
+        arguments(
+            "nameserver 127.0.0.1\n" + "nameserver 1.2.3.4\n",
+            List.of(new InetSocketAddress("127.0.0.1", 53), new InetSocketAddress("1.2.3.4", 53)),
+            List.of()),
+        arguments(
+            "nameserver 127.0.0.1\n"
+                + "nameserver 1.2.3.4\n"
+                + "search search.domain\n"
+                + "search anothersearch.anotherdomain\n",
+            List.of(new InetSocketAddress("127.0.0.1", 53), new InetSocketAddress("1.2.3.4", 53)),
+            List.of("search.domain", "anothersearch.anotherdomain")),
+        arguments(
+            "nameserver 127.0.0.1\n"
+                + "nameserver 1.2.3.4\n"
+                + "search search.domain anothersearch.anotherdomain\n",
+            List.of(new InetSocketAddress("127.0.0.1", 53), new InetSocketAddress("1.2.3.4", 53)),
+            List.of("search.domain", "anothersearch.anotherdomain")),
+        arguments("", List.of(), List.of()));
+  }
+}


### PR DESCRIPTION
The name of the Nessie/Quarkus management service is provided without a domain name, but the lookup needs to happen using the fully qualified domain name (FQDN). This change adds the ability to use the `search` list provided in `/etc/resolv.conf` in `AddressResolver`, via the utility class `ResolvConf`.

Verified locally with minikube with 1, 2 and 3 pods (scaling up).

Fixes #8829