### PR TITLE
Fix flaky `TestCacheInvalidationSender.regularServiceNameLookups`

### DIFF
--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/CacheInvalidationSender.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/CacheInvalidationSender.java
@@ -150,9 +150,14 @@ public class CacheInvalidationSender implements DistributedCacheInvalidation {
                     all);
               }
 
-              resolvedAddresses = all;
+              updateResolvedAddresses(all);
             })
         .onFailure(t -> LOGGER.error("Failed to resolve service names: {}", t.toString()));
+  }
+
+  @VisibleForTesting
+  void updateResolvedAddresses(List<String> all) {
+    resolvedAddresses = all;
   }
 
   private void updateServiceNamesHandleFailure() {


### PR DESCRIPTION
There is a concurrency issue in the test, which lets the test advance too fast, assuming that the new addresses have already been "stored" by the `CacheInvalidationSender`. This change adds a new "probe" that is triggered after the (new) addresses have been "stored".