### PR TITLE
Ability to identify related objects for Nessie export

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -92,6 +92,7 @@ dependencies {
     api(project(":nessie-versioned-storage-testextension"))
     api(project(":nessie-versioned-tests"))
     api(project(":nessie-versioned-transfer-proto"))
+    api(project(":nessie-versioned-transfer-related"))
     api(project(":nessie-versioned-transfer"))
 
     // Nessie Data Catalog
@@ -103,6 +104,7 @@ dependencies {
     api(project(":nessie-catalog-service-common"))
     api(project(":nessie-catalog-service-rest"))
     api(project(":nessie-catalog-service-impl"))
+    api(project(":nessie-catalog-service-transfer"))
     api(project(":nessie-catalog-secrets-api"))
 
     if (!isIncludedInNesQuEIT()) {

--- a/catalog/service/common/build.gradle.kts
+++ b/catalog/service/common/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
   implementation(project(":nessie-catalog-model"))
   implementation(project(":nessie-versioned-storage-common"))
   implementation(project(":nessie-tasks-api"))
+  implementation(project(":nessie-catalog-service-transfer"))
 
   compileOnly(project(":nessie-doc-generator-annotations"))
 

--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/EntityObj.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/EntityObj.java
@@ -15,9 +15,8 @@
  */
 package org.projectnessie.catalog.service.objtypes;
 
-import static java.util.Objects.requireNonNull;
+import static org.projectnessie.catalog.service.objtypes.transfer.CatalogObjIds.entityIdForContent;
 import static org.projectnessie.versioned.storage.common.objtypes.CustomObjType.customObjType;
-import static org.projectnessie.versioned.storage.common.persist.ObjIdHasher.objIdHasher;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -49,9 +48,7 @@ public interface EntityObj extends UpdateableObj {
   ObjType OBJ_TYPE = customObjType("catalog-entity", "c-e", EntityObj.class);
 
   static ObjId entityObjIdForContent(Content content) {
-    return objIdHasher("NessieEntity")
-        .hash(requireNonNull(content.getId(), "Nessie Content has no content ID"))
-        .generate();
+    return entityIdForContent(content);
   }
 
   static Builder builder() {

--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/EntitySnapshotObj.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/EntitySnapshotObj.java
@@ -15,8 +15,8 @@
  */
 package org.projectnessie.catalog.service.objtypes;
 
+import static org.projectnessie.catalog.service.objtypes.transfer.CatalogObjIds.snapshotIdForContent;
 import static org.projectnessie.versioned.storage.common.objtypes.CustomObjType.dynamicCaching;
-import static org.projectnessie.versioned.storage.common.persist.ObjIdHasher.objIdHasher;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -25,8 +25,6 @@ import jakarta.annotation.Nullable;
 import org.immutables.value.Value;
 import org.projectnessie.catalog.model.snapshot.NessieEntitySnapshot;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.IcebergTable;
-import org.projectnessie.model.IcebergView;
 import org.projectnessie.model.Namespace;
 import org.projectnessie.nessie.immutables.NessieImmutable;
 import org.projectnessie.nessie.tasks.api.TaskObj;
@@ -69,19 +67,9 @@ public interface EntitySnapshotObj extends TaskObj {
           c -> ObjType.NOT_CACHED);
 
   static ObjId snapshotObjIdForContent(Content content) {
-    if (content instanceof IcebergTable) {
-      IcebergTable icebergTable = (IcebergTable) content;
-      return objIdHasher("ContentSnapshot")
-          .hash(icebergTable.getMetadataLocation())
-          .hash(icebergTable.getSnapshotId())
-          .generate();
-    }
-    if (content instanceof IcebergView) {
-      IcebergView icebergView = (IcebergView) content;
-      return objIdHasher("ContentSnapshot")
-          .hash(icebergView.getMetadataLocation())
-          .hash(icebergView.getVersionId())
-          .generate();
+    ObjId id = snapshotIdForContent(content);
+    if (id != null) {
+      return id;
     }
     if (content instanceof Namespace) {
       throw new IllegalArgumentException("No snapshots for Namespace: " + content);

--- a/catalog/service/transfer/build.gradle.kts
+++ b/catalog/service/transfer/build.gradle.kts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+  id("nessie-conventions-server")
+  id("nessie-jacoco")
+}
+
+publishingHelper { mavenName = "Nessie - Catalog - Transfer Related" }
+
+dependencies {
+  implementation(project(":nessie-model"))
+  implementation(project(":nessie-versioned-storage-common"))
+  implementation(project(":nessie-versioned-transfer-related"))
+
+  compileOnly(platform(libs.jackson.bom))
+  compileOnly("com.fasterxml.jackson.core:jackson-annotations")
+
+  // javax/jakarta
+  compileOnly(libs.jakarta.ws.rs.api)
+  compileOnly(libs.jakarta.enterprise.cdi.api)
+  compileOnly(libs.jakarta.validation.api)
+  compileOnly(libs.findbugs.jsr305)
+
+  compileOnly(libs.errorprone.annotations)
+  compileOnly(libs.microprofile.openapi)
+}

--- a/catalog/service/transfer/src/main/java/org/projectnessie/catalog/service/objtypes/transfer/CatalogObjIds.java
+++ b/catalog/service/transfer/src/main/java/org/projectnessie/catalog/service/objtypes/transfer/CatalogObjIds.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.service.objtypes.transfer;
+
+import static java.util.Objects.requireNonNull;
+import static org.projectnessie.versioned.storage.common.persist.ObjIdHasher.objIdHasher;
+
+import org.projectnessie.model.Content;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.IcebergView;
+import org.projectnessie.versioned.storage.common.persist.ObjId;
+
+public final class CatalogObjIds {
+  private CatalogObjIds() {}
+
+  public static ObjId snapshotIdForContent(Content content) {
+    if (content instanceof IcebergTable) {
+      IcebergTable icebergTable = (IcebergTable) content;
+      return objIdHasher("ContentSnapshot")
+          .hash(icebergTable.getMetadataLocation())
+          .hash(icebergTable.getSnapshotId())
+          .generate();
+    }
+    if (content instanceof IcebergView) {
+      IcebergView icebergView = (IcebergView) content;
+      return objIdHasher("ContentSnapshot")
+          .hash(icebergView.getMetadataLocation())
+          .hash(icebergView.getVersionId())
+          .generate();
+    }
+    return null;
+  }
+
+  public static ObjId entityIdForContent(Content content) {
+    if (content instanceof IcebergTable || content instanceof IcebergView) {
+      return objIdHasher("NessieEntity")
+          .hash(requireNonNull(content.getId(), "Nessie Content has no content ID"))
+          .generate();
+    }
+    return null;
+  }
+}

--- a/catalog/service/transfer/src/main/java/org/projectnessie/catalog/service/objtypes/transfer/CatalogTransferRelated.java
+++ b/catalog/service/transfer/src/main/java/org/projectnessie/catalog/service/objtypes/transfer/CatalogTransferRelated.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.service.objtypes.transfer;
+
+import static java.util.Collections.emptySet;
+
+import java.util.Set;
+import org.projectnessie.model.Content;
+import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.transfer.related.TransferRelatedObjects;
+
+public class CatalogTransferRelated implements TransferRelatedObjects {
+  @Override
+  public Set<ObjId> contentRelatedObjects(Content content) {
+    ObjId entityId = CatalogObjIds.entityIdForContent(content);
+    ObjId snapshotId = CatalogObjIds.snapshotIdForContent(content);
+    if (snapshotId != null && entityId != null) {
+      return Set.of(entityId, snapshotId);
+    }
+    if (snapshotId != null) {
+      return Set.of(snapshotId);
+    }
+    if (entityId != null) {
+      return Set.of(entityId);
+    }
+    return emptySet();
+  }
+}

--- a/catalog/service/transfer/src/main/resources/META-INF/services/org.projectnessie.versioned.transfer.related.TransferRelatedObjects
+++ b/catalog/service/transfer/src/main/resources/META-INF/services/org.projectnessie.versioned.transfer.related.TransferRelatedObjects
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2024 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.projectnessie.catalog.service.objtypes.transfer.CatalogTransferRelated

--- a/gradle/projects.main.properties
+++ b/gradle/projects.main.properties
@@ -79,6 +79,7 @@ nessie-versioned-storage-store=versioned/storage/store
 nessie-versioned-storage-testextension=versioned/storage/testextension
 nessie-versioned-tests=versioned/tests
 nessie-versioned-transfer-proto=versioned/transfer-proto
+nessie-versioned-transfer-related=versioned/transfer-related
 nessie-versioned-transfer=versioned/transfer
 
 # Nessie Data Catalog
@@ -91,4 +92,5 @@ nessie-catalog-model=catalog/model
 nessie-catalog-service-common=catalog/service/common
 nessie-catalog-service-rest=catalog/service/rest
 nessie-catalog-service-impl=catalog/service/impl
+nessie-catalog-service-transfer=catalog/service/transfer
 nessie-catalog-secrets-api=catalog/secrets/api

--- a/tools/server-admin/build.gradle.kts
+++ b/tools/server-admin/build.gradle.kts
@@ -44,6 +44,8 @@ dependencies {
   implementation(project(":nessie-model-quarkus"))
   implementation(project(":nessie-notice"))
 
+  implementation(project(":nessie-catalog-service-transfer"))
+
   implementation(project(":nessie-versioned-storage-store"))
   implementation(project(":nessie-versioned-storage-bigtable"))
   implementation(project(":nessie-versioned-storage-cache"))
@@ -65,9 +67,6 @@ dependencies {
   implementation(enforcedPlatform(libs.quarkus.amazon.services.bom))
   implementation("io.quarkus:quarkus-picocli")
 
-  compileOnly(libs.jakarta.annotation.api)
-  compileOnly(libs.microprofile.openapi)
-
   implementation(platform(libs.jackson.bom))
   implementation("com.fasterxml.jackson.core:jackson-databind")
   implementation("com.fasterxml.jackson.core:jackson-annotations")
@@ -75,6 +74,10 @@ dependencies {
   implementation(libs.agroal.pool)
   implementation(libs.h2)
   implementation(libs.postgresql)
+
+  compileOnly(libs.jakarta.annotation.api)
+  compileOnly(libs.microprofile.openapi)
+  compileOnly("com.fasterxml.jackson.core:jackson-annotations")
 
   compileOnly(libs.immutables.builder)
   compileOnly(libs.immutables.value.annotations)

--- a/versioned/transfer-related/build.gradle.kts
+++ b/versioned/transfer-related/build.gradle.kts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+  id("nessie-conventions-server")
+  id("nessie-jacoco")
+}
+
+publishingHelper { mavenName = "Nessie - Import/Export - Related Objects" }
+
+dependencies {
+  implementation(project(":nessie-model"))
+  implementation(project(":nessie-versioned-storage-common"))
+
+  compileOnly(libs.microprofile.openapi)
+  compileOnly(libs.errorprone.annotations)
+
+  compileOnly(libs.jakarta.validation.api)
+  compileOnly(libs.jakarta.annotation.api)
+}

--- a/versioned/transfer-related/src/main/java/org/projectnessie/versioned/transfer/related/TransferRelatedObjects.java
+++ b/versioned/transfer-related/src/main/java/org/projectnessie/versioned/transfer/related/TransferRelatedObjects.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.transfer.related;
+
+import static java.util.Collections.emptySet;
+
+import java.util.Set;
+import org.projectnessie.model.Content;
+import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
+import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.Reference;
+
+/**
+ * Implementations identify object IDs that are needed for a complete export by providing {@link
+ * ObjId}s for the repository, for {@link CommitObj}s, for {@link Content}s and {@link Reference}s.
+ *
+ * <p>The {@link ObjId}s returned by these functions do not need to point to existing objects. In
+ * other words: it is fine to return IDs that do not exist.
+ */
+public interface TransferRelatedObjects {
+  default Set<ObjId> repositoryRelatedObjects() {
+    return emptySet();
+  }
+
+  default Set<ObjId> commitRelatedObjects(CommitObj content) {
+    return emptySet();
+  }
+
+  default Set<ObjId> contentRelatedObjects(Content content) {
+    return emptySet();
+  }
+
+  default Set<ObjId> referenceRelatedObjects(Reference reference) {
+    return emptySet();
+  }
+}

--- a/versioned/transfer/build.gradle.kts
+++ b/versioned/transfer/build.gradle.kts
@@ -27,9 +27,11 @@ dependencies {
   implementation(project(":nessie-model"))
   implementation(project(":nessie-versioned-spi"))
   implementation(project(":nessie-versioned-transfer-proto"))
+  implementation(project(":nessie-versioned-transfer-related"))
   implementation(project(":nessie-versioned-storage-batching"))
   implementation(project(":nessie-versioned-storage-common"))
   implementation(project(":nessie-versioned-storage-store"))
+  runtimeOnly(project(":nessie-catalog-service-transfer"))
 
   implementation(platform(libs.jackson.bom))
   implementation("com.fasterxml.jackson.core:jackson-databind")

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/CoreTransferRelatedObjects.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/CoreTransferRelatedObjects.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.transfer;
+
+import static java.util.Collections.singleton;
+import static org.projectnessie.versioned.storage.common.objtypes.UniqueIdObj.uniqueId;
+
+import java.util.Set;
+import java.util.UUID;
+import org.projectnessie.model.Content;
+import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.transfer.related.TransferRelatedObjects;
+
+public class CoreTransferRelatedObjects implements TransferRelatedObjects {
+  @Override
+  public Set<ObjId> contentRelatedObjects(Content content) {
+    String cid = content.getId();
+    if (cid == null) {
+      return null;
+    }
+    UUID contentId;
+    try {
+      contentId = UUID.fromString(cid);
+    } catch (Exception e) {
+      return null;
+    }
+    return singleton(uniqueId("content-id", contentId).id());
+  }
+}

--- a/versioned/transfer/src/main/resources/META-INF/services/org.projectnessie.versioned.transfer.related.TransferRelatedObjects
+++ b/versioned/transfer/src/main/resources/META-INF/services/org.projectnessie.versioned.transfer.related.TransferRelatedObjects
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2024 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.projectnessie.versioned.transfer.CoreTransferRelatedObjects


### PR DESCRIPTION
Nessie export needs to be able to identify which objects are related to the repository, references, commits and contents that are being exported.

This service-loader based functionality allows Nessie export to identify those objects. Each relevant module provides an implementation of the `TransferRelatedObjects` interface, ideally in an artifact that has no "superfluous" dependencies, so only the code that is required to compute the `ObjId`s. This change includes two implementations of `TransferRelatedObjects`, one to provide the `ObjId` of the `UniqueIdObj` for each `Content` and one for Nessie Catalog.