### PR TITLE
Catalog / Helm: fix wrong paths and invalid env vars

### DIFF
--- a/helm/nessie/ci/inmemory-values.yaml
+++ b/helm/nessie/ci/inmemory-values.yaml
@@ -23,7 +23,7 @@ catalog:
       override2: value2
     warehouses:
     - name: warehouse1
-      location: s3://bucket1.prod-us/warehouse
+      location: s3://bucket1/warehouse
       configDefaults:
         default1: value11
         default2: value22
@@ -42,7 +42,7 @@ catalog:
 #          awsAccessKeyId: access-key-id
 #          awsSecretAccessKey: secret-access-key
       buckets:
-        - name: bucket1.prod-us
+        - name: bucket1
           endpoint: prod-us.s3.amazonaws.com
           region: us-east-1
 #          accessKeySecret:
@@ -58,7 +58,7 @@ catalog:
 #          name: gcs-credentials
 #          key: credentials.json
       buckets:
-      - name: bucket1.prod-us
+      - name: bucket1
         projectId: project-id
 #        authCredentialsJsonSecret:
 #          name: gcs-credentials

--- a/helm/nessie/templates/_helpers.tpl
+++ b/helm/nessie/templates/_helpers.tpl
@@ -270,24 +270,24 @@ Define environkent variables for catalog storage options.
 {{- include "nessie.secretToEnv" (list .s3.defaultOptions.accessKeySecret "awsAccessKeyId" "nessie.catalog.service.s3.default-options.access-key.name") }}
 {{- include "nessie.secretToEnv" (list .s3.defaultOptions.accessKeySecret "awsSecretAccessKey" "nessie.catalog.service.s3.default-options.access-key.secret") }}
 {{- range $bucket := .s3.buckets -}}
-{{- include "nessie.secretToEnv" (list $bucket.accessKeySecret "awsAccessKeyId" (printf "nessie.catalog.service.s3.buckets.\"%s\".access-key.name" $bucket.name)) }}
-{{- include "nessie.secretToEnv" (list $bucket.accessKeySecret "awsSecretAccessKey" (printf "nessie.catalog.service.s3.buckets.\"%s\".access-key.secret" $bucket.name)) }}
+{{- include "nessie.secretToEnv" (list $bucket.accessKeySecret "awsAccessKeyId" (printf "nessie.catalog.service.s3.buckets.%s.access-key.name" $bucket.name)) }}
+{{- include "nessie.secretToEnv" (list $bucket.accessKeySecret "awsSecretAccessKey" (printf "nessie.catalog.service.s3.buckets.%s.access-key.secret" $bucket.name)) }}
 {{- end -}}
-{{- include "nessie.secretToEnv" (list .gcs.defaultOptions.authCredentialsJsonSecret "key" "nessie.catalog.service.gcs.default-options.auth-credentials-json.key") }}
+{{- include "nessie.secretToEnv" (list .gcs.defaultOptions.authCredentialsJsonSecret "key" "nessie.catalog.service.gcs.default-options.auth-credentials-json") }}
 {{- include "nessie.secretToEnv" (list .gcs.defaultOptions.oauth2TokenSecret "token" "nessie.catalog.service.gcs.default-options.oauth-token.token") }}
 {{- include "nessie.secretToEnv" (list .gcs.defaultOptions.oauth2TokenSecret "expiresAt" "nessie.catalog.service.gcs.default-options.oauth-token.expiresAt") }}
 {{- range $bucket := .gcs.buckets -}}
-{{- include "nessie.secretToEnv" (list $bucket.authCredentialsJsonSecret "key" (printf "nessie.catalog.service.gcs.buckets.\"%s\".auth-credentials-json.key" $bucket.name)) }}
-{{- include "nessie.secretToEnv" (list $bucket.oauth2TokenSecret "token" (printf "nessie.catalog.service.gcs.buckets.\"%s\".oauth-token.token" $bucket.name)) }}
-{{- include "nessie.secretToEnv" (list $bucket.oauth2TokenSecret "expiresAt" (printf "nessie.catalog.service.gcs.buckets.\"%s\".oauth-token.expires-at" $bucket.name)) }}
+{{- include "nessie.secretToEnv" (list $bucket.authCredentialsJsonSecret "key" (printf "nessie.catalog.service.gcs.buckets.%s.auth-credentials-json" $bucket.name)) }}
+{{- include "nessie.secretToEnv" (list $bucket.oauth2TokenSecret "token" (printf "nessie.catalog.service.gcs.buckets.%s.oauth-token.token" $bucket.name)) }}
+{{- include "nessie.secretToEnv" (list $bucket.oauth2TokenSecret "expiresAt" (printf "nessie.catalog.service.gcs.buckets.%s.oauth-token.expires-at" $bucket.name)) }}
 {{- end -}}
 {{- include "nessie.secretToEnv" (list .adls.defaultOptions.accountSecret "accountName" "nessie.catalog.service.adls.default-options.account.name") }}
 {{- include "nessie.secretToEnv" (list .adls.defaultOptions.accountSecret "accountKey" "nessie.catalog.service.adls.default-options.account.secret") }}
-{{- include "nessie.secretToEnv" (list .adls.defaultOptions.sasTokenSecret "sasToken" "nessie.catalog.service.adls.default-options.sas-token.key") }}
+{{- include "nessie.secretToEnv" (list .adls.defaultOptions.sasTokenSecret "sasToken" "nessie.catalog.service.adls.default-options.sas-token") }}
 {{- range $filesystem := .adls.filesystems -}}
