### PR TITLE
Allow Smallrye config sections to have no properties

### DIFF
--- a/tools/doc-generator/doclet/src/main/java/org/projectnessie/nessie/docgen/DocGenDoclet.java
+++ b/tools/doc-generator/doclet/src/main/java/org/projectnessie/nessie/docgen/DocGenDoclet.java
@@ -139,20 +139,22 @@ public class DocGenDoclet implements Doclet {
         }
 
         List<SmallRyeConfigPropertyInfo> properties = configSection.properties();
-        SmallRyeConfigPropertyInfo first = properties.get(0);
-        if (first.firstIsSectionDoc()) {
+        SmallRyeConfigPropertyInfo first = properties.isEmpty() ? null : properties.get(0);
+        if (first != null && first.firstIsSectionDoc()) {
           MarkdownTypeFormatter typeFormatter =
               new MarkdownTypeFormatter(first.propertyElement(), first.doc());
           writer.println(typeFormatter.description().trim());
           writer.println();
         }
 
-        writer.println("| Property | Default Value | Type | Description |");
-        writer.println("|----------|---------------|------|-------------|");
-        properties.forEach(
-            prop ->
-                writeProperty(
-                    prop, writer, configSection.prefix() + '.', smallryeConfigs, environment));
+        if (!properties.isEmpty()) {
+          writer.println("| Property | Default Value | Type | Description |");
+          writer.println("|----------|---------------|------|-------------|");
+          properties.forEach(
+              prop ->
+                  writeProperty(
+                      prop, writer, configSection.prefix() + '.', smallryeConfigs, environment));
+        }
       } catch (IOException ex) {
         throw new RuntimeException(ex);
       }

--- a/tools/doc-generator/doclet/src/main/java/org/projectnessie/nessie/docgen/SmallryeConfigs.java
+++ b/tools/doc-generator/doclet/src/main/java/org/projectnessie/nessie/docgen/SmallryeConfigs.java
@@ -71,12 +71,10 @@ public class SmallryeConfigs {
 
       additionalPrefixes.forEach(
           (k, v) -> {
-            if (!v.isEmpty()) {
-              if (k.equals(mapping.prefix)) {
-                sections.add(new SmallRyeConfigSection(k, v, mapping.element, mapping.typeComment));
-              } else {
-                sections.add(new SmallRyeConfigSection(mapping.prefix + '.' + k, v, null, null));
-              }
+            if (k.equals(mapping.prefix)) {
+              sections.add(new SmallRyeConfigSection(k, v, mapping.element, mapping.typeComment));
+            } else {
+              sections.add(new SmallRyeConfigSection(mapping.prefix + '.' + k, v, null, null));
             }
           });
     }


### PR DESCRIPTION
This may happen when a config class has all its properties grouped under sub-sections, but we still want to produce `.md` files from the top-level javadoc.

This is a pre-requisite to #8558