### PR TITLE
Relax image registry sync

### DIFF
--- a/.github/docker-sync/regsync.yml
+++ b/.github/docker-sync/regsync.yml
@@ -16,10 +16,6 @@ sync:
   - source: ghcr.io/projectnessie/nessie-unstable
     target: quay.io/projectnessie/nessie-unstable
     type: repository
-    tags:
-      allow:
-      - "latest.*"
-      - "0[.][789]\\d[.].*|[123][.].*"
   - source: ghcr.io/projectnessie/nessie
     target: quay.io/projectnessie/nessie
     type: repository


### PR DESCRIPTION
When we moved to ghcr, we wanted to prevent syncing extremely old Nessie container images. Since we neither publish nor sync from/to docker.io, that restriction can be removed.