-{{- include "nessie.secretToEnv" (list $filesystem.accountSecret "accountName" (printf "nessie.catalog.service.adls.file-systems.\"%s\".account.name" $filesystem.name)) }}
-{{- include "nessie.secretToEnv" (list $filesystem.accountSecret "accountKey" (printf "nessie.catalog.service.adls.file-systems.\"%s\".account.secret" $filesystem.name)) }}
-{{- include "nessie.secretToEnv" (list $filesystem.sasTokenSecret "sasToken" (printf "nessie.catalog.service.adls.file-systems.\"%s\".sas-token.key" $filesystem.name)) }}
+{{- include "nessie.secretToEnv" (list $filesystem.accountSecret "accountName" (printf "nessie.catalog.service.adls.file-systems.%s.account.name" $filesystem.name)) }}
+{{- include "nessie.secretToEnv" (list $filesystem.accountSecret "accountKey" (printf "nessie.catalog.service.adls.file-systems.%s.account.secret" $filesystem.name)) }}
+{{- include "nessie.secretToEnv" (list $filesystem.sasTokenSecret "sasToken" (printf "nessie.catalog.service.adls.file-systems.%s.sas-token" $filesystem.name)) }}
 {{- end -}}
 {{- end -}}
 
@@ -302,11 +302,11 @@ Define an env var from secret key.
 {{- $secretName := get $secret "name" -}}
 {{- $secretKey := get $secret $key -}}
 {{- if (and $secretName $secretKey) -}}
-- name: {{ $envVarName }}
+- name: {{ $envVarName | quote }}
   valueFrom:
     secretKeyRef:
-      name: {{ $secretName }}
-      key: {{ $secretKey }}
+      name: {{ $secretName | quote }}
+      key: {{ $secretKey | quote }}
 {{ end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/nessie/templates/configmap.yaml
+++ b/helm/nessie/templates/configmap.yaml
@@ -130,19 +130,19 @@ data:
     {{- list .Values.catalog.storage.s3.defaultOptions "nessie.catalog.service.s3.default-options." $map | include "nessie.applyCatalogStorageS3BucketOptions" }}
     {{- range $i, $bucket := .Values.catalog.storage.s3.buckets -}}
     {{- if not $bucket.name -}}{{- required ( printf "catalog.storage.s3.buckets[%d]: missing bucket name" $i ) $bucket.name -}}{{- end -}}
-    {{- list $bucket ( printf "nessie.catalog.service.s3.buckets.%s." (quote $bucket.name ) ) $map | include "nessie.applyCatalogStorageS3BucketOptions" }}
+    {{- list $bucket ( printf "nessie.catalog.service.s3.buckets.%s." $bucket.name ) $map | include "nessie.applyCatalogStorageS3BucketOptions" }}
     {{- end -}}
     {{- list .Values.catalog.storage.gcs "nessie.catalog.service.gcs." $map | include "nessie.applyCatalogStorageGcsRootOptions" }}
     {{- list .Values.catalog.storage.gcs.defaultOptions "nessie.catalog.service.gcs.default-options." $map | include "nessie.applyCatalogStorageGcsBucketOptions" }}
     {{- range $i, $bucket := .Values.catalog.storage.gcs.buckets -}}
     {{- if not $bucket.name -}}{{- required ( printf "catalog.storage.gcs.buckets[%d]: missing bucket name" $i ) $bucket.name -}}{{- end -}}
-    {{ list $bucket ( printf "nessie.catalog.service.gcs.buckets.%s." (quote $bucket.name ) ) $map | include "nessie.applyCatalogStorageGcsBucketOptions" }}
+    {{ list $bucket ( printf "nessie.catalog.service.gcs.buckets.%s." $bucket.name ) $map | include "nessie.applyCatalogStorageGcsBucketOptions" }}
     {{- end -}}
     {{- list .Values.catalog.storage.adls "nessie.catalog.service.adls." $map | include "nessie.applyCatalogStorageAdlsRootOptions" }}
     {{- list .Values.catalog.storage.adls.defaultOptions "nessie.catalog.service.adls.default-options." $map | include "nessie.applyCatalogStorageAdlsFileSystemOptions" }}
     {{- range $i, $filesystem := .Values.catalog.storage.adls.filesystems -}}
     {{- if not $filesystem.name -}}{{- required ( printf "catalog.storage.adls.filesystems[%d]: missing filesystem name" $i ) $filesystem.name -}}{{- end -}}
-    {{- list $filesystem ( printf "nessie.catalog.service.adls.file-systems.%s." (quote $filesystem.name ) ) $map | include "nessie.applyCatalogStorageAdlsFileSystemOptions" }}
+    {{- list $filesystem ( printf "nessie.catalog.service.adls.file-systems.%s." $filesystem.name ) $map | include "nessie.applyCatalogStorageAdlsFileSystemOptions" }}
     {{- end -}}
     {{- end -}}
 


### PR DESCRIPTION
Summary of changes:

* Fix config options of type KeySecret
* Remove all quotes from config options, both as env vars and in configmap
* Quote env var names

Note: TLDR is, we don't have the choice but to give up on double-quoting bucket names. This is sad, because bucket names can contain dots; but unfortunately, if that's the case, it will be impossible to provide configuration specific to such buckets.