### PR TITLE
GC: Record expiry exception in repository + record stack trace as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ as necessary. Empty sections will not end in the release notes.
 
 - GC: Fix behavior of cutoff policy "num commits", it was 'off by one' and considered the n-th commit as non-live
   vs the n-th commit as the last live one.
+- GC: Record failed "sweep"/"expire" runs in the repository. Before this fix, failures were reported on the console.
 - Catalog/ADLS: Don't let endpoint default to warehouse/object-store URI
 
 ### Commits

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/contents/inmem/InMemoryPersistenceSpi.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/contents/inmem/InMemoryPersistenceSpi.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.gc.contents.inmem;
 
+import static com.google.common.base.Throwables.getStackTraceAsString;
 import static java.util.Collections.emptySet;
 
 import com.google.common.base.Preconditions;
@@ -143,7 +144,7 @@ public class InMemoryPersistenceSpi implements PersistenceSpi {
                       .unbuild()
                       .expiryCompleted(finished);
               if (failure != null) {
-                b.status(Status.EXPIRY_FAILED).errorMessage(failure.toString());
+                b.status(Status.EXPIRY_FAILED).errorMessage(getStackTraceAsString(failure));
               } else {
                 b.status(Status.EXPIRY_SUCCESS);
               }

--- a/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/JdbcPersistenceSpi.java
+++ b/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/JdbcPersistenceSpi.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.gc.contents.jdbc;
 
+import static com.google.common.base.Throwables.getStackTraceAsString;
 import static org.projectnessie.gc.contents.jdbc.JdbcHelper.isIntegrityConstraintViolation;
 import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.ADD_CONTENT;
 import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.DELETE_FILE_DELETIONS;
@@ -164,7 +165,7 @@ public abstract class JdbcPersistenceSpi implements PersistenceSpi {
           stmt.setTimestamp(1, Timestamp.from(finished));
           if (failure != null) {
             stmt.setString(2, LiveContentSet.Status.EXPIRY_FAILED.name());
-            stmt.setString(3, trimError(failure.toString()));
+            stmt.setString(3, trimError(getStackTraceAsString(failure)));
           } else {
             stmt.setString(2, LiveContentSet.Status.EXPIRY_SUCCESS.name());
             stmt.setNull(3, Types.VARCHAR);


### PR DESCRIPTION
`o.p.gc.expire.local.DefaultLocalExpire.expire()` accidentally does not record a failure outcome (the `failure` parameter is always `null`, meaning "success").

This change fixes the above issue and also ensures to record the (truncated) stack trace and not just `Throwable.toString()`.