### PR TITLE
HTTP client: remove hard-coded behavior for status >= 400

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ResponseFilter.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ResponseFilter.java
@@ -17,7 +17,6 @@ package org.projectnessie.client.auth.oauth2;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import org.projectnessie.client.http.HttpClientException;
 import org.projectnessie.client.http.HttpClientResponseException;
@@ -43,9 +42,9 @@ class OAuth2ResponseFilter implements ResponseFilter {
       if (status != Status.OK && status != Status.FOUND) {
         String body = null;
         IOException decodeError = null;
-        InputStream errorStream = responseContext.getErrorStream();
-        if (errorStream != null) {
-          try (CapturingInputStream capturing = new CapturingInputStream(errorStream)) {
+        if (responseContext.getInputStream() != null) {
+          try (CapturingInputStream capturing =
+              new CapturingInputStream(responseContext.getInputStream())) {
             if (responseContext.isJsonCompatibleResponse()) {
               try {
                 ErrorResponse errorResponse =

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibilityFilter.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibilityFilter.java
@@ -61,8 +61,14 @@ public class NessieApiCompatibilityFilter implements RequestFilter {
       throws NessieApiCompatibilityException {
     JsonNode config;
     try {
-      config =
-          httpClient.newRequest().bypassFilters().path("config").get().readEntity(JsonNode.class);
+      HttpResponse response = httpClient.newRequest().bypassFilters().path("config").get();
+      if (response.getStatus() != Status.OK) {
+        LOGGER.warn(
+            "API compatibility check: config endpoint replied with status {}, proceeding without check",
+            response.getStatus());
+        return;
+      }
+      config = response.readEntity(JsonNode.class);
     } catch (HttpClientException e) {
       LOGGER.warn(
           "API compatibility check: failed to contact config endpoint, proceeding without check: {}",

--- a/api/client/src/main/java/org/projectnessie/client/http/ResponseContext.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/ResponseContext.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.client.http;
 
+import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -25,9 +26,14 @@ public interface ResponseContext {
   /** Get the status of the response. */
   Status getStatus();
 
+  /**
+   * Get the input stream for the response. Returns null if the response did not contain any
+   * readable entity.
+   *
+   * @implSpec Calling this method multiple times should return the same input stream.
+   */
+  @Nullable
   InputStream getInputStream() throws IOException;
-
-  InputStream getErrorStream() throws IOException;
 
   default boolean isJsonCompatibleResponse() {
     String contentType = getContentType();

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/BaseHttpRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/BaseHttpRequest.java
@@ -44,12 +44,10 @@ import org.projectnessie.client.http.HttpAuthentication;
 import org.projectnessie.client.http.HttpClient.Method;
 import org.projectnessie.client.http.HttpClientException;
 import org.projectnessie.client.http.HttpClientReadTimeoutException;
-import org.projectnessie.client.http.HttpClientResponseException;
 import org.projectnessie.client.http.HttpRequest;
 import org.projectnessie.client.http.HttpResponse;
 import org.projectnessie.client.http.RequestContext;
 import org.projectnessie.client.http.ResponseContext;
-import org.projectnessie.client.http.Status;
 
 public abstract class BaseHttpRequest extends HttpRequest {
 
@@ -70,7 +68,6 @@ public abstract class BaseHttpRequest extends HttpRequest {
       prepareRequest(requestContext);
       responseContext = processResponse(uri, method, body, requestContext);
       processResponseFilters(responseContext);
-      mimicUrlConnectionBehavior(method, responseContext, uri);
       return config.responseFactory().make(responseContext, config.getMapper());
     } catch (RuntimeException e) {
       error = e;
@@ -145,20 +142,6 @@ public abstract class BaseHttpRequest extends HttpRequest {
   protected void processResponseFilters(ResponseContext responseContext) {
     if (!bypassFilters) {
       config.getResponseFilters().forEach(responseFilter -> responseFilter.filter(responseContext));
-    }
-  }
-
-  /**
-   * This mimics the (weird) behavior of java.net.HttpURLConnection.getResponseCode() that throws an
-   * IOException for some status codes.
-   */
-  protected void mimicUrlConnectionBehavior(
-      Method method, ResponseContext responseContext, URI uri) {
-    Status status = responseContext.getStatus();
-    if (status.getCode() >= 400) {
-      throw new HttpClientResponseException(
-          String.format("%s request to %s failed with HTTP/%d", method, uri, status.getCode()),
-          status);
     }
   }
 

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaResponseContext.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaResponseContext.java
@@ -42,15 +42,10 @@ final class JavaResponseContext implements ResponseContext {
   private static final Logger LOGGER = LoggerFactory.getLogger(JavaResponseContext.class);
 
   private final HttpResponse<InputStream> response;
-  private final InputStream inputStream;
+  private InputStream inputStream;
 
   JavaResponseContext(HttpResponse<InputStream> response) {
     this.response = response;
-    try {
-      this.inputStream = maybeDecompress();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   @Override
@@ -59,12 +54,10 @@ final class JavaResponseContext implements ResponseContext {
   }
 
   @Override
-  public InputStream getInputStream() {
-    return inputStream;
-  }
-
-  @Override
-  public InputStream getErrorStream() {
+  public InputStream getInputStream() throws IOException {
+    if (inputStream == null) {
+      inputStream = maybeDecompress();
+    }
     return inputStream;
   }
 

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk8/UrlConnectionRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk8/UrlConnectionRequest.java
@@ -22,8 +22,6 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import javax.net.ssl.HttpsURLConnection;
 import org.projectnessie.client.http.HttpClient.Method;
-import org.projectnessie.client.http.HttpClientException;
-import org.projectnessie.client.http.HttpResponse;
 import org.projectnessie.client.http.RequestContext;
 import org.projectnessie.client.http.ResponseContext;
 import org.projectnessie.client.http.Status;
@@ -55,27 +53,7 @@ final class UrlConnectionRequest extends BaseHttpRequest {
       writeToOutputStream(requestContext, con.getOutputStream());
     }
     con.connect();
-    int code = con.getResponseCode(); // call to ensure http request is complete
-    return new UrlConnectionResponseContext(con, uri, Status.fromCode(code));
-  }
-
-  @Override
-  public HttpResponse get() throws HttpClientException {
-    return executeRequest(Method.GET, null);
-  }
-
-  @Override
-  public HttpResponse delete() throws HttpClientException {
-    return executeRequest(Method.DELETE, null);
-  }
-
-  @Override
-  public HttpResponse post(Object obj) throws HttpClientException {
-    return executeRequest(Method.POST, obj);
-  }
-
-  @Override
-  public HttpResponse put(Object obj) throws HttpClientException {
-    return executeRequest(Method.PUT, obj);
+    Status status = Status.fromCode(con.getResponseCode());
+    return new UrlConnectionResponseContext(con, uri, status);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk8/UrlConnectionResponseContext.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk8/UrlConnectionResponseContext.java
@@ -34,6 +34,7 @@ final class UrlConnectionResponseContext implements ResponseContext {
   private final HttpURLConnection connection;
   private final URI uri;
   private final Status status;
+  private InputStream inputStream;
 
   UrlConnectionResponseContext(HttpURLConnection connection, URI uri, Status status) {
     this.connection = connection;
@@ -48,12 +49,12 @@ final class UrlConnectionResponseContext implements ResponseContext {
 
   @Override
   public InputStream getInputStream() throws IOException {
-    return maybeDecompress(connection.getInputStream());
-  }
-
-  @Override
-  public InputStream getErrorStream() throws IOException {
-    return maybeDecompress(connection.getErrorStream());
+    if (inputStream == null) {
+      InputStream base =
+          status.getCode() >= 400 ? connection.getErrorStream() : connection.getInputStream();
+      inputStream = maybeDecompress(base);
+    }
+    return inputStream;
   }
 
   @Override

--- a/api/client/src/main/java/org/projectnessie/client/rest/ResponseCheckFilter.java
+++ b/api/client/src/main/java/org/projectnessie/client/rest/ResponseCheckFilter.java
@@ -55,7 +55,7 @@ public class ResponseCheckFilter {
 
     // this could IOException, in which case the error will be passed up to the client as an
     // HttpClientException
-    try (InputStream is = con.getErrorStream()) {
+    try (InputStream is = con.getInputStream()) {
       error = decodeErrorObject(status, is, MAPPER.reader());
     }
 
@@ -127,8 +127,7 @@ public class ResponseCheckFilter {
                 .message(
                     cap.isEmpty()
                         ? "got empty response body from server"
-                        : ("Could not parse error object in response beginning with: "
-                            + capturing.captured()))
+                        : ("Could not parse error object in response beginning with: " + cap))
                 .status(status.getCode())
                 .reason(status.getReason())
                 .clientProcessingError(e.toString())

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ResponseFilter.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ResponseFilter.java
@@ -61,11 +61,6 @@ class TestOAuth2ResponseFilter {
           }
 
           @Override
-          public InputStream getErrorStream() {
-            return getInputStream();
-          }
-
-          @Override
           public String getContentType() {
             return json ? "application/json" : "text/plain";
           }

--- a/api/client/src/test/java/org/projectnessie/client/http/BaseTestHttpClient.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/BaseTestHttpClient.java
@@ -63,7 +63,10 @@ import javax.net.ssl.SSLHandshakeException;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -74,10 +77,61 @@ import org.projectnessie.client.util.HttpTestServer;
 import org.projectnessie.model.CommitMeta;
 
 @ExtendWith(SoftAssertionsExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class BaseTestHttpClient {
 
   protected static final ObjectMapper MAPPER = new ObjectMapper();
   protected static final Instant NOW = Instant.now();
+
+  protected final AtomicReference<HttpTestServer.RequestHandler> handler = new AtomicReference<>();
+  protected final AtomicReference<ResponseContext> responseContext = new AtomicReference<>();
+
+  protected HttpTestServer httpServer;
+  protected HttpTestServer httpsServer;
+
+  protected HttpClient client;
+
+  @BeforeAll
+  void startHttpServer() throws Exception {
+    httpServer =
+        new HttpTestServer(
+            "/a/b",
+            (req, resp) -> {
+              handler.get().handle(req, resp);
+            });
+    client = createClient(httpServer.getUri(), b -> b.addResponseFilter(responseContext::set));
+  }
+
+  @BeforeAll
+  void startHttpsServer() throws Exception {
+    httpsServer =
+        new HttpTestServer(
+            "/a/b",
+            (req, resp) -> {
+              handler.get().handle(req, resp);
+            },
+            true);
+  }
+
+  @AfterAll
+  void stopHttpServer() {
+    try {
+      if (client != null) {
+        client.close();
+      }
+    } finally {
+      if (httpServer != null) {
+        httpServer.close();
+      }
+    }
+  }
+
+  @AfterAll
+  void stopHttpsServer() {
+    if (httpsServer != null) {
+      httpsServer.close();
+    }
+  }
 
   @InjectSoftAssertions protected SoftAssertions soft;
 
@@ -106,11 +160,11 @@ public abstract class BaseTestHttpClient {
     "SSL_UNVERIFIED, false",
     "SSL_UNVERIFIED, true"
   })
-  void testHttpCombinations(SSLMode ssl, boolean http2) throws Exception {
+  void testHttpCombinations(SSLMode ssl, boolean http2) {
     // Old URLConnection based client cannot handle HTTP/2
     assumeThat(!http2 || supportsHttp2()).isTrue();
 
-    HttpTestServer.RequestHandler handler =
+    handler.set(
         (req, resp) -> {
           ObjectNode r = new ObjectNode(JsonNodeFactory.instance);
           r.put("secure", req.isSecure());
@@ -122,26 +176,28 @@ public abstract class BaseTestHttpClient {
           try (OutputStream os = resp.getOutputStream()) {
             MAPPER.writeValue(os, r);
           }
-        };
-    try (HttpTestServer server = new HttpTestServer("/", handler, ssl.enabled);
-        HttpClient client =
-            createClient(
-                server.getUri(),
-                b -> {
-                  switch (ssl) {
-                    case NONE:
-                      break;
-                    case SSL_VERIFIED:
-                      b.setSslContext(server.getSslContext());
-                      break;
-                    case SSL_UNVERIFIED:
-                      b.setSslNoCertificateVerification(true);
-                      break;
-                    default:
-                      throw new UnsupportedOperationException();
-                  }
-                  b.setHttp2Upgrade(http2);
-                })) {
+        });
+
+    HttpTestServer server = ssl.enabled ? httpsServer : httpServer;
+
+    try (HttpClient client =
+        createClient(
+            server.getUri(),
+            b -> {
+              switch (ssl) {
+                case NONE:
+                  break;
+                case SSL_VERIFIED:
+                  b.setSslContext(server.getSslContext());
+                  break;
+                case SSL_UNVERIFIED:
+                  b.setSslNoCertificateVerification(true);
+                  break;
+                default:
+                  throw new UnsupportedOperationException();
+              }
+              b.setHttp2Upgrade(http2);
+            })) {
 
       JsonNode result = client.newRequest().get().readEntity(JsonNode.class);
       soft.assertThat(result)
@@ -154,10 +210,9 @@ public abstract class BaseTestHttpClient {
   }
 
   @Test
-  void testHttpsWithInsecureClient() throws Exception {
-    try (HttpTestServer server = new HttpTestServer("/", (req, resp) -> {}, true);
-        HttpClient insecureClient =
-            HttpClient.builder().setBaseUri(server.getUri()).setObjectMapper(MAPPER).build()) {
+  void testHttpsWithInsecureClient() {
+    try (HttpClient insecureClient =
+        HttpClient.builder().setBaseUri(httpsServer.getUri()).setObjectMapper(MAPPER).build()) {
       HttpRequest request;
       request = insecureClient.newRequest();
       assertThatThrownBy(request::get)
@@ -175,7 +230,7 @@ public abstract class BaseTestHttpClient {
     // Old URLConnection based client cannot handle HTTP/2
     assumeThat(!http2 || supportsHttp2()).isTrue();
 
-    HttpTestServer.RequestHandler handler =
+    handler.set(
         (req, resp) -> {
           ArrayBean input;
           switch (req.getMethod()) {
@@ -203,64 +258,64 @@ public abstract class BaseTestHttpClient {
           try (OutputStream os = resp.getOutputStream()) {
             MAPPER.writeValue(os, input);
           }
-        };
+        });
 
-    try (HttpTestServer server = new HttpTestServer(handler, ssl)) {
-      for (boolean disableCompression : new boolean[] {false, true}) {
-        try (HttpClient client =
-            createClient(
-                server.getUri(),
-                b -> {
-                  b.setDisableCompression(disableCompression).setHttp2Upgrade(http2);
-                  if (ssl) {
-                    b.setSslContext(server.getSslContext());
-                  }
-                })) {
+    HttpTestServer server = ssl ? httpsServer : httpServer;
 
-          // Intentionally repeat a bunch of requests as fast as possible to validate that the
-          // server/client combination works fine.
-          for (int i = 0; i < 5; i++) {
-            for (int num : new int[] {1, 10, 20, 100}) {
-              int len = 10_000;
+    for (boolean disableCompression : new boolean[] {false, true}) {
+      try (HttpClient client =
+          createClient(
+              server.getUri(),
+              b -> {
+                b.setDisableCompression(disableCompression).setHttp2Upgrade(http2);
+                if (ssl) {
+                  b.setSslContext(server.getSslContext());
+                }
+              })) {
 
-              ArrayBean inputBean = ArrayBean.construct(10_000, num);
+        // Intentionally repeat a bunch of requests as fast as possible to validate that the
+        // server/client combination works fine.
+        for (int i = 0; i < 5; i++) {
+          for (int num : new int[] {1, 10, 20, 100}) {
+            int len = 10_000;
 
-              Supplier<HttpRequest> newRequest =
-                  () ->
-                      client
-                          .newRequest()
-                          .queryParam("len", Integer.toString(len))
-                          .queryParam("num", Integer.toString(num))
-                          .queryParam("disableCompression", Boolean.toString(disableCompression));
+            ArrayBean inputBean = ArrayBean.construct(10_000, num);
 
-              soft.assertThatCode(
-                      () ->
-                          assertThat(newRequest.get().get().readEntity(ArrayBean.class))
-                              .isEqualTo(inputBean))
-                  .describedAs("GET, disableCompression:%s, num:%d", disableCompression, num)
-                  .doesNotThrowAnyException();
+            Supplier<HttpRequest> newRequest =
+                () ->
+                    client
+                        .newRequest()
+                        .queryParam("len", Integer.toString(len))
+                        .queryParam("num", Integer.toString(num))
+                        .queryParam("disableCompression", Boolean.toString(disableCompression));
 
-              soft.assertThatCode(
-                      () ->
-                          assertThat(newRequest.get().delete().readEntity(ArrayBean.class))
-                              .isEqualTo(inputBean))
-                  .describedAs("DELETE, disableCompression:%s, num:%d", disableCompression, num)
-                  .doesNotThrowAnyException();
+            soft.assertThatCode(
+                    () ->
+                        assertThat(newRequest.get().get().readEntity(ArrayBean.class))
+                            .isEqualTo(inputBean))
+                .describedAs("GET, disableCompression:%s, num:%d", disableCompression, num)
+                .doesNotThrowAnyException();
 
-              soft.assertThatCode(
-                      () ->
-                          assertThat(newRequest.get().put(inputBean).readEntity(ArrayBean.class))
-                              .isEqualTo(inputBean))
-                  .describedAs("PUT, disableCompression:%s, num:%d", disableCompression, num)
-                  .doesNotThrowAnyException();
+            soft.assertThatCode(
+                    () ->
+                        assertThat(newRequest.get().delete().readEntity(ArrayBean.class))
+                            .isEqualTo(inputBean))
+                .describedAs("DELETE, disableCompression:%s, num:%d", disableCompression, num)
+                .doesNotThrowAnyException();
 
-              soft.assertThatCode(
-                      () ->
-                          assertThat(newRequest.get().post(inputBean).readEntity(ArrayBean.class))
-                              .isEqualTo(inputBean))
-                  .describedAs("POST, disableCompression:%s, num:%d", disableCompression, num)
-                  .doesNotThrowAnyException();
-            }
+            soft.assertThatCode(
+                    () ->
+                        assertThat(newRequest.get().put(inputBean).readEntity(ArrayBean.class))
+                            .isEqualTo(inputBean))
+                .describedAs("PUT, disableCompression:%s, num:%d", disableCompression, num)
+                .doesNotThrowAnyException();
+
+            soft.assertThatCode(
+                    () ->
+                        assertThat(newRequest.get().post(inputBean).readEntity(ArrayBean.class))
+                            .isEqualTo(inputBean))
+                .describedAs("POST, disableCompression:%s, num:%d", disableCompression, num)
+                .doesNotThrowAnyException();
           }
         }
       }
@@ -268,37 +323,30 @@ public abstract class BaseTestHttpClient {
   }
 
   @Test
-  void testGet() throws Exception {
+  void testGet() {
     ExampleBean inputBean = new ExampleBean("x", 1, NOW);
-    HttpTestServer.RequestHandler handler =
+    handler.set(
         (req, resp) -> {
           soft.assertThat(req.getMethod()).isEqualTo("GET");
           String response = MAPPER.writeValueAsString(inputBean);
           writeResponseBody(resp, response);
-        };
-    try (HttpTestServer server = new HttpTestServer(handler)) {
-      URI baseUri = server.getUri();
-      try (HttpClient client = createClient(baseUri, b -> {})) {
-        ExampleBean bean = client.newRequest().get().readEntity(ExampleBean.class);
-        soft.assertThat(bean).isEqualTo(inputBean);
-      }
-    }
+        });
+    ExampleBean bean = client.newRequest().get().readEntity(ExampleBean.class);
+    soft.assertThat(bean).isEqualTo(inputBean);
   }
 
   @Test
-  void testPerRequestBaseUri() throws Exception {
+  void testPerRequestBaseUri() {
     ExampleBean inputBean = new ExampleBean("x", 1, NOW);
-    HttpTestServer.RequestHandler handler =
+    handler.set(
         (req, resp) -> {
           soft.assertThat(req.getMethod()).isEqualTo("GET");
           String response = MAPPER.writeValueAsString(inputBean);
           writeResponseBody(resp, response);
-        };
-    try (HttpTestServer server = new HttpTestServer(handler)) {
-      try (HttpClient client = createClient(null, b -> {})) {
-        ExampleBean bean = client.newRequest(server.getUri()).get().readEntity(ExampleBean.class);
-        soft.assertThat(bean).isEqualTo(inputBean);
-      }
+        });
+    try (HttpClient client = createClient(null, b -> {})) {
+      ExampleBean bean = client.newRequest(httpServer.getUri()).get().readEntity(ExampleBean.class);
+      soft.assertThat(bean).isEqualTo(inputBean);
     }
   }
 
@@ -321,9 +369,9 @@ public abstract class BaseTestHttpClient {
   }
 
   @Test
-  void testPut() throws Exception {
+  void testPut() {
     ExampleBean inputBean = new ExampleBean("x", 1, NOW);
-    HttpTestServer.RequestHandler handler =
+    handler.set(
         (req, resp) -> {
           soft.assertThat(req.getMethod()).isEqualTo("PUT");
           try (InputStream in = req.getInputStream()) {
@@ -331,19 +379,14 @@ public abstract class BaseTestHttpClient {
             soft.assertThat(bean).isEqualTo(inputBean);
           }
           writeEmptyResponse(resp);
-        };
-    try (HttpTestServer server = new HttpTestServer(handler)) {
-      URI baseUri = server.getUri();
-      try (HttpClient client = createClient(baseUri, b -> {})) {
-        client.newRequest().put(inputBean);
-      }
-    }
+        });
+    client.newRequest().put(inputBean);
   }
 
   @Test
-  void testPost() throws Exception {
+  void testPost() {
     ExampleBean inputBean = new ExampleBean("x", 1, NOW);
-    HttpTestServer.RequestHandler handler =
+    handler.set(
         (req, resp) -> {
           soft.assertThat(req.getMethod()).isEqualTo("POST");
           try (InputStream in = req.getInputStream()) {
@@ -351,54 +394,38 @@ public abstract class BaseTestHttpClient {
             soft.assertThat(bean).isEqualTo(inputBean);
           }
           writeEmptyResponse(resp);
-        };
-    try (HttpTestServer server = new HttpTestServer(handler)) {
-      URI baseUri = server.getUri();
-      try (HttpClient client = createClient(baseUri, b -> {})) {
-        client.newRequest().post(inputBean);
-      }
-    }
+        });
+    client.newRequest().post(inputBean);
   }
 
   @Test
-  void testDelete() throws Exception {
-    HttpTestServer.RequestHandler handler =
+  void testDelete() {
+    handler.set(
         (req, resp) -> {
           soft.assertThat(req.getMethod()).isEqualTo("DELETE");
           writeEmptyResponse(resp);
-        };
-    try (HttpTestServer server = new HttpTestServer(handler)) {
-      URI baseUri = server.getUri();
-      try (HttpClient client = createClient(baseUri, b -> {})) {
-        client.newRequest().delete();
-      }
-    }
+        });
+    client.newRequest().delete();
   }
 
   @Test
-  void testGetQueryParam() throws Exception {
+  void testGetQueryParam() {
     ExampleBean inputBean = new ExampleBean("x", 1, NOW);
-    HttpTestServer.RequestHandler handler =
+    handler.set(
         (req, resp) -> {
           soft.assertThat(req.getQueryString()).isEqualTo("x=y");
           soft.assertThat(req.getMethod()).isEqualTo("GET");
           String response = MAPPER.writeValueAsString(inputBean);
           writeResponseBody(resp, response);
-        };
-    try (HttpTestServer server = new HttpTestServer(handler)) {
-      URI baseUri = server.getUri();
-      try (HttpClient client = createClient(baseUri, b -> {})) {
-        ExampleBean bean =
-            client.newRequest().queryParam("x", "y").get().readEntity(ExampleBean.class);
-        soft.assertThat(bean).isEqualTo(inputBean);
-      }
-    }
+        });
+    ExampleBean bean = client.newRequest().queryParam("x", "y").get().readEntity(ExampleBean.class);
+    soft.assertThat(bean).isEqualTo(inputBean);
   }
 
   @Test
-  void testGetMultipleQueryParam() throws Exception {
+  void testGetMultipleQueryParam() {
     ExampleBean inputBean = new ExampleBean("x", 1, NOW);
-    HttpTestServer.RequestHandler handler =
+    handler.set(
         (req, resp) -> {
           String[] queryParams = req.getQueryString().split("&");
           soft.assertThat(queryParams).hasSize(2);
@@ -407,67 +434,52 @@ public abstract class BaseTestHttpClient {
           soft.assertThat(req.getMethod()).isEqualTo("GET");
           String response = MAPPER.writeValueAsString(inputBean);
           writeResponseBody(resp, response);
-        };
-    try (HttpTestServer server = new HttpTestServer(handler)) {
-      URI baseUri = server.getUri();
-      try (HttpClient client = createClient(baseUri, b -> {})) {
-        ExampleBean bean =
-            client
-                .newRequest()
-                .queryParam("x", "y")
-                .queryParam("a", "b")
-                .get()
-                .readEntity(ExampleBean.class);
-        soft.assertThat(bean).isEqualTo(inputBean);
-      }
-    }
+        });
+    ExampleBean bean =
+        client
+            .newRequest()
+            .queryParam("x", "y")
+            .queryParam("a", "b")
+            .get()
+            .readEntity(ExampleBean.class);
+    soft.assertThat(bean).isEqualTo(inputBean);
   }
 
   @Test
-  void testGetNullQueryParam() throws Exception {
+  void testGetNullQueryParam() {
     ExampleBean inputBean = new ExampleBean("x", 1, NOW);
-    HttpTestServer.RequestHandler handler =
+    handler.set(
         (req, resp) -> {
           String queryParams = req.getQueryString();
           soft.assertThat(queryParams).isNull();
           soft.assertThat(req.getMethod()).isEqualTo("GET");
           String response = MAPPER.writeValueAsString(inputBean);
           writeResponseBody(resp, response);
-        };
-    try (HttpTestServer server = new HttpTestServer(handler)) {
-      URI baseUri = server.getUri();
-      try (HttpClient client = createClient(baseUri, b -> {})) {
-        ExampleBean bean =
-            client.newRequest().queryParam("x", (String) null).get().readEntity(ExampleBean.class);
-        soft.assertThat(bean).isEqualTo(inputBean);
-      }
-    }
+        });
+    ExampleBean bean =
+        client.newRequest().queryParam("x", (String) null).get().readEntity(ExampleBean.class);
+    soft.assertThat(bean).isEqualTo(inputBean);
   }
 
   @Test
-  void testGetTemplate() throws Exception {
+  void testGetTemplate() {
     ExampleBean inputBean = new ExampleBean("x", 1, NOW);
-    HttpTestServer.RequestHandler handler =
+    handler.set(
         (req, resp) -> {
           soft.assertThat(req.getMethod()).isEqualTo("GET");
           String response = MAPPER.writeValueAsString(inputBean);
           writeResponseBody(resp, response);
-        };
-    try (HttpTestServer server = new HttpTestServer("/a/b", handler)) {
-      URI baseUri = server.getUri();
-      try (HttpClient client = createClient(baseUri, b1 -> {})) {
-        ExampleBean bean = client.newRequest().path("a/b").get().readEntity(ExampleBean.class);
-        soft.assertThat(bean).isEqualTo(inputBean);
-        bean =
-            client
-                .newRequest()
-                .path("a/{b}")
-                .resolveTemplate("b", "b")
-                .get()
-                .readEntity(ExampleBean.class);
-        soft.assertThat(bean).isEqualTo(inputBean);
-      }
-    }
+        });
+    ExampleBean bean = client.newRequest().path("a/b").get().readEntity(ExampleBean.class);
+    soft.assertThat(bean).isEqualTo(inputBean);
+    bean =
+        client
+            .newRequest()
+            .path("a/{b}")
+            .resolveTemplate("b", "b")
+            .get()
+            .readEntity(ExampleBean.class);
+    soft.assertThat(bean).isEqualTo(inputBean);
   }
 
   static Stream<Status> httpResponses() {
@@ -481,9 +493,9 @@ public abstract class BaseTestHttpClient {
 
   @ParameterizedTest
   @MethodSource("httpResponses")
-  void testHttpResponses(Status status) throws Exception {
+  void testHttpResponses(Status status) {
     ExampleBean expected = new ExampleBean("x", 1, NOW);
-    HttpTestServer.RequestHandler handler =
+    handler.set(
         (req, resp) -> {
           resp.setStatus(status.getCode());
           if (status != Status.NO_CONTENT && status != Status.NOT_MODIFIED) {
@@ -492,29 +504,23 @@ public abstract class BaseTestHttpClient {
               MAPPER.writeValue(os, expected);
             }
           }
-        };
-    try (HttpTestServer server = new HttpTestServer("/a/b", handler)) {
-      AtomicReference<ResponseContext> responseContext = new AtomicReference<>();
-      try (HttpClient client =
-          createClient(server.getUri(), b -> b.addResponseFilter(responseContext::set))) {
-        ExampleBean actual = client.newRequest().get().readEntity(ExampleBean.class);
-        if (status == Status.NO_CONTENT || status == Status.NOT_MODIFIED) {
-          soft.assertThat(actual).isNull();
-        } else {
-          soft.assertThat(actual).isNotNull().isEqualTo(expected);
-        }
-      }
-      soft.assertThat(responseContext.get())
-          .isNotNull()
-          .extracting(ResponseContext::getStatus)
-          .isEqualTo(status);
+        });
+    ExampleBean actual = client.newRequest().get().readEntity(ExampleBean.class);
+    if (status == Status.NO_CONTENT || status == Status.NOT_MODIFIED) {
+      soft.assertThat(actual).isNull();
+    } else {
+      soft.assertThat(actual).isNotNull().isEqualTo(expected);
     }
+    soft.assertThat(responseContext.get())
+        .isNotNull()
+        .extracting(ResponseContext::getStatus)
+        .isEqualTo(status);
   }
 
   @ParameterizedTest
   @MethodSource("httpResponses")
-  void testHttpResponsesNoJsonEntity(Status status) throws Exception {
-    HttpTestServer.RequestHandler handler =
+  void testHttpResponsesNoJsonEntity(Status status) {
+    handler.set(
         (req, resp) -> {
           resp.setStatus(status.getCode());
           if (status != Status.NO_CONTENT && status != Status.NOT_MODIFIED) {
@@ -523,165 +529,131 @@ public abstract class BaseTestHttpClient {
               MAPPER.writeValue(os, "Hello, World!");
             }
           }
-        };
-    try (HttpTestServer server = new HttpTestServer("/a/b", handler)) {
-      AtomicReference<ResponseContext> responseContext = new AtomicReference<>();
-      try (HttpClient client =
-          createClient(server.getUri(), b -> b.addResponseFilter(responseContext::set))) {
-        if (status == Status.NO_CONTENT || status == Status.NOT_MODIFIED) {
-          ExampleBean actual = client.newRequest().get().readEntity(ExampleBean.class);
-          soft.assertThat(actual).isNull();
-        } else {
-          soft.assertThatThrownBy(() -> client.newRequest().get().readEntity(ExampleBean.class))
-              .asInstanceOf(throwable(NessieBadResponseException.class))
-              .extracting(NessieBadResponseException::getError)
-              .satisfies(
-                  error -> {
-                    assertThat(error.getStatus()).isEqualTo(status.getCode());
-                    assertThat(error.getMessage()).contains("text/plain");
-                  });
-        }
-      }
-      soft.assertThat(responseContext.get())
-          .isNotNull()
-          .extracting(ResponseContext::getStatus)
-          .isEqualTo(status);
+        });
+    if (status == Status.NO_CONTENT || status == Status.NOT_MODIFIED) {
+      ExampleBean actual = client.newRequest().get().readEntity(ExampleBean.class);
+      soft.assertThat(actual).isNull();
+    } else {
+      soft.assertThatThrownBy(() -> client.newRequest().get().readEntity(ExampleBean.class))
+          .asInstanceOf(throwable(NessieBadResponseException.class))
+          .extracting(NessieBadResponseException::getError)
+          .satisfies(
+              error -> {
+                assertThat(error.getStatus()).isEqualTo(status.getCode());
+                assertThat(error.getMessage()).contains("text/plain");
+              });
     }
+    soft.assertThat(responseContext.get())
+        .isNotNull()
+        .extracting(ResponseContext::getStatus)
+        .isEqualTo(status);
   }
 
   @ParameterizedTest
   @MethodSource("httpResponses")
-  void testHttpResponsesJsonNoEntity(Status status) throws Exception {
-    HttpTestServer.RequestHandler handler =
+  void testHttpResponsesJsonNoEntity(Status status) {
+    handler.set(
         (req, resp) -> {
           resp.setStatus(status.getCode());
           resp.setContentType("application/json");
-        };
-    try (HttpTestServer server = new HttpTestServer("/a/b", handler)) {
-      AtomicReference<ResponseContext> responseContext = new AtomicReference<>();
-      try (HttpClient client =
-          createClient(server.getUri(), b -> b.addResponseFilter(responseContext::set))) {
-        ExampleBean actual = client.newRequest().get().readEntity(ExampleBean.class);
-        soft.assertThat(actual).isNull();
-      }
-      soft.assertThat(responseContext.get())
-          .isNotNull()
-          .extracting(ResponseContext::getStatus)
-          .isEqualTo(status);
-    }
+        });
+    ExampleBean actual = client.newRequest().get().readEntity(ExampleBean.class);
+    soft.assertThat(actual).isNull();
+    soft.assertThat(responseContext.get())
+        .isNotNull()
+        .extracting(ResponseContext::getStatus)
+        .isEqualTo(status);
   }
 
   @ParameterizedTest
   @MethodSource("httpResponses")
-  void testHttpResponsesNoJsonNoEntity(Status status) throws Exception {
-    HttpTestServer.RequestHandler handler = (req, resp) -> resp.setStatus(status.getCode());
-    try (HttpTestServer server = new HttpTestServer("/a/b", handler)) {
-      AtomicReference<ResponseContext> responseContext = new AtomicReference<>();
-      try (HttpClient client =
-          createClient(server.getUri(), b -> b.addResponseFilter(responseContext::set))) {
-        ExampleBean actual = client.newRequest().get().readEntity(ExampleBean.class);
-        soft.assertThat(actual).isNull();
-      }
-      soft.assertThat(responseContext.get())
-          .isNotNull()
-          .extracting(ResponseContext::getStatus)
-          .isEqualTo(status);
-    }
+  void testHttpResponsesNoJsonNoEntity(Status status) {
+    handler.set((req, resp) -> resp.setStatus(status.getCode()));
+    ExampleBean actual = client.newRequest().get().readEntity(ExampleBean.class);
+    soft.assertThat(actual).isNull();
+    soft.assertThat(responseContext.get())
+        .isNotNull()
+        .extracting(ResponseContext::getStatus)
+        .isEqualTo(status);
   }
 
   @Test
-  void testGetTemplateThrows() throws Exception {
-    HttpTestServer.RequestHandler handler =
-        (req, resp) -> resp.sendError(Status.INTERNAL_SERVER_ERROR.getCode());
-    try (HttpTestServer server = new HttpTestServer("/a/b", handler)) {
-      AtomicReference<ResponseContext> responseContext = new AtomicReference<>();
-      try (HttpClient client =
-          createClient(server.getUri(), b -> b.addResponseFilter(responseContext::set))) {
+  void testGetTemplateThrows() {
+    handler.set((req, resp) -> resp.sendError(Status.INTERNAL_SERVER_ERROR.getCode()));
+    soft.assertThatThrownBy(
+            () -> client.newRequest().path("a/{b}").get().readEntity(ExampleBean.class))
+        .isInstanceOf(NessieBadResponseException.class);
+    soft.assertThat(responseContext.get())
+        .isNotNull()
+        .extracting(ResponseContext::getStatus)
+        .isEqualTo(Status.INTERNAL_SERVER_ERROR);
 
-        soft.assertThatThrownBy(
-                () -> client.newRequest().path("a/{b}").get().readEntity(ExampleBean.class))
-            .isInstanceOf(NessieBadResponseException.class);
-        soft.assertThat(responseContext.get())
-            .isNotNull()
-            .extracting(ResponseContext::getStatus)
-            .isEqualTo(Status.INTERNAL_SERVER_ERROR);
-
-        responseContext.set(null);
-        soft.assertThatThrownBy(
-                () ->
-                    client
-                        .newRequest()
-                        .path("a/b")
-                        .resolveTemplate("b", "b")
-                        .get()
-                        .readEntity(ExampleBean.class))
-            .isInstanceOf(HttpClientException.class)
-            .hasMessageContaining(
-                "Cannot build uri. Not all template keys (b) were used in uri a/b");
-      }
-      soft.assertThat(responseContext.get()).isNull();
-    }
+    responseContext.set(null);
+    soft.assertThatThrownBy(
+            () ->
+                client
+                    .newRequest()
+                    .path("a/b")
+                    .resolveTemplate("b", "b")
+                    .get()
+                    .readEntity(ExampleBean.class))
+        .isInstanceOf(HttpClientException.class)
+        .hasMessageContaining("Cannot build uri. Not all template keys (b) were used in uri a/b");
+    soft.assertThat(responseContext.get()).isNull();
   }
 
   @Test
-  void testFilters() throws Exception {
+  void testFilters() {
     AtomicBoolean requestFilterCalled = new AtomicBoolean(false);
     AtomicBoolean responseFilterCalled = new AtomicBoolean(false);
     AtomicReference<ResponseContext> responseContextGotCallback = new AtomicReference<>();
     AtomicReference<ResponseContext> responseContextGotFilter = new AtomicReference<>();
-    HttpTestServer.RequestHandler handler =
+    handler.set(
         (req, resp) -> {
           assertThat(req.getHeader("x")).isEqualTo("y");
           writeEmptyResponse(resp);
-        };
-    try (HttpTestServer server = new HttpTestServer(handler)) {
-      HttpClient.Builder builder =
-          HttpClient.builder().setBaseUri(server.getUri()).setObjectMapper(MAPPER);
-      builder.addRequestFilter(
-          context -> {
-            requestFilterCalled.set(true);
-            context.putHeader("x", "y");
-            context.addResponseCallback(
-                (responseContext, failure) -> {
-                  responseContextGotCallback.set(responseContext);
-                  soft.assertThat(failure).isNull();
-                });
-          });
-      builder.addResponseFilter(
-          con -> {
-            soft.assertThat(con.getStatus()).isEqualTo(Status.OK);
-            responseFilterCalled.set(true);
-            responseContextGotFilter.set(con);
-          });
-      try (HttpClient client = builder.build()) {
-        client.newRequest().get();
-      }
-      soft.assertThat(responseContextGotFilter.get())
-          .isNotNull()
-          .isSameAs(responseContextGotCallback.get());
-      soft.assertThat(responseFilterCalled.get()).isTrue();
-      soft.assertThat(requestFilterCalled.get()).isTrue();
+        });
+    HttpClient.Builder builder =
+        HttpClient.builder().setBaseUri(httpServer.getUri()).setObjectMapper(MAPPER);
+    builder.addRequestFilter(
+        context -> {
+          requestFilterCalled.set(true);
+          context.putHeader("x", "y");
+          context.addResponseCallback(
+              (responseContext, failure) -> {
+                responseContextGotCallback.set(responseContext);
+                soft.assertThat(failure).isNull();
+              });
+        });
+    builder.addResponseFilter(
+        con -> {
+          soft.assertThat(con.getStatus()).isEqualTo(Status.OK);
+          responseFilterCalled.set(true);
+          responseContextGotFilter.set(con);
+        });
+    try (HttpClient client = builder.build()) {
+      client.newRequest().get();
     }
+    soft.assertThat(responseContextGotFilter.get())
+        .isNotNull()
+        .isSameAs(responseContextGotCallback.get());
+    soft.assertThat(responseFilterCalled.get()).isTrue();
+    soft.assertThat(requestFilterCalled.get()).isTrue();
   }
 
   @Test
-  void testHeaders() throws Exception {
-    HttpTestServer.RequestHandler handler =
+  void testHeaders() {
+    handler.set(
         (req, resp) -> {
           assertThat(req.getHeader("x")).isEqualTo("y");
           writeEmptyResponse(resp);
-        };
-    try (HttpTestServer server = new HttpTestServer(handler)) {
-      URI baseUri = server.getUri();
-      try (HttpClient client = createClient(baseUri, b -> {})) {
-        client.newRequest().header("x", "y").get();
-      }
-    }
+        });
+    client.newRequest().header("x", "y").get();
   }
 
   @Test
-  void testMultiValueHeaders() throws Exception {
-    HttpTestServer.RequestHandler handler =
+  void testMultiValueHeaders() {
+    handler.set(
         (req, resp) -> {
           List<String> values = new ArrayList<>();
           for (Enumeration<String> e = req.getHeaders("x"); e != null && e.hasMoreElements(); ) {
@@ -689,19 +661,17 @@ public abstract class BaseTestHttpClient {
           }
           assertThat(values).containsExactly("y", "z");
           writeEmptyResponse(resp);
-        };
-    try (HttpTestServer server = new HttpTestServer(handler)) {
-      URI baseUri = server.getUri();
-      try (HttpClient client = createClient(baseUri, b -> {})) {
-        client.newRequest().header("x", "y").header("x", "z").get();
-      }
+        });
+    URI baseUri = httpServer.getUri();
+    try (HttpClient client = createClient(baseUri, b -> {})) {
+      client.newRequest().header("x", "y").header("x", "z").get();
     }
   }
 
   @ParameterizedTest
   @MethodSource
-  void testPostForm(ExampleBean inputBean) throws Exception {
-    HttpTestServer.RequestHandler handler =
+  void testPostForm(ExampleBean inputBean) {
+    handler.set(
         (req, resp) -> {
           soft.assertThat(req.getMethod()).isEqualTo("POST");
           soft.assertThat(req.getContentType()).isEqualTo("application/x-www-form-urlencoded");
@@ -709,13 +679,8 @@ public abstract class BaseTestHttpClient {
           ExampleBean actual = MAPPER.convertValue(data, ExampleBean.class);
           soft.assertThat(actual).isEqualTo(inputBean);
           writeEmptyResponse(resp);
-        };
-    try (HttpTestServer server = new HttpTestServer(handler)) {
-      URI baseUri = server.getUri();
-      try (HttpClient client = createClient(baseUri, b -> {})) {
-        client.newRequest().postForm(inputBean);
-      }
-    }
+        });
+    client.newRequest().postForm(inputBean);
   }
 
   static Stream<ExampleBean> testPostForm() {

--- a/api/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
+++ b/api/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.projectnessie.error.ReferenceConflicts.referenceConflicts;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -38,7 +39,6 @@ import java.util.stream.Stream;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -238,12 +238,6 @@ public class TestResponseFilter {
 
                       @Override
                       public InputStream getInputStream() {
-                        Assertions.fail();
-                        return null;
-                      }
-
-                      @Override
-                      public InputStream getErrorStream() {
                         return new StringInputStream("this will fail");
                       }
 
@@ -281,12 +275,6 @@ public class TestResponseFilter {
 
                       @Override
                       public InputStream getInputStream() {
-                        Assertions.fail();
-                        return null;
-                      }
-
-                      @Override
-                      public InputStream getErrorStream() {
                         // Quarkus may sometimes produce JSON error responses like this
                         return new StringInputStream(
                             "{\"details\":\"Error id ee7f7293-67ad-42bd-8973-179801e7120e-1\",\"stack\":\"\"}");
@@ -395,13 +383,7 @@ public class TestResponseFilter {
     }
 
     @Override
-    public InputStream getInputStream() {
-      Assertions.fail();
-      return null;
-    }
-
-    @Override
-    public InputStream getErrorStream() throws IOException {
+    public InputStream getInputStream() throws JsonProcessingException {
       if (error == null) {
         return null;
       }

--- a/api/client/src/test/java/org/projectnessie/client/rest/v1/TestRestV1Client.java
+++ b/api/client/src/test/java/org/projectnessie/client/rest/v1/TestRestV1Client.java
@@ -79,7 +79,7 @@ class TestRestV1Client {
       assertThatThrownBy(api::getDefaultBranch)
           .isInstanceOf(NessieBadResponseException.class)
           .hasMessageStartingWith(
-              "Expected the server to return a JSON compatible response, but the server returned with Content-Type 'text/html' from ");
+              "OK (HTTP/200): Expected the server to return a JSON compatible response, but the server replied with Content-Type 'text/html' from ");
     }
   }
 


### PR DESCRIPTION
As requested here:

https://github.com/projectnessie/nessie/pull/9055#discussion_r1672844009

This PR removes all the "oddities" due to the legacy `HttpURLConnection` request impl:

* No more hard-coded error when status >= 400
* `RequestContext` returns only a single `InputStream`

As a consequence, `HttpResponse` now handles such statuses gracefully and returns `null` if the response has no body. It was slightly refactored  to use `CapturingInputStream` for improved error messages.

#### Remarks on the "UrlConnection behavior" and impacts of removing it to end users

To my surprise, the "UrlConnection behavior" consisting of throwing a hard-coded exception for statuses >= 400, and which was being mimicked for Java and Apache request impls... does not manifest itself when using `UrlConnectionRequest` :-)

The odd-behaving method seemed to be `HttpURLConnection.getResponseCode()`, judging from comments in the code. Looking at the implementations, it calls `getInputStream()`, which indeed throws a hard-coded `IOException` when the status is >= 400. But what's really weird is that `getResponseCode()` catches the exception, and ignores it completely! I verified this for JDKs 17, 11 and 8.

The only way to surface that `IOException` is to call `HttpURLConnection.getInputStream()` directly. I suppose that in earlier versions of the HTTP client, this might have happened, but it doesn't anymore: we don't call this method anymore if the status is >= 400.

Apart from that, this PR introduces an obvious behavioral change since we are not throwing any error for status >= 400 anymore. Instead, an `HttpResponse` is returned, which may or may not contain an entity.

I had to adapt the code that reads the entity a bit because of that.

In overall I think this behavioral change is fine, because the HTTP client is never used in the wild without the `NessieHttpResponseFilter` which already intercepts statuses >= 400. So from a user perspective, there is no change because the removed behavior wasn't exercised.