### PR TITLE
Fix older-client/server dependency resolution errors

### DIFF
--- a/build-tools-integration-tests/src/test/java/org/projectnessie/buildtools/TestPublishedPoms.java
+++ b/build-tools-integration-tests/src/test/java/org/projectnessie/buildtools/TestPublishedPoms.java
@@ -170,7 +170,13 @@ public class TestPublishedPoms {
       .forEach(
         (k, v) -> {
           String key = k.toString();
-          if (key.startsWith("java.")) {
+          if (key.startsWith("java.")
+              || key.startsWith("file.")
+              || key.startsWith("os.")
+              || key.endsWith(".separator")
+              || key.endsWith(".encoding")
+              || key.startsWith("sun.")
+              || key.startsWith("user.")) {
             session.setSystemProperty(key, v.toString());
           }
         });

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/DependencyResolver.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/DependencyResolver.java
@@ -153,7 +153,13 @@ final class DependencyResolver {
         .forEach(
             (k, v) -> {
               String key = k.toString();
-              if (key.startsWith("java.")) {
+              if (key.startsWith("java.")
+                  || key.startsWith("file.")
+                  || key.startsWith("os.")
+                  || key.endsWith(".separator")
+                  || key.endsWith(".encoding")
+                  || key.startsWith("sun.")
+                  || key.startsWith("user.")) {
                 session.setSystemProperty(key, v.toString());
               }
             });


### PR DESCRIPTION
Maven-resolver now fails to resolve dependencies due to a profile activation error in `org.apache.maven.model.profile.activation.OperatingSystemProfileActivator#isActive` when it tries to resolve the system properties starting with `os.`. This change adds more "standard" system properties.

Fixes CI errors for #9024 and #9025