### PR TITLE
Unify obj-type namespaces

### DIFF
--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraPersist.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraPersist.java
@@ -38,6 +38,7 @@ import static org.projectnessie.versioned.storage.cassandra.CassandraConstants.S
 import static org.projectnessie.versioned.storage.cassandra.CassandraConstants.UPDATE_REFERENCE_POINTER;
 import static org.projectnessie.versioned.storage.cassandra.CassandraSerde.deserializeObjId;
 import static org.projectnessie.versioned.storage.cassandra.CassandraSerde.serializeObjId;
+import static org.projectnessie.versioned.storage.common.persist.ObjTypes.objTypeByName;
 import static org.projectnessie.versioned.storage.serialize.ProtoSerialization.serializePreviousPointers;
 
 import com.datastax.oss.driver.api.core.DriverException;
@@ -69,7 +70,6 @@ import org.projectnessie.versioned.storage.common.persist.CloseableIterator;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 import org.projectnessie.versioned.storage.common.persist.ObjType;
-import org.projectnessie.versioned.storage.common.persist.ObjTypes;
 import org.projectnessie.versioned.storage.common.persist.Persist;
 import org.projectnessie.versioned.storage.common.persist.Reference;
 import org.projectnessie.versioned.storage.common.persist.UpdateableObj;
@@ -254,7 +254,7 @@ public class CassandraPersist implements Persist {
     Row row = backend.execute(stmt).one();
     if (row != null) {
       String objType = requireNonNull(row.getString(0));
-      return ObjTypes.forName(objType);
+      return objTypeByName(objType);
     }
     throw new ObjNotFoundException(id);
   }
