### PR TITLE
Catalog S3: use DefaultCredentialsProvider if no access key configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Breaking changes
 
+- Catalog: The `nessie.catalog.s3.default-options.auth-mode` configuration property has been renamed
+  to `nessie.catalog.s3.default-options.client-auth-mode` to better reflect its purpose. The old
+  property name is not supported anymore.
+
 ### New Features
 
 - Catalog: Improve indicated health check errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ as necessary. Empty sections will not end in the release notes.
 
 - Catalog: The `nessie.catalog.s3.default-options.auth-mode` configuration property has been renamed
   to `nessie.catalog.s3.default-options.client-auth-mode` to better reflect its purpose. The old
-  property name is not supported anymore.
+  property name is not supported anymore and must be updated in customized Helm values and/or 
+  Quarkus configurations.
 
 ### New Features
 

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3BucketOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3BucketOptions.java
@@ -103,15 +103,6 @@ public interface S3BucketOptions {
    * <ul>
    *   <li>{@code DEFAULT}: Default credentials provider chain.
    *   <li>{@code STATIC}: Static credentials provided through the {@code access-key} option.
-   *   <li>{@code ENV_VARIABLE}: Loads credentials from the {@code AWS_ACCESS_KEY_ID}, {@code
-   *       AWS_SECRET_ACCESS_KEY} and {@code AWS_SESSION_TOKEN} environment variables.
-   *   <li>{@code SYSTEM_PROPERTY}: Loads credentials from the system properties {@code
-   *       aws.accessKeyId} and {@code aws.secretAccessKey}.
-   *   <li>{@code PROFILE}: Loads credentials from AWS profile files.
-   *   <li>{@code INSTANCE_PROFILE}: Loads credentials from the Amazon EC2 metadata service.
-   *   <li>{@code CONTAINER}: Loads credentials from a local metadata service on ECS or AWS
-   *       Greengrass.
-   *   <li>{@code ANONYMOUS}: Anonymous access.
    * </ul>
    */
   Optional<S3ServerAuthenticationMode> serverAuthenticationMode();

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3BucketOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3BucketOptions.java
@@ -101,7 +101,7 @@ public interface S3BucketOptions {
    * <p>Valid values are:
    *
    * <ul>
-   *   <li>{@code DEFAULT}: Default credentials provider chain.
+   *   <li>{@code APPLICATION_GLOBAL}: Default credentials provider chain.
    *   <li>{@code STATIC}: Static credentials provided through the {@code access-key} option.
    * </ul>
    */

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3BucketOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3BucketOptions.java
@@ -123,16 +123,6 @@ public interface S3BucketOptions {
   Optional<BasicCredentials> accessKey();
 
   /**
-   * The profile name to use when loading AWS credentials from the standard AWS configuration files.
-   *
-   * <p>Required when {@code server-authentication-mode} is {@code PROFILE}.
-   *
-   * <p>For STS, this defines the profile name to be used as a basic credential provider for
-   * obtaining temporary session credentials.
-   */
-  Optional<String> profile();
-
-  /**
    * The <a href="https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html">Security Token
    * Service</a> endpoint.
    *

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3BucketOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3BucketOptions.java
@@ -101,7 +101,9 @@ public interface S3BucketOptions {
    * <p>Valid values are:
    *
    * <ul>
-   *   <li>{@code APPLICATION_GLOBAL}: Default credentials provider chain.
+   *   <li>{@code APPLICATION_GLOBAL}: Use the AWSSDK <a
+   *       href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html">default
+   *       credentials provider</a>.
    *   <li>{@code STATIC}: Static credentials provided through the {@code access-key} option.
    * </ul>
    */

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3BucketOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3BucketOptions.java
@@ -101,14 +101,17 @@ public interface S3BucketOptions {
    * <p>Valid values are:
    *
    * <ul>
-   *   <li>{@code DEFAULT} - Default credentials provider chain.
-   *   <li>{@code STATIC} - Static credentials (access-key-id and secret-access-key).
-   *   <li>{@code ENV_VARIABLE} - Environment variables.
-   *   <li>{@code SYSTEM_PROPERTY} - System properties.
-   *   <li>{@code PROFILE} - AWS profile.
-   *   <li>{@code INSTANCE_PROFILE} - AWS Instance profile.
-   *   <li>{@code CONTAINER} - Container credentials.
-   *   <li>{@code ANONYMOUS} - Anonymous access.
+   *   <li>{@code DEFAULT}: Default credentials provider chain.
+   *   <li>{@code STATIC}: Static credentials provided through the {@code access-key} option.
+   *   <li>{@code ENV_VARIABLE}: Loads credentials from the {@code AWS_ACCESS_KEY_ID}, {@code
+   *       AWS_SECRET_ACCESS_KEY} and {@code AWS_SESSION_TOKEN} environment variables.
+   *   <li>{@code SYSTEM_PROPERTY}: Loads credentials from the system properties {@code
+   *       aws.accessKeyId} and {@code aws.secretAccessKey}.
+   *   <li>{@code PROFILE}: Loads credentials from AWS profile files.
+   *   <li>{@code INSTANCE_PROFILE}: Loads credentials from the Amazon EC2 metadata service.
+   *   <li>{@code CONTAINER}: Loads credentials from a local metadata service on ECS or AWS
+   *       Greengrass.
+   *   <li>{@code ANONYMOUS}: Anonymous access.
    * </ul>
    */
   Optional<S3ServerAuthenticationMode> serverAuthenticationMode();

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3Clients.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3Clients.java
@@ -117,10 +117,9 @@ public class S3Clients {
 
   public static AwsCredentialsProvider awsCredentialsProvider(
       S3BucketOptions bucketOptions, S3Sessions sessions) {
-    if (bucketOptions.assumeRole().isPresent()) {
-      return sessions.assumeRoleForServer(bucketOptions);
-    }
-    return bucketOptions.effectiveServerAuthenticationMode().newCredentialsProvider(bucketOptions);
+    return bucketOptions.assumeRole().isPresent()
+        ? sessions.assumeRoleForServer(bucketOptions)
+        : bucketOptions.effectiveServerAuthenticationMode().newCredentialsProvider(bucketOptions);
   }
 
   private static final class FileStoreTlsTrustManagersProvider implements TlsTrustManagersProvider {

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3ServerAuthenticationMode.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3ServerAuthenticationMode.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.projectnessie.catalog.files.s3;
+
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
+
+/**
+ * @see <a
+ *     href="https://github.com/quarkiverse/quarkus-amazon-services/blob/4ecc71767857d476767ffd36f0fac98c1b2b7de1/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AwsCredentialsProviderType.java">Quarkus
+ *     AWS AwsCredentialsProviderType</a>
+ */
+public enum S3ServerAuthenticationMode {
+  DEFAULT {
+    @Override
+    public AwsCredentialsProvider newCredentialsProvider(S3BucketOptions bucketOptions) {
+      return DefaultCredentialsProvider.builder()
+          .asyncCredentialUpdateEnabled(false)
+          .reuseLastProviderEnabled(true)
+          .build();
+    }
+  },
+
+  STATIC {
+    @Override
+    public AwsCredentialsProvider newCredentialsProvider(S3BucketOptions bucketOptions) {
+      return bucketOptions
+          .accessKey()
+          // TODO support session token: AwsSessionCredentials.create(accessKeyId, secretAccessKey,
+          // sessionToken)
+          .map(key -> AwsBasicCredentials.create(key.name(), key.secret()))
+          .map(creds -> (AwsCredentialsProvider) StaticCredentialsProvider.create(creds))
+          .orElseThrow(
+              () ->
+                  new IllegalArgumentException(
+                      "Missing access key and secret for STATIC auth type"));
+    }
+  },
+
+  SYSTEM_PROPERTY {
+    @Override
+    public AwsCredentialsProvider newCredentialsProvider(S3BucketOptions bucketOptions) {
+      return SystemPropertyCredentialsProvider.create();
+    }
+  },
+
+  ENV_VARIABLE {
+    @Override
+    public AwsCredentialsProvider newCredentialsProvider(S3BucketOptions bucketOptions) {
+      return EnvironmentVariableCredentialsProvider.create();
+    }
+  },
+
+  PROFILE {
+    @Override
+    public AwsCredentialsProvider newCredentialsProvider(S3BucketOptions bucketOptions) {
+      return bucketOptions
+          .profile()
+          .map(ProfileCredentialsProvider::create)
+          .orElseThrow(
+              () -> new IllegalArgumentException("Missing profile name for PROFILE auth type"));
+    }
+  },
+
+  CONTAINER {
+    @Override
+    public AwsCredentialsProvider newCredentialsProvider(S3BucketOptions bucketOptions) {
+      return ContainerCredentialsProvider.builder().build();
+    }
+  },
+
+  INSTANCE_PROFILE {
+    @Override
+    public AwsCredentialsProvider newCredentialsProvider(S3BucketOptions bucketOptions) {
+      return InstanceProfileCredentialsProvider.builder().build();
+    }
+  },
+
+  ANONYMOUS {
+    @Override
+    public AwsCredentialsProvider newCredentialsProvider(S3BucketOptions bucketOptions) {
+      return AnonymousCredentialsProvider.create();
+    }
+  },
+  ;
+
+  public abstract AwsCredentialsProvider newCredentialsProvider(S3BucketOptions bucketOptions);
+}

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3ServerAuthenticationMode.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3ServerAuthenticationMode.java
@@ -22,7 +22,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 
 /** Server authentication modes for S3. */
 public enum S3ServerAuthenticationMode {
-  DEFAULT {
+  APPLICATION_GLOBAL {
     @Override
     public AwsCredentialsProvider newCredentialsProvider(S3BucketOptions bucketOptions) {
       return DefaultCredentialsProvider.create(); // actually a singleton

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3ServerAuthenticationMode.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3ServerAuthenticationMode.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.projectnessie.catalog.files.s3;
 
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
@@ -28,6 +27,8 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
 
 /**
+ * Authentication modes for S3.
+ *
  * @see <a
  *     href="https://github.com/quarkiverse/quarkus-amazon-services/blob/4ecc71767857d476767ffd36f0fac98c1b2b7de1/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AwsCredentialsProviderType.java">Quarkus
  *     AWS AwsCredentialsProviderType</a>
@@ -55,7 +56,7 @@ public enum S3ServerAuthenticationMode {
           .orElseThrow(
               () ->
                   new IllegalArgumentException(
-                      "Missing access key and secret for STATIC auth type"));
+                      "Missing access key and secret for STATIC authentication mode"));
     }
   },
 
@@ -80,7 +81,9 @@ public enum S3ServerAuthenticationMode {
           .profile()
           .map(ProfileCredentialsProvider::create)
           .orElseThrow(
-              () -> new IllegalArgumentException("Missing profile name for PROFILE auth type"));
+              () ->
+                  new IllegalArgumentException(
+                      "Missing profile name for PROFILE authentication mode"));
     }
   },
 

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3SessionsManager.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3SessionsManager.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import org.checkerframework.checker.index.qual.NonNegative;
+import org.immutables.value.Value;
 import org.projectnessie.nessie.immutables.NessieImmutable;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.SdkHttpClient;

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3SessionsManager.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3SessionsManager.java
@@ -18,7 +18,6 @@ package org.projectnessie.catalog.files.s3;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.projectnessie.catalog.files.s3.S3Clients.basicCredentialsProvider;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -39,7 +38,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import org.checkerframework.checker.index.qual.NonNegative;
-import org.projectnessie.catalog.secrets.BasicCredentials;
 import org.projectnessie.nessie.immutables.NessieImmutable;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -175,8 +173,13 @@ public class S3SessionsManager {
 
   private Credentials fetchCredentials(SessionKey sessionKey, Optional<Duration> sessionDuration) {
     // Note: StsClients may be shared across repositories.
+    String region =
+        sessionKey
+            .bucketOptions()
+            .region()
+            .orElseThrow(() -> new IllegalArgumentException("Missing S3 region"));
     StsClientKey clientKey =
-        ImmutableStsClientKey.of(sessionKey.stsEndpoint(), sessionKey.region());
+        ImmutableStsClientKey.of(sessionKey.bucketOptions().stsEndpoint(), region);
     StsClient client = clients.get(clientKey, clientBuilder);
 
     return sessionCredentialsFetcher.fetchCredentials(client, sessionKey, sessionDuration);
@@ -185,11 +188,12 @@ public class S3SessionsManager {
   private Credentials executeAssumeRoleRequest(
       StsClient client, SessionKey sessionKey, Optional<Duration> sessionDuration) {
     AssumeRoleRequest.Builder request = AssumeRoleRequest.builder();
+    S3BucketOptions bucketOptions = sessionKey.bucketOptions();
     request.roleSessionName(
-        sessionKey.roleSessionName().orElse(S3BucketOptions.DEFAULT_SESSION_NAME));
-    request.roleArn(sessionKey.roleArn());
-    sessionKey.externalId().ifPresent(request::externalId);
-    sessionKey.iamPolicy().ifPresent(request::policy);
+        bucketOptions.roleSessionName().orElse(S3BucketOptions.DEFAULT_SESSION_NAME));
+    bucketOptions.assumeRole().ifPresent(request::roleArn);
+    bucketOptions.externalId().ifPresent(request::externalId);
+    bucketOptions.sessionIamPolicy().ifPresent(request::policy);
     sessionDuration.ifPresent(
         duration -> {
           long seconds = duration.toSeconds();
@@ -199,7 +203,10 @@ public class S3SessionsManager {
         });
 
     request.overrideConfiguration(
-        builder -> builder.credentialsProvider(basicCredentialsProvider(sessionKey.accessKey())));
+        builder -> {
+          S3ServerAuthenticationMode authMode = bucketOptions.effectiveServerAuthenticationMode();
+          builder.credentialsProvider(authMode.newCredentialsProvider(bucketOptions));
+        });
 
     AssumeRoleResponse response = client.assumeRole(request.build());
     return response.credentials();
@@ -222,23 +229,7 @@ public class S3SessionsManager {
   private static SessionKey buildSessionKey(String repositoryId, S3BucketOptions options) {
     // Client parameters are part of the credential's key because clients in different regions may
     // issue different credentials.
-    return ImmutableSessionKey.builder()
-        .repositoryId(repositoryId)
-        .region(
-            options
-                .region()
-                .orElseThrow(() -> new IllegalArgumentException("S3 region must be provided")))
-        .stsEndpoint(options.stsEndpoint())
-        .roleArn(
-            options
-                .assumeRole()
-                .orElseThrow(() -> new IllegalArgumentException("Role ARN must be configured")))
-        .accessKey(options.accessKey())
-        .stsEndpoint(options.stsEndpoint())
-        .iamPolicy(options.sessionIamPolicy())
-        .roleSessionName(options.roleSessionName())
-        .externalId(options.externalId())
-        .build();
+    return ImmutableSessionKey.builder().repositoryId(repositoryId).bucketOptions(options).build();
   }
 
   private static StsClient client(StsClientKey parameters, SdkHttpClient sdkClient) {
@@ -260,19 +251,7 @@ public class S3SessionsManager {
   interface SessionKey {
     String repositoryId();
 
-    String region();
-
-    String roleArn();
-
-    Optional<URI> stsEndpoint();
-
-    Optional<BasicCredentials> accessKey();
-
-    Optional<String> iamPolicy();
-
-    Optional<String> roleSessionName();
-
-    Optional<String> externalId();
+    S3BucketOptions bucketOptions();
   }
 
   @NessieImmutable

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3SessionsManager.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3SessionsManager.java
@@ -38,7 +38,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import org.checkerframework.checker.index.qual.NonNegative;
-import org.immutables.value.Value;
 import org.projectnessie.nessie.immutables.NessieImmutable;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.SdkHttpClient;

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3SessionsManager.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3SessionsManager.java
@@ -199,9 +199,7 @@ public class S3SessionsManager {
         });
 
     request.overrideConfiguration(
-        builder ->
-            builder.credentialsProvider(
-                basicCredentialsProvider(sessionKey.accessKeyId(), sessionKey.secretAccessKey())));
+        builder -> builder.credentialsProvider(basicCredentialsProvider(sessionKey.accessKey())));
 
     AssumeRoleResponse response = client.assumeRole(request.build());
     return response.credentials();
@@ -235,8 +233,7 @@ public class S3SessionsManager {
             options
                 .assumeRole()
                 .orElseThrow(() -> new IllegalArgumentException("Role ARN must be configured")))
-        .accessKeyId(options.accessKey().map(BasicCredentials::name))
-        .secretAccessKey(options.accessKey().map(BasicCredentials::secret))
+        .accessKey(options.accessKey())
         .stsEndpoint(options.stsEndpoint())
         .iamPolicy(options.sessionIamPolicy())
         .roleSessionName(options.roleSessionName())
@@ -269,9 +266,7 @@ public class S3SessionsManager {
 
     Optional<URI> stsEndpoint();
 
-    Optional<String> accessKeyId();
-
-    Optional<String> secretAccessKey();
+    Optional<BasicCredentials> accessKey();
 
     Optional<String> iamPolicy();
 

--- a/helm/nessie/templates/_helpers.tpl
+++ b/helm/nessie/templates/_helpers.tpl
@@ -160,7 +160,6 @@ Apply S3 catalog options.
 {{- if .allowCrossRegionAccessPoint -}}{{- $_ := set $map ( print $prefix "allow-cross-region-access-point" ) .allowCrossRegionAccessPoint -}}{{- end -}}
 {{- if .serverAuthenticationMode -}}{{- $_ := set $map ( print $prefix "server-auth-mode" ) .serverAuthenticationMode -}}{{- end -}}
 {{- if .clientAuthenticationMode -}}{{- $_ := set $map ( print $prefix "client-auth-mode" ) .clientAuthenticationMode -}}{{- end -}}
-{{- if .profile -}}{{- $_ := set $map ( print $prefix "profile" ) .profile -}}{{- end -}}
 {{- if .assumeRole -}}
 {{- if .assumeRole.stsEndpoint -}}{{- $_ := set $map ( print $prefix "sts-endpoint" ) .assumeRole.stsEndpoint -}}{{- end -}}
 {{- if .assumeRole.roleArn -}}{{- $_ := set $map ( print $prefix "assume-role" ) .assumeRole.roleArn -}}{{- end -}}

--- a/helm/nessie/templates/_helpers.tpl
+++ b/helm/nessie/templates/_helpers.tpl
@@ -158,7 +158,9 @@ Apply S3 catalog options.
 {{- if .pathStyleAccess -}}{{- $_ := set $map ( print $prefix "path-style-access" ) .pathStyleAccess -}}{{- end -}}
 {{- if .accessPoint -}}{{- $_ := set $map ( print $prefix "access-point" ) .accessPoint -}}{{- end -}}
 {{- if .allowCrossRegionAccessPoint -}}{{- $_ := set $map ( print $prefix "allow-cross-region-access-point" ) .allowCrossRegionAccessPoint -}}{{- end -}}
-{{- if .clientAuthenticationMode -}}{{- $_ := set $map ( print $prefix "auth-mode" ) .clientAuthenticationMode -}}{{- end -}}
+{{- if .serverAuthenticationMode -}}{{- $_ := set $map ( print $prefix "server-auth-mode" ) .serverAuthenticationMode -}}{{- end -}}
+{{- if .clientAuthenticationMode -}}{{- $_ := set $map ( print $prefix "client-auth-mode" ) .clientAuthenticationMode -}}{{- end -}}
+{{- if .profile -}}{{- $_ := set $map ( print $prefix "profile" ) .profile -}}{{- end -}}
 {{- if .assumeRole -}}
 {{- if .assumeRole.stsEndpoint -}}{{- $_ := set $map ( print $prefix "sts-endpoint" ) .assumeRole.stsEndpoint -}}{{- end -}}
 {{- if .assumeRole.roleArn -}}{{- $_ := set $map ( print $prefix "assume-role" ) .assumeRole.roleArn -}}{{- end -}}

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -195,12 +195,6 @@ catalog:
         # -- Controls the authentication mode for the Catalog server. Valid values are:
         # - DEFAULT: Use the default AWS credentials provider chain.
         # - STATIC: Static credentials provided through the accessKeySecret option.
-        # - ENV_VARIABLE: Loads credentials from the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN environment variables.
-        # - SYSTEM_PROPERTY: Loads credentials from the system properties aws.accessKeyId and aws.secretAccessKey.
-        # - PROFILE: Loads credentials from AWS profile files.
-        # - INSTANCE_PROFILE: Loads credentials from the Amazon EC2 metadata service.
-        # - CONTAINER: Loads credentials from a local metadata service on ECS or AWS Greengrass.
-        # - ANONYMOUS: Anonymous access.
         # The default is STATIC.
         serverAuthenticationMode: ~  # STATIC
         # -- Controls the authentication mode for Catalog clients accessing this bucket. Valid values
@@ -243,9 +237,6 @@ catalog:
           awsAccessKeyId: ~
           # -- The secret key storing the AWS secret access key.
           awsSecretAccessKey: ~
-
-        # -- AWS profile name. Required when serverAuthenticationMode is PROFILE.
-        profile: ~
 
       # -- Per-bucket S3 settings. Override the general settings above.
       buckets: []

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -192,6 +192,17 @@ catalog:
         accessPoint: ~
         # -- Authorize cross-region calls when contacting an access point. The default is false.
         allowCrossRegionAccessPoint: false
+        # -- Controls the authentication mode for the Catalog server. Valid values are:
+        # - DEFAULT: Default credentials provider chain.
+        # - STATIC: Static credentials (access-key-id and secret-access-key).
+        # - ENV_VARIABLE: Environment variables.
+        # - SYSTEM_PROPERTY: System properties.
+        # - PROFILE: AWS profile.
+        # - INSTANCE_PROFILE: AWS Instance profile.
+        # - CONTAINER: Container credentials.
+        # - ANONYMOUS: No authentication.
+        # The default is STATIC.
+        serverAuthenticationMode: ~  # STATIC
         # -- Controls the authentication mode for Catalog clients accessing this bucket. Valid values
         # are:
         # - REQUEST_SIGNING: Each client I/O request is individually authorized (signed) by the
@@ -224,8 +235,7 @@ catalog:
           # associated with the warehouse. If unset, a default of one hour is assumed.
           clientSessionDuration: ~
 
-        # -- AWS credentials. For STS, this defines the Access Key ID and Secret Key ID to be used as
-        # a basic credential for obtaining temporary session credentials.
+        # -- AWS credentials. Required when serverAuthenticationMode is STATIC.
         accessKeySecret:
           # -- The secret name to pull AWS credentials from. Optional; if not present, the default AWS
           # credentials provider chain is used.
@@ -234,6 +244,9 @@ catalog:
           awsAccessKeyId: ~
           # -- The secret key storing the AWS secret access key.
           awsSecretAccessKey: ~
+
+        # -- AWS profile name. Required when serverAuthenticationMode is PROFILE.
+        profile: ~
 
       # -- Per-bucket S3 settings. Override the general settings above.
       buckets: []

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -193,7 +193,7 @@ catalog:
         # -- Authorize cross-region calls when contacting an access point. The default is false.
         allowCrossRegionAccessPoint: false
         # -- Controls the authentication mode for the Catalog server. Valid values are:
-        # - DEFAULT: Use the default AWS credentials provider chain.
+        # - APPLICATION_GLOBAL: Use the default AWS credentials provider chain.
         # - STATIC: Static credentials provided through the accessKeySecret option.
         # The default is STATIC.
         serverAuthenticationMode: ~  # STATIC

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -193,14 +193,14 @@ catalog:
         # -- Authorize cross-region calls when contacting an access point. The default is false.
         allowCrossRegionAccessPoint: false
         # -- Controls the authentication mode for the Catalog server. Valid values are:
-        # - DEFAULT: Default credentials provider chain.
-        # - STATIC: Static credentials (access-key-id and secret-access-key).
-        # - ENV_VARIABLE: Environment variables.
-        # - SYSTEM_PROPERTY: System properties.
-        # - PROFILE: AWS profile.
-        # - INSTANCE_PROFILE: AWS Instance profile.
-        # - CONTAINER: Container credentials.
-        # - ANONYMOUS: No authentication.
+        # - DEFAULT: Use the default AWS credentials provider chain.
+        # - STATIC: Static credentials provided through the accessKeySecret option.
+        # - ENV_VARIABLE: Loads credentials from the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN environment variables.
+        # - SYSTEM_PROPERTY: Loads credentials from the system properties aws.accessKeyId and aws.secretAccessKey.
+        # - PROFILE: Loads credentials from AWS profile files.
+        # - INSTANCE_PROFILE: Loads credentials from the Amazon EC2 metadata service.
+        # - CONTAINER: Loads credentials from a local metadata service on ECS or AWS Greengrass.
+        # - ANONYMOUS: Anonymous access.
         # The default is STATIC.
         serverAuthenticationMode: ~  # STATIC
         # -- Controls the authentication mode for Catalog clients accessing this bucket. Valid values
@@ -237,8 +237,7 @@ catalog:
 
         # -- AWS credentials. Required when serverAuthenticationMode is STATIC.
         accessKeySecret:
-          # -- The secret name to pull AWS credentials from. Optional; if not present, the default AWS
-          # credentials provider chain is used.
+          # -- The secret name to pull AWS credentials from.
           name: ~
           # -- The secret key storing the AWS secret key id.
           awsAccessKeyId: ~

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogS3BucketConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogS3BucketConfig.java
@@ -19,6 +19,7 @@ import io.smallrye.config.WithName;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Optional;
+import org.projectnessie.catalog.files.s3.S3ServerAuthenticationMode;
 import org.projectnessie.catalog.files.s3.S3BucketOptions;
 import org.projectnessie.catalog.files.s3.S3ClientAuthenticationMode;
 import org.projectnessie.catalog.secrets.BasicCredentials;
@@ -46,6 +47,13 @@ public interface CatalogS3BucketConfig extends S3BucketOptions {
   @Override
   Optional<Boolean> allowCrossRegionAccessPoint();
 
+  @WithName("server-auth-mode")
+  @Override
+  Optional<S3ServerAuthenticationMode> serverAuthenticationMode();
+
+  @Override
+  Optional<String> profile();
+
   @Override
   Optional<URI> stsEndpoint();
 
@@ -61,7 +69,7 @@ public interface CatalogS3BucketConfig extends S3BucketOptions {
   @Override
   Optional<String> externalId();
 
-  @WithName("auth-mode")
+  @WithName("client-auth-mode")
   @Override
   Optional<S3ClientAuthenticationMode> clientAuthenticationMode();
 

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogS3BucketConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogS3BucketConfig.java
@@ -52,9 +52,6 @@ public interface CatalogS3BucketConfig extends S3BucketOptions {
   Optional<S3ServerAuthenticationMode> serverAuthenticationMode();
 
   @Override
-  Optional<String> profile();
-
-  @Override
   Optional<URI> stsEndpoint();
 
   @Override

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogS3BucketConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogS3BucketConfig.java
@@ -19,9 +19,9 @@ import io.smallrye.config.WithName;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Optional;
-import org.projectnessie.catalog.files.s3.S3ServerAuthenticationMode;
 import org.projectnessie.catalog.files.s3.S3BucketOptions;
 import org.projectnessie.catalog.files.s3.S3ClientAuthenticationMode;
+import org.projectnessie.catalog.files.s3.S3ServerAuthenticationMode;
 import org.projectnessie.catalog.secrets.BasicCredentials;
 
 public interface CatalogS3BucketConfig extends S3BucketOptions {

--- a/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/s3/ITS3VendedAssumeRoleIcebergCatalog.java
+++ b/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/s3/ITS3VendedAssumeRoleIcebergCatalog.java
@@ -136,7 +136,7 @@ public class ITS3VendedAssumeRoleIcebergCatalog {
     public Map<String, String> getConfigOverrides() {
       return ImmutableMap.<String, String>builder()
           .put(
-              "nessie.catalog.service.s3.default-options.auth-mode",
+              "nessie.catalog.service.s3.default-options.client-auth-mode",
               S3ClientAuthenticationMode.ASSUME_ROLE.name())
           .put("nessie.catalog.service.s3.default-options.session-iam-policy", IAM_POLICY)
           .put(

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/s3/TestVendedS3CredentialsExpiry.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/s3/TestVendedS3CredentialsExpiry.java
@@ -111,7 +111,7 @@ public class TestVendedS3CredentialsExpiry {
           .put("nessie.catalog.warehouses.warehouse.location", "s3://test-bucket")
           .put("nessie.catalog.service.s3.default-options.region", "us-west-2")
           .put(
-              "nessie.catalog.service.s3.default-options.auth-mode",
+              "nessie.catalog.service.s3.default-options.client-auth-mode",
               S3ClientAuthenticationMode.ASSUME_ROLE.name())
           .put("nessie.catalog.service.s3.default-options.client-session-duration", "PT5H")
           .put("nessie.catalog.service.s3.default-options.role-session-name", "test-session-name")


### PR DESCRIPTION
Using DefaultCredentialsProvider as a last resort allows leveraging instance profile credentials delivered through the Amazon EC2 metadata service.