### PR TITLE
Helm chart: don't call template if feature is disabled

### DIFF
--- a/helm/nessie/templates/deployment.yaml
+++ b/helm/nessie/templates/deployment.yaml
@@ -80,8 +80,12 @@ spec:
               value: /bigtable-nessie/sa_credentials.json
             {{- end }}
             {{- end -}}
+            {{- if .Values.authentication.enabled -}}
             {{- include "nessie.secretToEnv" (list .Values.authentication.oidcClientSecret "key" "quarkus.oidc.credentials.secret" ) | trim | nindent 12 -}}
+            {{- end -}}
+            {{- if .Values.catalog.enabled -}}
             {{- include "nessie.catalogStorageEnv" .Values.catalog.storage | trim | nindent 12 -}}
+            {{- end -}}
             {{- if .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
... as this could result in unnecessary environment variables in the resulting deployment.yaml.