### PR TITLE
Docs: reuse Nessie CLI history in docker examples

### DIFF
--- a/site/docs/downloads/index.md
+++ b/site/docs/downloads/index.md
@@ -73,20 +73,23 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
 === "Docker Image"
 
     Docker images are multiplatform images for amd64, arm64, ppc64le, s390x.
+
     They are available from the following repositories:
-     
+    
     * [GitHub Container Registry](https://github.com/projectnessie/nessie/pkgs/container/nessie-cli):
 
     ```bash
     docker pull ghcr.io/projectnessie/nessie-cli:{{ versions.nessie }}
-    docker run -it ghcr.io/projectnessie/nessie-cli:{{ versions.nessie }}
+    docker create -it --name nessie-cli --network=host -v $HOME/.nessie:/home/default/.nessie ghcr.io/projectnessie/nessie-cli:{{ versions.nessie }}
+    docker start -i nessie-cli
     ```
 
     * [Quay.io](https://quay.io/repository/projectnessie/nessie-cli?tab=tags):
 
     ```bash
     docker pull quay.io/projectnessie/nessie-cli:{{ versions.nessie }}
-    docker run -it quay.io/projectnessie/nessie-cli:{{ versions.nessie }}
+    docker create -it --name nessie-cli --network=host -v $HOME/.nessie:/home/default/.nessie quay.io/projectnessie/nessie-cli:{{ versions.nessie }}
+    docker start -i nessie-cli
     ```
 
 === "Standalone Jar"

--- a/site/in-dev/index-release.md
+++ b/site/in-dev/index-release.md
@@ -79,14 +79,16 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
 
     ```bash
     docker pull ghcr.io/projectnessie/nessie-cli:::NESSIE_VERSION::
-    docker run -it ghcr.io/projectnessie/nessie-cli:::NESSIE_VERSION:: 
+    docker create -it --name nessie-cli --network=host -v $HOME/.nessie:/home/default/.nessie ghcr.io/projectnessie/nessie-cli:::NESSIE_VERSION::
+    docker start -i nessie-cli
     ```
 
     * [Quay.io](https://quay.io/repository/projectnessie/nessie-cli?tab=tags):
 
     ```bash
     docker pull quay.io/projectnessie/nessie-cli:::NESSIE_VERSION::
-    docker run -it quay.io/projectnessie/nessie-cli:::NESSIE_VERSION::
+    docker create -it --name nessie-cli --network=host -v $HOME/.nessie:/home/default/.nessie quay.io/projectnessie/nessie-cli:::NESSIE_VERSION::
+    docker start -i nessie-cli
     ```
 
 === "Standalone Jar"

--- a/site/in-dev/index.md
+++ b/site/in-dev/index.md
@@ -26,14 +26,14 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
 
     ```bash
     docker pull ghcr.io/projectnessie/nessie-unstable
-    docker run -p 19120:19120 -p 9000:9000 ghcr.io/projectnessie/nessie-unstable
+    docker run --rm -p 19120:19120 -p 9000:9000 ghcr.io/projectnessie/nessie-unstable
     ```
 
     * [Quay.io](https://quay.io/repository/projectnessie/nessie-unstable?tab=tags):
     
     ```bash
     docker pull quay.io/projectnessie/nessie-unstable
-    docker run -p 19120:19120 -p 9000:9000 quay.io/projectnessie/nessie-unstable
+    docker run --rm -p 19120:19120 -p 9000:9000 quay.io/projectnessie/nessie-unstable
     ```
 
 ## Nessie CLI unstable/nightly
@@ -50,14 +50,14 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
 
     ```bash
     docker pull ghcr.io/projectnessie/nessie-cli-unstable
-    docker run -it ghcr.io/projectnessie/nessie-cli-unstable
+    docker run -it --rm ghcr.io/projectnessie/nessie-cli-unstable
     ```
 
     * [Quay.io](https://quay.io/repository/projectnessie/nessie-cli-unstable?tab=tags):
 
     ```bash
     docker pull quay.io/projectnessie/nessie-cli-unstable
-    docker run -it quay.io/projectnessie/nessie-cli-unstable
+    docker run -it --rm quay.io/projectnessie/nessie-cli-unstable
     ```
 
 ## GC Tool unstable/nightly
@@ -77,14 +77,14 @@ expiration policies.
 
     ```bash
     docker pull ghcr.io/projectnessie/nessie-gc-unstable
-    docker run ghcr.io/projectnessie/nessie-gc-unstable --help
+    docker run --rm ghcr.io/projectnessie/nessie-gc-unstable --help
     ```
 
     * [Quay.io](https://quay.io/repository/projectnessie/nessie-gc-unstable?tab=tags):
 
     ```bash
     docker pull quay.io/projectnessie/nessie-gc-unstable
-    docker run quay.io/projectnessie/nessie-gc-unstable --help
+    docker run --rm quay.io/projectnessie/nessie-gc-unstable --help
     ```
 
 ## Server Admin Tool unstable/nightly
@@ -104,14 +104,14 @@ Nessie repository.
 
     ```bash
     docker pull ghcr.io/projectnessie/nessie-server-admin-unstable
-    docker run ghcr.io/projectnessie/nessie-server-admin-unstable --help
+    docker run --rm ghcr.io/projectnessie/nessie-server-admin-unstable --help
     ```
 
     * [Quay.io](https://quay.io/repository/projectnessie/nessie-server-admin-unstable?tab=tags):
 
     ```bash
     docker pull quay.io/projectnessie/nessie-server-admin-unstable
-    docker run quay.io/projectnessie/nessie-server-admin-unstable --help
+    docker run --rm quay.io/projectnessie/nessie-server-admin-unstable --help
     ```
 
 ## Build Nessie from source


### PR DESCRIPTION
...and use host network for easier connectivity.

Also: automatically remove docker containers for unstable images when the container exits.