### PR TITLE
Support using the default application credentials for google client

### DIFF
--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsBucketOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsBucketOptions.java
@@ -93,5 +93,6 @@ public interface GcsBucketOptions {
     USER,
     SERVICE_ACCOUNT,
     ACCESS_TOKEN,
+    APPLICATION_DEFAULT
   }
 }

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsClients.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsClients.java
@@ -23,6 +23,7 @@ import com.google.api.gax.retrying.RetrySettings;
 import com.google.auth.Credentials;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.auth.oauth2.UserCredentials;
@@ -148,7 +149,12 @@ public final class GcsClients {
                 oauth2token.expiresAt().map(i -> new Date(i.toEpochMilli())).orElse(null));
         return OAuth2Credentials.create(accessToken);
       default:
-        throw new IllegalArgumentException("Unsupported auth type " + authType);
+        try {
+          return GoogleCredentials.getApplicationDefault();
+        } catch (IOException e) {
+          throw new IllegalArgumentException("Unsupported auth type " + authType
+            + " and didn't found valid credentials");
+        }
     }
   }
 }

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsClients.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsClients.java
@@ -148,13 +148,14 @@ public final class GcsClients {
                 oauth2token.token(),
                 oauth2token.expiresAt().map(i -> new Date(i.toEpochMilli())).orElse(null));
         return OAuth2Credentials.create(accessToken);
-      default:
+      case APPLICATION_DEFAULT:
         try {
           return GoogleCredentials.getApplicationDefault();
         } catch (IOException e) {
-          throw new IllegalArgumentException("Unsupported auth type " + authType
-            + " and didn't found valid credentials");
+          throw new IllegalArgumentException("Unable to load default credentials", e);
         }
+      default:
+        throw new IllegalArgumentException("Unsupported auth type " + authType);
     }
   }
 }


### PR DESCRIPTION
---

### Motivation

In the kubernetes environment, we more like use workload identity to all a pod to access the google service. Using the default application credentials will scan all possible credentails to access the google service.