### PR TITLE
GC: Fix behavior of cutoff policy "num commits", 'off by one'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Fixes
 
+- GC: Fix behavior of cutoff policy "num commits", it was 'off by one' and considered the n-th commit as non-live
+  vs the n-th commit as the last live one.
+
 ### Commits
 
 ## [0.92.1] Release (2024-07-13)

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/identify/NumCommitsCutoffPolicy.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/identify/NumCommitsCutoffPolicy.java
@@ -29,7 +29,7 @@ final class NumCommitsCutoffPolicy implements CutoffPolicy {
 
   @Override
   public boolean isCutoff(@Nonnull Instant commitTime, int numCommits) {
-    return numCommits >= commits;
+    return numCommits > commits;
   }
 
   @Override

--- a/gc/gc-base/src/test/java/org/projectnessie/gc/roundtrip/TestMarkAndSweep.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/gc/roundtrip/TestMarkAndSweep.java
@@ -169,7 +169,7 @@ public class TestMarkAndSweep {
 
     PerRefCutoffPolicySupplier cutOffPolicySupplier() {
       Instant cutOff = now.minus(numCommits - numExpired, ChronoUnit.SECONDS);
-      return atTimestamp ? r -> atTimestamp(cutOff) : r -> numCommits((int) numCommits);
+      return atTimestamp ? r -> atTimestamp(cutOff) : r -> numCommits((int) numCommits - 1);
     }
   }
 


### PR DESCRIPTION
Fix behavior of cutoff policy "num commits", it was 'off by one' and considered the n-th commit as non-live vs the n-th commit as the last live one.

Fixes #9094
