### PR TITLE
Catalog: Don't expose ADLS + GCS credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Changes
 
+- Catalog: ADLS + GCS credentials are no longer sent to the client. It is considered insecure to expose the
+  server's credentials to clients, even if this is likely very convenient. Unless we have a secure mechanism
+  to provide per-client/table credentials, users have to configure object store credentials when using GCS or
+  ADLS via the local Iceberg configuration(s).
+
 ### Deprecations
 
 ### Fixes

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergConfigurer.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergConfigurer.java
@@ -272,25 +272,6 @@ public class IcebergConfigurer {
     gcsBucketOptions
         .deleteBatchSize()
         .ifPresent(dbs -> configOverrides.put(GCS_DELETE_BATCH_SIZE, Integer.toString(dbs)));
-    // FIXME it is not safe to send de/encryption keys and oauth2 tokens
-    gcsBucketOptions
-        .decryptionKey()
-        .ifPresent(key -> configOverrides.put(GCS_DECRYPTION_KEY, key.key()));
-    gcsBucketOptions
-        .encryptionKey()
-        .ifPresent(key -> configOverrides.put(GCS_ENCRYPTION_KEY, key.key()));
-    gcsBucketOptions
-        .oauth2Token()
-        .ifPresent(
-            token -> {
-              configOverrides.put(GCS_OAUTH2_TOKEN, token.token());
-              token
-                  .expiresAt()
-                  .ifPresent(
-                      e ->
-                          configOverrides.put(
-                              GCS_OAUTH2_TOKEN_EXPIRES_AT, String.valueOf(e.toEpochMilli())));
-            });
     if (gcsBucketOptions.authType().isPresent()
         && gcsBucketOptions.authType().get() == GcsBucketOptions.GcsAuthType.NONE) {
       configOverrides.put(GCS_NO_AUTH, "true");
@@ -304,18 +285,6 @@ public class IcebergConfigurer {
     Optional<String> fileSystem = location.container();
     AdlsFileSystemOptions fileSystemOptions =
         adlsOptions.effectiveOptionsForFileSystem(fileSystem, secretsProvider);
-    // FIXME send account key and token?
-    fileSystemOptions
-        .account()
-        .ifPresent(
-            key -> {
-              configOverrides.put(ADLS_SHARED_KEY_ACCOUNT_NAME, key.name());
-              configOverrides.put(ADLS_SHARED_KEY_ACCOUNT_KEY, key.secret());
-            });
-    fileSystemOptions
-        .sasToken()
-        .ifPresent(
-            s -> configOverrides.put(ADLS_SAS_TOKEN_PREFIX + location.storageAccount(), s.key()));
     fileSystemOptions
         .endpoint()
         .ifPresent(

--- a/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/adls/ITAdlsIcebergCatalog.java
+++ b/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/adls/ITAdlsIcebergCatalog.java
@@ -17,6 +17,7 @@ package org.projectnessie.server.catalog.adls;
 
 import static java.util.UUID.randomUUID;
 
+import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import java.net.URI;
@@ -24,6 +25,8 @@ import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
 import org.projectnessie.server.catalog.AbstractIcebergCatalogIntTests;
 import org.projectnessie.server.catalog.AzuriteTestResourceLifecycleManager;
+import org.projectnessie.server.catalog.WarehouseAccount;
+import org.projectnessie.server.catalog.WarehouseAccountSecret;
 import org.projectnessie.server.catalog.WarehouseLocation;
 
 @QuarkusTestResource(
@@ -33,10 +36,18 @@ import org.projectnessie.server.catalog.WarehouseLocation;
 public class ITAdlsIcebergCatalog extends AbstractIcebergCatalogIntTests {
 
   @WarehouseLocation URI warehouseLocation;
+  @WarehouseAccount String account;
+  @WarehouseAccountSecret String accountSecret;
 
   @Override
   protected Map<String, String> catalogOptions() {
-    return Map.of(CatalogProperties.WAREHOUSE_LOCATION, warehouseLocation.toString());
+    return ImmutableMap.of(
+        CatalogProperties.WAREHOUSE_LOCATION,
+        warehouseLocation.toString(),
+        "adls.auth.shared-key.account.name",
+        account,
+        "adls.auth.shared-key.account.key",
+        accountSecret);
   }
 
   @Override

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/AbstractIcebergCatalogTests.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/AbstractIcebergCatalogTests.java
@@ -15,10 +15,10 @@
  */
 package org.projectnessie.server.catalog;
 
-import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.projectnessie.server.catalog.IcebergCatalogTestCommon.WAREHOUSE_NAME;
 
+import com.google.common.collect.ImmutableMap;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -74,7 +74,11 @@ public abstract class AbstractIcebergCatalogTests extends CatalogTests<RESTCatal
   }
 
   protected Map<String, String> catalogOptions() {
-    return singletonMap(CatalogProperties.WAREHOUSE_LOCATION, WAREHOUSE_NAME);
+    return ImmutableMap.of(
+        CatalogProperties.WAREHOUSE_LOCATION,
+        WAREHOUSE_NAME,
+        "adls.sas-token.account.dfs.core.windows.net",
+        "token");
   }
 
   @AfterAll

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/AzuriteTestResourceLifecycleManager.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/AzuriteTestResourceLifecycleManager.java
@@ -57,5 +57,11 @@ public class AzuriteTestResourceLifecycleManager implements QuarkusTestResourceL
     testInjector.injectIntoFields(
         warehouseLocation,
         new TestInjector.AnnotatedAndMatchesType(WarehouseLocation.class, URI.class));
+    testInjector.injectIntoFields(
+        azurite.account(),
+        new TestInjector.AnnotatedAndMatchesType(WarehouseAccount.class, String.class));
+    testInjector.injectIntoFields(
+        azurite.secretBase64(),
+        new TestInjector.AnnotatedAndMatchesType(WarehouseAccountSecret.class, String.class));
   }
 }

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/WarehouseAccount.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/WarehouseAccount.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.server.catalog;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface WarehouseAccount {}

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/WarehouseAccountSecret.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/WarehouseAccountSecret.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.server.catalog;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface WarehouseAccountSecret {}


### PR DESCRIPTION
ADLS + GCS credentials are no longer sent to the client. It is considered insecure to expose the server's credentials to clients, even if this is likely very convenient. Unless we have a secure mechanism to provide per-client/table credentials, users have to configure object store credentials when using GCS or ADLS via the local Iceberg configuration(s).