### PR TITLE
Fix behavior of metadata-update/set-statistics + set-partition-statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ as necessary. Empty sections will not end in the release notes.
 - Fix potential class-loader deadlock via `Namespace.EMPTY`
 - Catalog: Fix double write of metadata objects to S3
 - GC/ADLS: Handle `BlobNotFound` as well
+- Fix behavior of metadata-update/set-statistics + set-partition-statistics
 
 ### Commits
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergMetadataUpdate.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergMetadataUpdate.java
@@ -17,6 +17,7 @@ package org.projectnessie.catalog.formats.iceberg.rest;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
 import static org.projectnessie.catalog.formats.iceberg.nessie.NessieModelIceberg.icebergStatisticsFileToNessie;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
@@ -234,7 +235,7 @@ public interface IcebergMetadataUpdate {
     default void applyToTable(IcebergTableMetadataUpdateState state) {
       long snapshotId = Objects.requireNonNull(state.snapshot().icebergSnapshotId());
       if (snapshotId == snapshotId()) {
-        state.builder().addStatisticsFile(icebergStatisticsFileToNessie(statistics()));
+        state.builder().statisticsFiles(singleton(icebergStatisticsFileToNessie(statistics())));
       }
     }
   }
@@ -270,8 +271,10 @@ public interface IcebergMetadataUpdate {
       if (snapshotId == partitionStatistics().snapshotId()) {
         state
             .builder()
-            .addPartitionStatisticsFile(
-                NessieModelIceberg.icebergPartitionStatisticsFileToNessie(partitionStatistics()));
+            .partitionStatisticsFiles(
+                singleton(
+                    NessieModelIceberg.icebergPartitionStatisticsFileToNessie(
+                        partitionStatistics())));
       }
     }
   }


### PR DESCRIPTION
`o.p.catalog.formats.iceberg.rest.IcebergMetadataUpdate.SetStatistics` wrongly _adds_ the given statistics file, but should instead _set_ it as the only one, which is the behavior of `org.apache.iceberg.MetadataUpdate.SetStatistics`. Similarly for `SetPartitionStatistics`.

Fixes #9044