### PR TITLE
Catalog/ADLS: Don't let endpoint default to warehouse/object-store URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ as necessary. Empty sections will not end in the release notes.
 
 - GC: Fix behavior of cutoff policy "num commits", it was 'off by one' and considered the n-th commit as non-live
   vs the n-th commit as the last live one.
+- Catalog/ADLS: Don't let endpoint default to warehouse/object-store URI
 
 ### Commits
 

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsClientSupplier.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsClientSupplier.java
@@ -80,8 +80,7 @@ public final class AdlsClientSupplier {
 
     String accountName = account.map(BasicCredentials::name).orElse(location.storageAccount());
 
-    clientBuilder.endpoint(
-        fileSystemOptions.endpoint().orElse(location.getUri().resolve("/").toString()));
+    fileSystemOptions.endpoint().ifPresent(clientBuilder::endpoint);
 
     if (fileSystemOptions.sasToken().isPresent()) {
       clientBuilder.sasToken(fileSystemOptions.sasToken().get().key());


### PR DESCRIPTION
Object-store URIs use the `abfs[s]` scheme, which is used to identify the object store, endpoint needs to be a `http[s]`URL of the REST endpoint.