### PR TITLE
Committing operations: cleanup metadata after failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ as necessary. Empty sections will not end in the release notes.
 - Catalog/GCS: Support using the default application credentials
 - Catalog/S3: Allow custom key+trust stores
 - Catalog: Check privileges earlier
+- Catalog: cleanup non-committed metadata objects
 
 ### Changes
 

--- a/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/CatalogServiceImpl.java
+++ b/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/CatalogServiceImpl.java
@@ -425,6 +425,7 @@ public class CatalogServiceImpl implements CatalogService {
               if (e instanceof CompletionException) {
                 e = e.getCause();
               }
+              // Unwrap a `throw new RuntimeException(exception)`
               if (e.getClass() == RuntimeException.class
                   && e.getMessage().equals(e.getCause().toString())) {
                 e = e.getCause();

--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/HeapStorageBucket.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/HeapStorageBucket.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
+import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Stream;
 
@@ -37,6 +38,10 @@ public class HeapStorageBucket {
 
   public void clear() {
     objects.clear();
+  }
+
+  public Map<String, MockObject> objects() {
+    return objects;
   }
 
   public Bucket bucket() {

--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/InterceptingBucket.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/InterceptingBucket.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.objectstoragemock;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public final class InterceptingBucket extends Bucket {
+  private final Bucket bucket;
+
+  private volatile Function<String, Optional<MockObject>> retriever;
+  private volatile Function<String, Optional<Boolean>> deleter;
+  private volatile BiFunction<String, UpdaterMode, Optional<ObjectUpdater>> updater;
+  private volatile BiFunction<String, String, Optional<Stream<ListElement>>> lister;
+
+  public InterceptingBucket(Bucket bucket) {
+    this.bucket = bucket;
+    reset();
+  }
+
+  public void reset() {
+    retriever = key -> Optional.empty();
+    deleter = key -> Optional.empty();
+    updater = (key, mode) -> Optional.empty();
+    lister = (prefix, offset) -> Optional.empty();
+  }
+
+  public void setRetriever(Function<String, Optional<MockObject>> retriever) {
+    this.retriever = retriever;
+  }
+
+  public void setDeleter(Function<String, Optional<Boolean>> deleter) {
+    this.deleter = deleter;
+  }
+
+  public void setUpdater(BiFunction<String, UpdaterMode, Optional<ObjectUpdater>> updater) {
+    this.updater = updater;
+  }
+
+  public void setLister(BiFunction<String, String, Optional<Stream<ListElement>>> lister) {
+    this.lister = lister;
+  }
+
+  @Override
+  public String creationDate() {
+    return bucket.creationDate();
+  }
+
+  @Override
+  public ObjectRetriever object() {
+    return key -> retriever.apply(key).orElseGet(() -> bucket.object().retrieve(key));
+  }
+
+  @Override
+  public Deleter deleter() {
+    return key -> deleter.apply(key).orElseGet(() -> bucket.deleter().delete(key));
+  }
+
+  @Override
+  public Updater updater() {
+    return (key, mode) ->
+        updater.apply(key, mode).orElseGet(() -> bucket.updater().update(key, mode));
+  }
+
+  @Override
+  public Lister lister() {
+    return (prefix, offset) ->
+        lister.apply(prefix, offset).orElseGet(() -> bucket.lister().list(prefix, offset));
+  }
+}


### PR DESCRIPTION
Ensures that objects/files written during a commit are cleaned up if either one of the object/file write operations or the Nessie commit operation fails.

Refactors `CatalogServiceImpl.MultiTableUpdate` to be a top-level type and adds a list of successfully written objects/files in a separate `exceptionally()` stage, that calls `ObjectIO.deleteObjects()` for the written objects/files.

Fixes #8728