### PR TITLE
Fix STDOUT in `ConnectCommand`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Fixes
 
+- Fix console output during `CONNECT` in CLI/REPL (the bug was introduced in 0.91.1)
+
 ### Commits
 
 ## [0.91.2] Release (2024-06-24)

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/ConnectCommand.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/ConnectCommand.java
@@ -150,7 +150,7 @@ public class ConnectCommand extends NessieCommand<ConnectCommandSpec> {
             icebergClient = new RESTCatalog();
             icebergClient.initialize("iceberg", icebergProperties);
           } finally {
-            System.setErr(out);
+            System.setOut(out);
             System.setErr(err);
           }
         } catch (RESTException e) {


### PR DESCRIPTION
Properly restore the saved output stream.

Follow-up to #8885