### PR TITLE
Refactor Nessie HTTP compatibility filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ as necessary. Empty sections will not end in the release notes.
 - Catalog: Fix double write of metadata objects to S3
 - GC/ADLS: Handle `BlobNotFound` as well
 - Fix behavior of metadata-update/set-statistics + set-partition-statistics
+- Fix duplicate OAuth interactive flows when the Nessie API compatibilty filter is enabled
 
 ### Commits
 

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClient.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClient.java
@@ -53,8 +53,6 @@ public interface HttpClient extends AutoCloseable {
   void close();
 
   interface Builder {
-    Builder copy();
-
     @SuppressWarnings("unused")
     @CanIgnoreReturnValue
     Builder setClientSpec(int clientSpec);
@@ -119,12 +117,6 @@ public interface HttpClient extends AutoCloseable {
      */
     @CanIgnoreReturnValue
     Builder addResponseFilter(ResponseFilter filter);
-
-    @CanIgnoreReturnValue
-    Builder clearRequestFilters();
-
-    @CanIgnoreReturnValue
-    Builder clearResponseFilters();
 
     /**
      * Add tracing to the client. This will load the opentracing libraries. It is not possible to

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
@@ -97,12 +97,6 @@ final class HttpClientBuilderImpl implements HttpClient.Builder {
     this.cancellationFuture = other.cancellationFuture;
   }
 
-  /** Creates a (shallow) copy of this builder. */
-  @Override
-  public HttpClient.Builder copy() {
-    return new HttpClientBuilderImpl(this);
-  }
-
   @CanIgnoreReturnValue
   public HttpClient.Builder setClientSpec(int clientSpec) {
     this.clientSpec = clientSpec;

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibilityFilter.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibilityFilter.java
@@ -28,22 +28,24 @@ public class NessieApiCompatibilityFilter implements RequestFilter {
   private static final String MAX_API_VERSION = "maxSupportedApiVersion";
   private static final String ACTUAL_API_VERSION = "actualApiVersion";
 
-  private HttpClient.Builder builder;
   private final int clientApiVersion;
   private final AtomicBoolean checkDone = new AtomicBoolean(false);
 
-  NessieApiCompatibilityFilter(HttpClient.Builder builder, int clientApiVersion) {
-    this.builder = builder.copy().clearRequestFilters().clearResponseFilters();
+  private volatile HttpClient httpClient;
+
+  NessieApiCompatibilityFilter(int clientApiVersion) {
     this.clientApiVersion = clientApiVersion;
+  }
+
+  void setHttpClient(HttpClient httpClient) {
+    this.httpClient = httpClient;
   }
 
   @Override
   public void filter(RequestContext context) {
-    if (checkDone.compareAndSet(false, true)) {
-      try (HttpClient httpClient = builder.build()) {
+    if (httpClient != null) {
+      if (checkDone.compareAndSet(false, true)) {
         check(clientApiVersion, httpClient);
-      } finally {
-        builder = null;
       }
     }
   }

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibilityFilter.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibilityFilter.java
@@ -31,7 +31,7 @@ public class NessieApiCompatibilityFilter implements RequestFilter {
   private final int clientApiVersion;
   private final AtomicBoolean checkDone = new AtomicBoolean(false);
 
-  private volatile HttpClient httpClient;
+  private HttpClient httpClient;
 
   NessieApiCompatibilityFilter(int clientApiVersion) {
     this.clientApiVersion = clientApiVersion;

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClientBuilderImpl.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClientBuilderImpl.java
@@ -269,21 +269,30 @@ public class NessieHttpClientBuilderImpl
       builder.addTracing();
     }
 
+    NessieApiCompatibilityFilter nessieApiCompatibilityFilter = null;
     if (apiVersion.isAssignableFrom(HttpApiV1.class)) {
       if (enableApiCompatibilityCheck) {
-        builder.addRequestFilter(new NessieApiCompatibilityFilter(builder, 1));
+        nessieApiCompatibilityFilter = new NessieApiCompatibilityFilter(1);
+        builder.addRequestFilter(nessieApiCompatibilityFilter);
       }
       builder.setJsonView(Views.V1.class);
       HttpClient httpClient = HttpClients.buildClient(tracing, builder);
+      if (nessieApiCompatibilityFilter != null) {
+        nessieApiCompatibilityFilter.setHttpClient(httpClient);
+      }
       return apiVersion.cast(new HttpApiV1(new RestV1Client(httpClient)));
     }
 
     if (apiVersion.isAssignableFrom(HttpApiV2.class)) {
       if (enableApiCompatibilityCheck) {
-        builder.addRequestFilter(new NessieApiCompatibilityFilter(builder, 2));
+        nessieApiCompatibilityFilter = new NessieApiCompatibilityFilter(2);
+        builder.addRequestFilter(nessieApiCompatibilityFilter);
       }
       builder.setJsonView(Views.V2.class);
       HttpClient httpClient = HttpClients.buildClient(tracing, builder);
+      if (nessieApiCompatibilityFilter != null) {
+        nessieApiCompatibilityFilter.setHttpClient(httpClient);
+      }
       return apiVersion.cast(new HttpApiV2(httpClient));
     }
 

--- a/api/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
@@ -185,8 +185,6 @@ public class TestHttpClientBuilder {
         HttpClient.builder()
             .setSslNoCertificateVerification(true)
             .setObjectMapper(new ObjectMapper());
-    assertThatCode(() -> builder1.copy().build().close()).doesNotThrowAnyException();
-    assertThatCode(() -> builder1.copy().build().close()).doesNotThrowAnyException();
     assertThatCode(() -> builder1.build().close()).doesNotThrowAnyException();
   }
 
@@ -199,10 +197,6 @@ public class TestHttpClientBuilder {
             .setObjectMapper(new ObjectMapper());
     assertThatIllegalArgumentException()
         .isThrownBy(() -> builder1.build().close())
-        .withMessage(
-            "Cannot construct Http client, must not combine nessie.ssl.no-certificate-verification and an explicitly configured SSLContext");
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> builder1.copy().build().close())
         .withMessage(
             "Cannot construct Http client, must not combine nessie.ssl.no-certificate-verification and an explicitly configured SSLContext");
   }


### PR DESCRIPTION
The `NessieApiCompatibilityFilter` creates its own `HttpClient` instance to perform the API compatibility check. This currently leads to _duplicate_ authentication attempts.

I did not really investigate why this worked in the past and now fails, but instead focused on getting rid of the duplicated Nessie `HttpClient`.

This change removes the builder-copy code and but instead injects the `HttpClient` into the `NessieApiCompatibilityFilter` once it has been produced.

Reference logs with errornous behavior:

Nessie CLI log, successfully authenticated for the first "request":
```
2024-07-09 18:53:34,934 [nessie-oauth2-client-GFiw-token-refresh-1] DEBUG o.p.c.a.o.OAuth2TokenRefreshExecutor - [nessie-oauth2-client-GFiw] Starting new OAuth2 token refresh thread
2024-07-09 18:53:34,934 [nessie-oauth2-client-GFiw-token-refresh-1] DEBUG o.p.client.auth.oauth2.OAuth2Client - [nessie-oauth2-client-GFiw] Fetching new tokens using AUTHORIZATION_CODE
2024-07-09 18:53:34,942 [nessie-oauth2-client-GFiw-token-refresh-1] DEBUG o.p.c.http.impl.jdk11.JavaRequest - Sending GET request to http://127.0.0.1:8080/realms/iceberg/.well-known/openid-configuration ...
2024-07-09 18:53:34,969 [nessie-oauth2-client-GFiw-token-refresh-1] DEBUG o.p.c.a.oauth2.AuthorizationCodeFlow - Authorization Code Flow: started, redirect URI: http://localhost:53180/nessie-client/auth

[nessie-oauth2-client] ======= Nessie authentication required =======
[nessie-oauth2-client] Browse to the following URL to continue:
[nessie-oauth2-client] http://127.0.0.1:8080/realms/iceberg/protocol/openid-connect/auth?response_type=code&client_id=client1&redirect_uri=http%3A%2F%2Flocalhost%3A53180%2Fnessie-client%2Fauth&state=KZpUfOr9RCn2zuJj

2024-07-09 18:53:42,876 [HTTP-Dispatcher] DEBUG o.p.c.a.oauth2.AuthorizationCodeFlow - Authorization Code Flow: received request
2024-07-09 18:53:42,877 [HTTP-Dispatcher] DEBUG o.p.c.a.oauth2.AuthorizationCodeFlow - Authorization Code Flow: extracting code
2024-07-09 18:53:42,878 [HTTP-Dispatcher] DEBUG o.p.c.a.oauth2.AuthorizationCodeFlow - Authorization Code Flow: fetching new tokens
2024-07-09 18:53:42,882 [HTTP-Dispatcher] DEBUG o.p.c.http.impl.jdk11.JavaRequest - Sending POST request to http://127.0.0.1:8080/realms/iceberg/protocol/openid-connect/token ...
2024-07-09 18:53:42,956 [HTTP-Dispatcher] DEBUG o.p.c.a.oauth2.AuthorizationCodeFlow - Authorization Code Flow: new tokens received
2024-07-09 18:53:42,956 [HTTP-Dispatcher] DEBUG o.p.c.a.oauth2.AuthorizationCodeFlow - Authorization Code Flow: tokens received
2024-07-09 18:53:42,956 [HTTP-Dispatcher] DEBUG o.p.c.a.oauth2.AuthorizationCodeFlow - Authorization Code Flow: sending response, error: none
2024-07-09 18:53:42,968 [nessie-oauth2-client-GFiw-token-refresh-1] DEBUG o.p.c.a.oauth2.AuthorizationCodeFlow - Authorization Code Flow: closing
2024-07-09 18:53:42,969 [nessie-oauth2-client-GFiw-token-refresh-1] DEBUG o.p.client.auth.oauth2.OAuth2Client - [nessie-oauth2-client-GFiw] Successfully fetched new tokens
2024-07-09 18:53:42,969 [nessie-oauth2-client-GFiw-token-refresh-1] DEBUG o.p.client.auth.oauth2.OAuth2Client - [nessie-oauth2-client-GFiw] Scheduling token refresh in PT59M48.986275S
2024-07-09 18:53:42,970 [main] DEBUG o.p.c.http.impl.jdk11.JavaRequest - Sending GET request to http://127.0.0.1:19120/api/v2/config ...
2024-07-09 18:53:42,981 [main] DEBUG o.p.client.auth.oauth2.OAuth2Client - [nessie-oauth2-client-GFiw] Closing...
2024-07-09 18:53:42,982 [nessie-oauth2-client-GFiw-token-refresh-1] DEBUG o.p.c.a.o.OAuth2TokenRefreshExecutor - [nessie-oauth2-client-GFiw] OAuth2 token refresh thread exiting
2024-07-09 18:53:42,982 [main] DEBUG o.p.client.auth.oauth2.OAuth2Client - [nessie-oauth2-client-GFiw] Closed
2024-07-09 18:53:42,982 [nessie-oauth2-client-EM75-token-refresh-1] DEBUG o.p.c.a.o.OAuth2TokenRefreshExecutor - [nessie-oauth2-client-EM75] Starting new OAuth2 token refresh thread
2024-07-09 18:53:42,982 [nessie-oauth2-client-EM75-token-refresh-1] DEBUG o.p.client.auth.oauth2.OAuth2Client - [nessie-oauth2-client-EM75] Fetching new tokens using AUTHORIZATION_CODE
2024-07-09 18:53:42,983 [nessie-oauth2-client-EM75-token-refresh-1] DEBUG o.p.c.http.impl.jdk11.JavaRequest - Sending GET request to http://127.0.0.1:8080/realms/iceberg/.well-known/openid-configuration ...
2024-07-09 18:53:42,986 [nessie-oauth2-client-EM75-token-refresh-1] DEBUG o.p.c.a.oauth2.AuthorizationCodeFlow - Authorization Code Flow: started, redirect URI: http://localhost:53190/nessie-client/auth

[nessie-oauth2-client] ======= Nessie authentication required =======
[nessie-oauth2-client] Browse to the following URL to continue:
[nessie-oauth2-client] http://127.0.0.1:8080/realms/iceberg/protocol/openid-connect/auth?response_type=code&client_id=client1&redirect_uri=http%3A%2F%2Flocalhost%3A53190%2Fnessie-client%2Fauth&state=VnLlQkfeGB13BYTy
```

Similar behavior like above, when aborting the authentication with ctrl-C.

Without the compatiblity filter, everything works fine:

```
2024-07-09 18:56:40,937 [nessie-oauth2-client-5Zce-token-refresh-1] DEBUG o.p.c.a.o.OAuth2TokenRefreshExecutor - [nessie-oauth2-client-5Zce] Starting new OAuth2 token refresh thread
2024-07-09 18:56:40,937 [nessie-oauth2-client-5Zce-token-refresh-1] DEBUG o.p.client.auth.oauth2.OAuth2Client - [nessie-oauth2-client-5Zce] Fetching new tokens using AUTHORIZATION_CODE
2024-07-09 18:56:40,944 [nessie-oauth2-client-5Zce-token-refresh-1] DEBUG o.p.c.http.impl.jdk11.JavaRequest - Sending GET request to http://127.0.0.1:8080/realms/iceberg/.well-known/openid-configuration ...
2024-07-09 18:56:40,973 [nessie-oauth2-client-5Zce-token-refresh-1] DEBUG o.p.c.a.oauth2.AuthorizationCodeFlow - Authorization Code Flow: started, redirect URI: http://localhost:53321/nessie-client/auth

[nessie-oauth2-client] ======= Nessie authentication required =======
[nessie-oauth2-client] Browse to the following URL to continue:
[nessie-oauth2-client] http://127.0.0.1:8080/realms/iceberg/protocol/openid-connect/auth?response_type=code&client_id=client1&redirect_uri=http%3A%2F%2Flocalhost%3A53321%2Fnessie-client%2Fauth&state=GYFz388wiFa1LxUF

2024-07-09 18:56:48,564 [HTTP-Dispatcher] DEBUG o.p.c.a.oauth2.AuthorizationCodeFlow - Authorization Code Flow: received request
2024-07-09 18:56:48,564 [HTTP-Dispatcher] DEBUG o.p.c.a.oauth2.AuthorizationCodeFlow - Authorization Code Flow: extracting code
2024-07-09 18:56:48,564 [HTTP-Dispatcher] DEBUG o.p.c.a.oauth2.AuthorizationCodeFlow - Authorization Code Flow: fetching new tokens
2024-07-09 18:56:48,568 [HTTP-Dispatcher] DEBUG o.p.c.http.impl.jdk11.JavaRequest - Sending POST request to http://127.0.0.1:8080/realms/iceberg/protocol/openid-connect/token ...
2024-07-09 18:56:48,647 [HTTP-Dispatcher] DEBUG o.p.c.a.oauth2.AuthorizationCodeFlow - Authorization Code Flow: new tokens received
2024-07-09 18:56:48,647 [HTTP-Dispatcher] DEBUG o.p.c.a.oauth2.AuthorizationCodeFlow - Authorization Code Flow: tokens received
2024-07-09 18:56:48,647 [HTTP-Dispatcher] DEBUG o.p.c.a.oauth2.AuthorizationCodeFlow - Authorization Code Flow: sending response, error: none
2024-07-09 18:56:48,658 [nessie-oauth2-client-5Zce-token-refresh-1] DEBUG o.p.c.a.oauth2.AuthorizationCodeFlow - Authorization Code Flow: closing
2024-07-09 18:56:48,659 [nessie-oauth2-client-5Zce-token-refresh-1] DEBUG o.p.client.auth.oauth2.OAuth2Client - [nessie-oauth2-client-5Zce] Successfully fetched new tokens
2024-07-09 18:56:48,659 [nessie-oauth2-client-5Zce-token-refresh-1] DEBUG o.p.client.auth.oauth2.OAuth2Client - [nessie-oauth2-client-5Zce] Scheduling token refresh in PT59M49.98752S
2024-07-09 18:56:48,659 [main] DEBUG o.p.c.http.impl.jdk11.JavaRequest - Sending GET request to http://127.0.0.1:19120/api/v2/config ...
2024-07-09 18:56:48,685 [main] DEBUG o.p.c.http.impl.jdk11.JavaRequest - Sending GET request to http://127.0.0.1:19120/api/v2/trees/- ...
Successfully connected to Nessie REST at http://127.0.0.1:19120/api/v2 - Nessie API version 2, spec version 2.1.0
main>
```