### PR TITLE
Clarify OpenAPI doc for updateRepositoryConfig

### DIFF
--- a/api/model/src/main/java/org/projectnessie/api/v2/http/HttpConfigApi.java
+++ b/api/model/src/main/java/org/projectnessie/api/v2/http/HttpConfigApi.java
@@ -107,6 +107,8 @@ public interface HttpConfigApi extends ConfigApi {
   @APIResponses({
     @APIResponse(
         responseCode = "200",
+        description =
+            "The configuration was updated. The response body contains the previous configuration value.",
         content =
             @Content(
                 mediaType = "application/json",


### PR DESCRIPTION
Add a 200 response description to make it clear that the response contains the previous configuration value.