### PR TITLE
Catalog/Bug: Fix double-write for S3

### DIFF
--- a/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/AbstractClients.java
+++ b/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/AbstractClients.java
@@ -55,6 +55,10 @@ public abstract class AbstractClients {
 
       try (OutputStream output = objectIO.writeObject(uri)) {
         output.write("hello world".getBytes(UTF_8));
+        // Explicitly close the output stream more than once
+        output.close();
+        //noinspection RedundantExplicitClose
+        output.close();
       }
       String response1;
       try (InputStream input = objectIO.readObject(uri)) {


### PR DESCRIPTION
Writing (metadata) objects to S3 has a bug that makes it write the content twice, actually as often as `.close()` is called on the output stream.

It goes back to an somewhat unexpectable side effect of Jackson, which closes the output-stream when it writes an object (`ObjectMapper.writeValue(OutputStream,Object)` et al).

Thankfully, this "double metadata" doesn't have any negative effect, because OTOH a call like `ObjectMapper.readValue()` returns after the first deserialized object and ignores any following ones.