@@ -274,7 +274,7 @@ public class CassandraPersist implements Persist {
 
     Function<Row, T> rowMapper =
         row -> {
-          ObjType objType = ObjTypes.forName(requireNonNull(row.getString(COL_OBJ_TYPE.name())));
+          ObjType objType = objTypeByName(requireNonNull(row.getString(COL_OBJ_TYPE.name())));
           if (type != null && !type.equals(objType)) {
             return null;
           }
@@ -505,7 +505,7 @@ public class CassandraPersist implements Persist {
         }
 
         Row row = rs.next();
-        ObjType type = ObjTypes.forName(requireNonNull(row.getString(1)));
+        ObjType type = objTypeByName(requireNonNull(row.getString(1)));
         if (!returnedObjTypes.contains(type)) {
           continue;
         }

--- a/versioned/storage/common-serialize/src/main/java/org/projectnessie/versioned/storage/serialize/ProtoSerialization.java
+++ b/versioned/storage/common-serialize/src/main/java/org/projectnessie/versioned/storage/serialize/ProtoSerialization.java
@@ -26,6 +26,7 @@ import static org.projectnessie.versioned.storage.common.objtypes.RefObj.ref;
 import static org.projectnessie.versioned.storage.common.objtypes.StringObj.stringData;
 import static org.projectnessie.versioned.storage.common.objtypes.TagObj.tag;
 import static org.projectnessie.versioned.storage.common.objtypes.UniqueIdObj.uniqueId;
+import static org.projectnessie.versioned.storage.common.persist.ObjTypes.objTypeByName;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -55,7 +56,6 @@ import org.projectnessie.versioned.storage.common.persist.ImmutableReference;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 import org.projectnessie.versioned.storage.common.persist.ObjType;
-import org.projectnessie.versioned.storage.common.persist.ObjTypes;
 import org.projectnessie.versioned.storage.common.persist.Reference;
 import org.projectnessie.versioned.storage.common.persist.UpdateableObj;
 import org.projectnessie.versioned.storage.common.proto.StorageTypes;
@@ -508,7 +508,7 @@ public final class ProtoSerialization {
   }
 
   private static Obj deserializeCustom(ObjId id, CustomProto custom, String versionToken) {
-    ObjType type = ObjTypes.forShortName(custom.getObjType());
+    ObjType type = objTypeByName(custom.getObjType());
     if (versionToken == null) {
       // versionToken is set when reading objects from the database, but cache-deserialization has
       // the versionToken in the object

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBPersist.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBPersist.java
@@ -21,6 +21,7 @@ import static java.util.Collections.emptyListIterator;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
 import static org.projectnessie.versioned.storage.common.persist.ObjId.objIdFromString;
+import static org.projectnessie.versioned.storage.common.persist.ObjTypes.objTypeByName;
 import static org.projectnessie.versioned.storage.common.persist.Reference.reference;
 import static org.projectnessie.versioned.storage.dynamodb.DynamoDBBackend.condition;
 import static org.projectnessie.versioned.storage.dynamodb.DynamoDBBackend.keyPrefix;
@@ -73,7 +74,6 @@ import org.projectnessie.versioned.storage.common.persist.CloseableIterator;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 import org.projectnessie.versioned.storage.common.persist.ObjType;
-import org.projectnessie.versioned.storage.common.persist.ObjTypes;
 import org.projectnessie.versioned.storage.common.persist.Persist;
 import org.projectnessie.versioned.storage.common.persist.Reference;
 import org.projectnessie.versioned.storage.common.persist.UpdateableObj;
@@ -353,7 +353,7 @@ public class DynamoDBPersist implements Persist {
       throw new ObjNotFoundException(id);
     }
 
-    return ObjTypes.forShortName(item.item().get(COL_OBJ_TYPE).s());
+    return objTypeByName(item.item().get(COL_OBJ_TYPE).s());
   }
 
   @Nonnull
@@ -607,7 +607,7 @@ public class DynamoDBPersist implements Persist {
       Map<String, AttributeValue> item, ObjType t, @SuppressWarnings("unused") Class<T> typeClass) {
     ObjId id = objIdFromString(item.get(KEY_NAME).s().substring(keyPrefix.length()));
     AttributeValue attributeValue = item.get(COL_OBJ_TYPE);
-    ObjType type = ObjTypes.forShortName(attributeValue.s());
+    ObjType type = objTypeByName(attributeValue.s());
     if (t != null && !t.equals(type)) {
       return null;
     }

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned.storage.jdbc;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.joining;
+import static org.projectnessie.versioned.storage.common.persist.ObjTypes.objTypeByName;
 import static org.projectnessie.versioned.storage.common.util.Closing.closeMultiple;
 import static org.projectnessie.versioned.storage.jdbc.JdbcSerde.deserializeObjId;
 import static org.projectnessie.versioned.storage.jdbc.JdbcSerde.serializeObjId;
@@ -73,7 +74,6 @@ import org.projectnessie.versioned.storage.common.persist.CloseableIterator;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 import org.projectnessie.versioned.storage.common.persist.ObjType;
-import org.projectnessie.versioned.storage.common.persist.ObjTypes;
 import org.projectnessie.versioned.storage.common.persist.Persist;
 import org.projectnessie.versioned.storage.common.persist.Reference;
 import org.projectnessie.versioned.storage.common.persist.UpdateableObj;
@@ -341,7 +341,7 @@ abstract class AbstractJdbcPersist implements Persist {
       try (ResultSet rs = ps.executeQuery()) {
         if (rs.next()) {
           String objType = rs.getString(1);
-          return ObjTypes.forName(objType);
+          return objTypeByName(objType);
         }
       }
       throw new ObjNotFoundException(id);
@@ -408,7 +408,7 @@ abstract class AbstractJdbcPersist implements Persist {
     ObjId id = deserializeObjId(rs, COL_OBJ_ID);
     String objType = rs.getString(COL_OBJ_TYPE);
     String versionToken = rs.getString(COL_OBJ_VERS);
-    ObjType type = ObjTypes.forName(objType);
+    ObjType type = objTypeByName(objType);
     ObjSerializer<Obj> serializer = ObjSerializers.forType(type);
     return serializer.deserialize(rs, type, id, versionToken);
   }

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
@@ -26,6 +26,7 @@ import static com.mongodb.client.model.Updates.set;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toList;
+import static org.projectnessie.versioned.storage.common.persist.ObjTypes.objTypeByName;
 import static org.projectnessie.versioned.storage.common.persist.Reference.reference;
 import static org.projectnessie.versioned.storage.mongodb.MongoDBConstants.COL_OBJ_ID;
 import static org.projectnessie.versioned.storage.mongodb.MongoDBConstants.COL_OBJ_TYPE;
@@ -90,7 +91,6 @@ import org.projectnessie.versioned.storage.common.persist.CloseableIterator;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 import org.projectnessie.versioned.storage.common.persist.ObjType;
-import org.projectnessie.versioned.storage.common.persist.ObjTypes;
 import org.projectnessie.versioned.storage.common.persist.Persist;
 import org.projectnessie.versioned.storage.common.persist.Reference;
 import org.projectnessie.versioned.storage.common.persist.UpdateableObj;
@@ -384,7 +384,7 @@ public class MongoDBPersist implements Persist {
       throw new ObjNotFoundException(id);
     }
 
-    return ObjTypes.forShortName(doc.getString(COL_OBJ_TYPE));
+    return objTypeByName(doc.getString(COL_OBJ_TYPE));
   }
 
   @Override
@@ -668,7 +668,7 @@ public class MongoDBPersist implements Persist {
     if (doc == null) {
       return null;
     }
-    ObjType type = ObjTypes.forShortName(doc.getString(COL_OBJ_TYPE));
+    ObjType type = objTypeByName(doc.getString(COL_OBJ_TYPE));
     if (t != null && !t.equals(type)) {
       return null;
     }


### PR DESCRIPTION
Nessie's export/import functionality needs to be enhanced to transfer "generic objects". These are objects that are defined for example in Nessie Catalog or other extensions that use Nessie's persistence framework. `ObjType` has two names: a short name and a (long) name. Unfortunately, we were not that carefuly and some persistence implementations use the short name and some the (long) name. Since export/import should work even if the respective `ObjTypeBundle`s are not in the runtime classpath, both `ObjType` names need to work (think: exporting a repo using short names and importing into repo using (long) names) - export would only have the name from the persistence layer, which can be short or long.

This change unifies both namespaces.