### PR TITLE
OAuthClient: improve next token refresh computation

### DIFF
--- a/api/client/build.gradle.kts
+++ b/api/client/build.gradle.kts
@@ -88,6 +88,10 @@ dependencies {
 
   testRuntimeOnly(libs.logback.classic)
 
+  testCompileOnly(libs.immutables.builder)
+  testCompileOnly(libs.immutables.value.annotations)
+  testAnnotationProcessor(libs.immutables.value.processor)
+
   intTestImplementation(platform(libs.testcontainers.bom))
   intTestImplementation("org.testcontainers:testcontainers")
   intTestImplementation("org.testcontainers:junit-jupiter")
@@ -162,6 +166,12 @@ testing {
 
       configurations.named("testJackson_${safeName}Implementation") {
         extendsFrom(configurations.getByName("testImplementation"))
+      }
+      configurations.named("testJackson_${safeName}CompileOnly") {
+        extendsFrom(configurations.getByName("testCompileOnly"))
+      }
+      configurations.named("testJackson_${safeName}AnnotationProcessor") {
+        extendsFrom(configurations.getByName("testAnnotationProcessor"))
       }
     }
   }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
@@ -301,8 +301,10 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
         tokenExpirationTime(
             now, currentTokens.getAccessToken(), config.getDefaultAccessTokenLifespan());
     Instant refreshExpirationTime =
-        tokenExpirationTime(
-            now, currentTokens.getRefreshToken(), config.getDefaultRefreshTokenLifespan());
+        currentTokens.getRefreshToken() == null
+            ? null
+            : tokenExpirationTime(
+                now, currentTokens.getRefreshToken(), config.getDefaultRefreshTokenLifespan());
     return OAuth2Utils.shortestDelay(
         now,
         accessExpirationTime,

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Utils.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Utils.java
@@ -94,16 +94,13 @@ class OAuth2Utils {
   }
 
   static Instant tokenExpirationTime(Instant now, Token token, Duration defaultLifespan) {
-    Instant expirationTime = null;
-    if (token != null) {
-      expirationTime = token.getExpirationTime();
-      if (expirationTime == null) {
-        try {
-          JwtToken jwtToken = JwtToken.parse(token.getPayload());
-          expirationTime = jwtToken.getExpirationTime();
-        } catch (Exception ignored) {
-          // fall through
-        }
+    Instant expirationTime = token.getExpirationTime();
+    if (expirationTime == null) {
+      try {
+        JwtToken jwtToken = JwtToken.parse(token.getPayload());
+        expirationTime = jwtToken.getExpirationTime();
+      } catch (Exception ignored) {
+        // fall through
       }
     }
     if (expirationTime == null) {

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Utils.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Utils.java
@@ -83,7 +83,7 @@ class OAuth2Utils {
       Duration refreshSafetyWindow,
       Duration minRefreshDelay) {
     Instant expirationTime =
-        accessExpirationTime.isBefore(refreshExpirationTime)
+        refreshExpirationTime == null || accessExpirationTime.isBefore(refreshExpirationTime)
             ? accessExpirationTime
             : refreshExpirationTime;
     Duration delay = Duration.between(now, expirationTime).minus(refreshSafetyWindow);


### PR DESCRIPTION
Discovered while working on #8847.

When there is no refresh token, use the access token expiration directly, instead of artificially computing a "default" expiration for a token that doesn't exist.

This PR also refactors `TestOAuth2Utils.testShortestDelay` to improve its readability.