### PR TITLE
Refactor `MultiTableUpdate`

### DIFF
--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/EntitySnapshotObj.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/EntitySnapshotObj.java
@@ -86,7 +86,11 @@ public interface EntitySnapshotObj extends TaskObj {
     if (content instanceof Namespace) {
       throw new IllegalArgumentException("No snapshots for Namespace: " + content);
     }
-    throw new UnsupportedOperationException("IMPLEMENT ME FOR " + content);
+    throw new UnsupportedOperationException(
+        "Support for content with type "
+            + content.getType()
+            + " not implemented, content = "
+            + content);
   }
 
   static Builder builder() {

--- a/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/IcebergStuff.java
+++ b/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/IcebergStuff.java
@@ -66,6 +66,7 @@ public class IcebergStuff {
   }
 
   @SuppressWarnings("unchecked")
+  @Nonnull
   private <S extends NessieEntitySnapshot<?>> CompletionStage<S> triggerIcebergSnapshot(
       EntitySnapshotTaskRequest snapshotTaskRequest) {
     // TODO Handle hash-collision - when entity-snapshot refers to a different(!) snapshot
@@ -86,6 +87,7 @@ public class IcebergStuff {
             });
   }
 
+  @Nonnull
   public <S extends NessieEntitySnapshot<?>> CompletionStage<S> storeSnapshot(
       S snapshot, Content content) {
     EntitySnapshotTaskRequest snapshotTaskRequest =

--- a/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/MultiTableUpdate.java
+++ b/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/MultiTableUpdate.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.service.impl;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.projectnessie.catalog.model.snapshot.NessieEntitySnapshot;
+import org.projectnessie.client.api.CommitMultipleOperationsBuilder;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitResponse;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.Operation;
+
+/** Maintains state across all individual updates of a commit. */
+final class MultiTableUpdate {
+  private final CommitMultipleOperationsBuilder nessieCommit;
+  private final List<SingleTableUpdate> tableUpdates = new ArrayList<>();
+  private final List<String> storedLocations = new ArrayList<>();
+  private Map<ContentKey, String> addedContentsMap;
+  private Branch targetBranch;
+  private boolean committed;
+
+  MultiTableUpdate(CommitMultipleOperationsBuilder nessieCommit, Branch target) {
+    this.nessieCommit = nessieCommit;
+    this.targetBranch = target;
+  }
+
+  MultiTableUpdate commit() throws NessieConflictException, NessieNotFoundException {
+    synchronized (this) {
+      committed = true;
+      if (!tableUpdates.isEmpty()) {
+        CommitResponse commitResponse = nessieCommit.commitWithResponse();
+        addedContentsMap =
+            commitResponse.getAddedContents() != null
+                ? commitResponse.toAddedContentsMap()
+                : Map.of();
+        targetBranch = commitResponse.getTargetBranch();
+      }
+      return this;
+    }
+  }
+
+  Branch targetBranch() {
+    synchronized (this) {
+      return targetBranch;
+    }
+  }
+
+  Map<ContentKey, String> addedContentsMap() {
+    synchronized (this) {
+      return addedContentsMap != null ? addedContentsMap : Map.of();
+    }
+  }
+
+  List<SingleTableUpdate> tableUpdates() {
+    synchronized (this) {
+      return tableUpdates;
+    }
+  }
+
+  List<String> storedLocations() {
+    synchronized (this) {
+      return storedLocations;
+    }
+  }
+
+  void addUpdate(ContentKey key, SingleTableUpdate singleTableUpdate) {
+    checkState(!committed, "Already committed");
+    synchronized (this) {
+      tableUpdates.add(singleTableUpdate);
+      nessieCommit.operation(Operation.Put.of(key, singleTableUpdate.content));
+    }
+  }
+
+  void addStoredLocation(String location) {
+    checkState(!committed, "Already committed");
+    synchronized (this) {
+      storedLocations.add(location);
+    }
+  }
+
+  static final class SingleTableUpdate {
+    final NessieEntitySnapshot<?> snapshot;
+    final Content content;
+    final ContentKey key;
+
+    SingleTableUpdate(NessieEntitySnapshot<?> snapshot, Content content, ContentKey key) {
+      this.snapshot = snapshot;
+      this.content = content;
+      this.key = key;
+    }
+  }
+}

--- a/catalog/service/impl/src/test/java/org/projectnessie/catalog/service/impl/TestCatalogServiceImpl.java
+++ b/catalog/service/impl/src/test/java/org/projectnessie/catalog/service/impl/TestCatalogServiceImpl.java
@@ -16,24 +16,9 @@
 package org.projectnessie.catalog.service.impl;
 
 import static org.projectnessie.api.v2.params.ParsedReference.parsedReference;
-import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.AddPartitionSpec.addPartitionSpec;
-import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.AddSchema.addSchema;
-import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.AddSortOrder.addSortOrder;
-import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.AssignUUID.assignUUID;
-import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.SetCurrentSchema.setCurrentSchema;
-import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.SetDefaultPartitionSpec.setDefaultPartitionSpec;
-import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.SetDefaultSortOrder.setDefaultSortOrder;
-import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.UpgradeFormatVersion.upgradeFormatVersion;
-import static org.projectnessie.catalog.formats.iceberg.rest.IcebergUpdateRequirement.AssertCreate.assertTableDoesNotExist;
-import static org.projectnessie.model.Content.Type.ICEBERG_TABLE;
 
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.api.v2.params.ParsedReference;
-import org.projectnessie.catalog.formats.iceberg.meta.IcebergPartitionSpec;
-import org.projectnessie.catalog.formats.iceberg.meta.IcebergSchema;
-import org.projectnessie.catalog.formats.iceberg.meta.IcebergSortOrder;
-import org.projectnessie.catalog.formats.iceberg.rest.IcebergCatalogOperation;
 import org.projectnessie.catalog.service.api.CatalogCommit;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.Reference;
@@ -41,34 +26,30 @@ import org.projectnessie.model.Reference;
 public class TestCatalogServiceImpl extends AbstractCatalogService {
 
   @Test
-  public void singleTableCreate() throws Exception {
+  public void noCommitOps() throws Exception {
     Reference main = api.getReference().refName("main").get();
 
     ParsedReference ref =
         parsedReference(main.getName(), main.getHash(), Reference.ReferenceType.BRANCH);
-    ContentKey key = ContentKey.of("mytable");
-    CatalogCommit commit =
-        CatalogCommit.builder()
-            .addOperations(
-                IcebergCatalogOperation.builder()
-                    .key(key)
-                    .addUpdates(
-                        assignUUID(UUID.randomUUID().toString()),
-                        upgradeFormatVersion(2),
-                        addSchema(IcebergSchema.builder().build(), 0),
-                        setCurrentSchema(-1),
-                        addPartitionSpec(IcebergPartitionSpec.UNPARTITIONED_SPEC),
-                        setDefaultPartitionSpec(-1),
-                        addSortOrder(IcebergSortOrder.UNSORTED_ORDER),
-                        setDefaultSortOrder(-1))
-                    .addRequirement(assertTableDoesNotExist())
-                    .type(ICEBERG_TABLE)
-                    .build())
-            .build();
+    CatalogCommit commit = CatalogCommit.builder().build();
 
     catalogService.commit(ref, commit).toCompletableFuture().get();
 
     Reference afterCommit = api.getReference().refName("main").get();
-    soft.assertThat(afterCommit).isNotEqualTo(main);
+    soft.assertThat(afterCommit).isEqualTo(main);
+  }
+
+  @Test
+  public void singleTableCreate() throws Exception {
+    Reference main = api.getReference().refName("main").get();
+    ContentKey key = ContentKey.of("mytable");
+
+    ParsedReference committed = commitSingle(main, key);
+
+    Reference afterCommit = api.getReference().refName("main").get();
+    soft.assertThat(afterCommit)
+        .isNotEqualTo(main)
+        .extracting(Reference::getName, Reference::getHash)
+        .containsExactly(committed.name(), committed.hashWithRelativeSpec());
   }
 }


### PR DESCRIPTION
Refactors `CatalogServiceImpl.MultiTableUpdate` to be a top-level type and adds a list of successfully written objects/files in a separate `exceptionally()` stage, that calls `ObjectIO.deleteObjects()` for the written objects/files.

The change is unfortunately quite verbose.

Prerequisite for testing #8889 and #8768 