### PR TITLE
Catalog: Fix assignment of nested fields in a table's initial schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Fixes
 
+- Catalog: fix field-ID reassignment and last-column-id calculation
+
 ### Commits
 
 ## [0.92.0] Release (2024-07-11)

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergListType.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergListType.java
@@ -62,10 +62,16 @@ public interface IcebergListType extends IcebergComplexType {
     return schema;
   }
 
-  @SuppressWarnings("unused")
+  static Builder builder() {
+    return ImmutableIcebergListType.builder();
+  }
+
   interface Builder {
     @CanIgnoreReturnValue
     Builder clear();
+
+    @CanIgnoreReturnValue
+    Builder from(IcebergType instance);
 
     @CanIgnoreReturnValue
     Builder elementId(int elementId);

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergMapType.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergMapType.java
@@ -93,10 +93,16 @@ public interface IcebergMapType extends IcebergComplexType {
                     keyValueName, null, null, false, ImmutableList.of(keyField, valueField))));
   }
 
-  @SuppressWarnings("unused")
+  static Builder builder() {
+    return ImmutableIcebergMapType.builder();
+  }
+
   interface Builder {
     @CanIgnoreReturnValue
     Builder clear();
+
+    @CanIgnoreReturnValue
+    Builder from(IcebergType instance);
 
     @CanIgnoreReturnValue
     Builder type(String type);

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergStructType.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergStructType.java
@@ -90,10 +90,16 @@ public interface IcebergStructType extends IcebergComplexType {
     return Schema.createRecord(recordName, null, null, false, fields);
   }
 
-  @SuppressWarnings("unused")
+  static Builder builder() {
+    return ImmutableIcebergStructType.builder();
+  }
+
   interface Builder {
     @CanIgnoreReturnValue
     Builder clear();
+
+    @CanIgnoreReturnValue
+    Builder from(IcebergType instance);
 
     @CanIgnoreReturnValue
     Builder type(String type);


### PR DESCRIPTION
The field IDs of nested structures/lists/maps are not properly (re)assigned during the creation of a table. This can lead to duplicate field IDs.

This change fixes the oversight and adds a test for this case.

Another bug fixed by this change it the calculation of the `last-column-id`, which needs to even respect IDs in collection types (maps + lists).
