### PR TITLE
CLI: Add `REVERT CONTENT` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ as necessary. Empty sections will not end in the release notes.
 
 ### New Features
 
+- CLI: New `REVERT CONTENT` command to update one or more tables or views to a previous state.
+
 ### Changes
 
 - Catalog: ADLS + GCS credentials are no longer sent to the client. It is considered insecure to expose the

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/cli/BaseNessieCli.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/cli/BaseNessieCli.java
@@ -18,6 +18,7 @@ package org.projectnessie.nessie.cli.cli;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.jline.utils.AttributedStyle.BLUE;
+import static org.jline.utils.AttributedStyle.CYAN;
 import static org.jline.utils.AttributedStyle.GREEN;
 import static org.jline.utils.AttributedStyle.RED;
 import static org.jline.utils.AttributedStyle.YELLOW;
@@ -42,10 +43,20 @@ import org.projectnessie.model.Reference;
 public abstract class BaseNessieCli {
 
   public static final AttributedStyle STYLE_ERROR = AttributedStyle.DEFAULT.foreground(RED);
+  public static final AttributedStyle STYLE_FAIL = AttributedStyle.DEFAULT.bold().foreground(RED);
   public static final AttributedStyle STYLE_FAINT = AttributedStyle.DEFAULT.faint();
   public static final AttributedStyle STYLE_YELLOW = AttributedStyle.DEFAULT.foreground(YELLOW);
   public static final AttributedStyle STYLE_GREEN = AttributedStyle.DEFAULT.foreground(GREEN);
   public static final AttributedStyle STYLE_BLUE = AttributedStyle.DEFAULT.foreground(BLUE);
+  public static final AttributedStyle STYLE_SUCCESS = AttributedStyle.DEFAULT.foreground(GREEN);
+  public static final AttributedStyle STYLE_BOLD = AttributedStyle.DEFAULT.italic().bold();
+  public static final AttributedStyle STYLE_KEY = AttributedStyle.BOLD;
+  public static final AttributedStyle STYLE_COMMAND_NAME = AttributedStyle.BOLD;
+  public static final AttributedStyle STYLE_INFO = AttributedStyle.DEFAULT.foreground(CYAN);
+  public static final AttributedStyle STYLE_ITALIC_BOLD = AttributedStyle.DEFAULT.italic().bold();
+  public static final AttributedStyle STYLE_UNDERLINE_BOLD =
+      AttributedStyle.DEFAULT.underline().bold();
+  public static final AttributedStyle STYLE_HEADING = STYLE_UNDERLINE_BOLD;
 
   private Integer exitWithCode;
   private NessieApiV2 nessieApi;

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/cli/NessieCliImpl.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/cli/NessieCliImpl.java
@@ -466,7 +466,7 @@ public class NessieCliImpl extends BaseNessieCli implements Callable<Integer> {
       errMsg
           .append(e.toString(), STYLE_ERROR_HIGHLIGHT)
           .append('\n')
-          .append(stackTrace, AttributedStyle.DEFAULT.italic().bold());
+          .append(stackTrace, STYLE_ITALIC_BOLD);
     } else {
       errMsg
           .append(e.getClass().getSimpleName() + ": ", STYLE_ERROR_DELIGHT)

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/AssignReferenceCommand.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/AssignReferenceCommand.java
@@ -15,11 +15,13 @@
  */
 package org.projectnessie.nessie.cli.commands;
 
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_BOLD;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_FAINT;
+
 import jakarta.annotation.Nonnull;
 import java.io.PrintWriter;
 import java.util.List;
 import org.jline.utils.AttributedStringBuilder;
-import org.jline.utils.AttributedStyle;
 import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.Reference;
@@ -72,11 +74,11 @@ public class AssignReferenceCommand extends NessieCommand<AssignReferenceCommand
             .append("Assigned ")
             .append(assigned.getType().name())
             .append(' ')
-            .append(assigned.getName(), AttributedStyle.BOLD)
+            .append(assigned.getName(), STYLE_BOLD)
             .append(" from ")
-            .append(ref.getHash(), AttributedStyle.DEFAULT.faint())
+            .append(ref.getHash(), STYLE_FAINT)
             .append(" to ")
-            .append(assigned.getHash(), AttributedStyle.DEFAULT.faint()));
+            .append(assigned.getHash(), STYLE_FAINT));
   }
 
   public String name() {

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/CommandsFactory.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/CommandsFactory.java
@@ -41,6 +41,7 @@ public class CommandsFactory {
     COMMAND_FACTORIES.put(CommandType.SHOW_CONTENT, ShowContentCommand::new);
     COMMAND_FACTORIES.put(CommandType.SHOW_REFERENCE, ShowReferenceCommand::new);
     COMMAND_FACTORIES.put(CommandType.USE_REFERENCE, UseReferenceCommand::new);
+    COMMAND_FACTORIES.put(CommandType.REVERT_CONTENT, RevertContentCommand::new);
   }
 
   @SuppressWarnings({"rawtypes", "unchecked", "UnnecessaryLocalVariable"})

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/CreateReferenceCommand.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/CreateReferenceCommand.java
@@ -15,11 +15,13 @@
  */
 package org.projectnessie.nessie.cli.commands;
 
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_BOLD;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_FAINT;
+
 import jakarta.annotation.Nonnull;
 import java.io.PrintWriter;
 import java.util.List;
 import org.jline.utils.AttributedStringBuilder;
-import org.jline.utils.AttributedStyle;
 import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.error.NessieReferenceAlreadyExistsException;
 import org.projectnessie.model.Branch;
@@ -86,9 +88,9 @@ public class CreateReferenceCommand extends NessieCommand<CreateReferenceCommand
             .append("Created ")
             .append(created.getType().name())
             .append(' ')
-            .append(created.getName(), AttributedStyle.BOLD)
+            .append(created.getName(), STYLE_BOLD)
             .append(" at ")
-            .append(created.getHash(), AttributedStyle.DEFAULT.faint()));
+            .append(created.getHash(), STYLE_FAINT));
   }
 
   public String name() {

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/DropReferenceCommand.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/DropReferenceCommand.java
@@ -16,12 +16,13 @@
 package org.projectnessie.nessie.cli.commands;
 
 import static java.lang.String.format;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_BOLD;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_FAINT;
 
 import jakarta.annotation.Nonnull;
 import java.io.PrintWriter;
 import java.util.List;
 import org.jline.utils.AttributedStringBuilder;
-import org.jline.utils.AttributedStyle;
 import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.Reference;
@@ -73,9 +74,9 @@ public class DropReferenceCommand extends NessieCommand<DropReferenceCommandSpec
             .append("Deleted ")
             .append(deleted.getType().name())
             .append(' ')
-            .append(deleted.getName(), AttributedStyle.BOLD)
+            .append(deleted.getName(), STYLE_BOLD)
             .append(" at ")
-            .append(deleted.getHash(), AttributedStyle.DEFAULT.faint()));
+            .append(deleted.getHash(), STYLE_FAINT));
   }
 
   public String name() {

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/HelpCommand.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/HelpCommand.java
@@ -17,6 +17,8 @@ package org.projectnessie.nessie.cli.commands;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_COMMAND_NAME;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_HEADING;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,7 +33,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jline.utils.AttributedString;
 import org.jline.utils.AttributedStringBuilder;
-import org.jline.utils.AttributedStyle;
 import org.projectnessie.nessie.cli.cli.BaseNessieCli;
 import org.projectnessie.nessie.cli.cmdspec.CommandSpec;
 import org.projectnessie.nessie.cli.cmdspec.CommandType;
@@ -82,7 +83,6 @@ public class HelpCommand extends NessieListingCommand<HelpCommandSpec> {
 
   private static Stream<String> listAll(BaseNessieCli cli, List<CommandType> matches) {
     Stream<String> output;
-    AttributedStyle styleCommandName = AttributedStyle.DEFAULT.bold();
 
     output =
         matches.stream()
@@ -90,7 +90,7 @@ public class HelpCommand extends NessieListingCommand<HelpCommandSpec> {
             .flatMap(
                 c ->
                     Stream.of(
-                        new AttributedString(c.name(), styleCommandName).toAnsi(cli.terminal()),
+                        new AttributedString(c.name(), STYLE_COMMAND_NAME).toAnsi(cli.terminal()),
                         c.description(),
                         ""));
 
@@ -103,13 +103,12 @@ public class HelpCommand extends NessieListingCommand<HelpCommandSpec> {
 
     NessieCommand<CommandSpec> c = CommandsFactory.buildCommandInstance(commandType);
 
-    AttributedStyle styleCommandName = AttributedStyle.DEFAULT.bold();
     Stream<String> heading =
         Stream.of(
             "",
             new AttributedStringBuilder()
                 .append("Nessie CLI - ")
-                .append(c.name(), styleCommandName)
+                .append(c.name(), STYLE_COMMAND_NAME)
                 .append(" - ")
                 .append(c.description())
                 .toAnsi(cli.terminal()));
@@ -117,10 +116,8 @@ public class HelpCommand extends NessieListingCommand<HelpCommandSpec> {
     String extensionPlain = ".plain.txt";
     String extension = cli.dumbTerminal() ? extensionPlain : ".ansi.txt";
 
-    AttributedStyle styleHeading = AttributedStyle.DEFAULT.underline().bold();
-
     Stream<String> syntax =
-        Stream.of(new AttributedString("Syntax:", styleHeading).toAnsi(cli.terminal()), "");
+        Stream.of(new AttributedString("Syntax:", STYLE_HEADING).toAnsi(cli.terminal()), "");
 
     for (String nonTerminalRef : nonTerminalRefs(commandType.statementName())) {
       // .trim() would remove trailing ESC chars as well, but we need those for proper ANSI output.
@@ -144,7 +141,7 @@ public class HelpCommand extends NessieListingCommand<HelpCommandSpec> {
                 syntax,
                 Stream.of(
                     "\n"
-                        + new AttributedString(nonTerminalRef + ":", styleHeading)
+                        + new AttributedString(nonTerminalRef + ":", STYLE_HEADING)
                             .toAnsi(cli.terminal())
                         + "\n"));
       }
@@ -160,7 +157,7 @@ public class HelpCommand extends NessieListingCommand<HelpCommandSpec> {
                 isCommand
                     ? Stream.of(
                         "",
-                        new AttributedString("Description:", styleHeading).toAnsi(cli.terminal()),
+                        new AttributedString("Description:", STYLE_HEADING).toAnsi(cli.terminal()),
                         "",
                         help)
                     : Stream.of(help));

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/ListContentsCommand.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/ListContentsCommand.java
@@ -16,11 +16,11 @@
 package org.projectnessie.nessie.cli.commands;
 
 import static java.lang.String.format;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_FAINT;
 
 import java.util.List;
 import java.util.stream.Stream;
 import org.jline.utils.AttributedStringBuilder;
-import org.jline.utils.AttributedStyle;
 import org.projectnessie.client.api.GetEntriesBuilder;
 import org.projectnessie.nessie.cli.cli.BaseNessieCli;
 import org.projectnessie.nessie.cli.cmdspec.ListContentsCommandSpec;
@@ -54,12 +54,11 @@ public class ListContentsCommand extends NessieListingCommand<ListContentsComman
       entries.filter(filter);
     }
 
-    AttributedStyle faint = AttributedStyle.DEFAULT.faint();
     return entries.stream()
         .map(
             e ->
                 new AttributedStringBuilder()
-                    .append(format("%15s ", e.getType()), faint)
+                    .append(format("%15s ", e.getType()), STYLE_FAINT)
                     .append(e.getName().toString())
                     .toAnsi(cli.terminal()));
   }

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/ListReferencesCommand.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/ListReferencesCommand.java
@@ -16,11 +16,11 @@
 package org.projectnessie.nessie.cli.commands;
 
 import static java.lang.String.format;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_FAINT;
 
 import java.util.List;
 import java.util.stream.Stream;
 import org.jline.utils.AttributedStringBuilder;
-import org.jline.utils.AttributedStyle;
 import org.projectnessie.client.api.GetAllReferencesBuilder;
 import org.projectnessie.model.FetchOption;
 import org.projectnessie.nessie.cli.cli.BaseNessieCli;
@@ -61,10 +61,9 @@ public class ListReferencesCommand extends NessieListingCommand<ListReferencesCo
             ref ->
                 Stream.of(
                     new AttributedStringBuilder()
-                        .append(
-                            format(" %-6s ", ref.getType().name()), AttributedStyle.DEFAULT.faint())
+                        .append(format(" %-6s ", ref.getType().name()), STYLE_FAINT)
                         .append(ref.getName())
-                        .append(format(" @ %s", ref.getHash()), AttributedStyle.DEFAULT.faint())
+                        .append(format(" @ %s", ref.getHash()), STYLE_FAINT)
                         .toAnsi(cli.terminal())));
   }
 

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/MergeBranchCommand.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/MergeBranchCommand.java
@@ -16,9 +16,6 @@
 package org.projectnessie.nessie.cli.commands;
 
 import static java.lang.String.format;
-import static org.jline.utils.AttributedStyle.CYAN;
-import static org.jline.utils.AttributedStyle.GREEN;
-import static org.jline.utils.AttributedStyle.RED;
 
 import jakarta.annotation.Nonnull;
 import java.io.PrintWriter;
@@ -27,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import org.jline.terminal.Terminal;
 import org.jline.utils.AttributedStringBuilder;
-import org.jline.utils.AttributedStyle;
 import org.projectnessie.client.api.MergeReferenceBuilder;
 import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.model.Branch;
@@ -45,6 +41,7 @@ import org.projectnessie.nessie.cli.grammar.Node;
 import org.projectnessie.nessie.cli.grammar.Token;
 
 public class MergeBranchCommand extends NessieCommand<MergeBranchCommandSpec> {
+
   public MergeBranchCommand() {}
 
   @Override
@@ -117,13 +114,6 @@ public class MergeBranchCommand extends NessieCommand<MergeBranchCommandSpec> {
       cli.setCurrentReference(newTarget);
     }
 
-    AttributedStyle styleSuccess = AttributedStyle.DEFAULT.foreground(GREEN);
-    AttributedStyle styleFail = AttributedStyle.DEFAULT.bold().foreground(RED);
-    AttributedStyle styleFailFaint = AttributedStyle.DEFAULT.foreground(RED);
-    AttributedStyle styleFaint = AttributedStyle.DEFAULT.faint();
-    AttributedStyle styleKey = AttributedStyle.DEFAULT.bold();
-    AttributedStyle styleInfo = AttributedStyle.DEFAULT.foreground(CYAN);
-
     Terminal terminal = cli.terminal();
     @SuppressWarnings("resource")
     PrintWriter writer = cli.writer();
@@ -141,8 +131,8 @@ public class MergeBranchCommand extends NessieCommand<MergeBranchCommandSpec> {
     } else {
       writer.println(
           new AttributedStringBuilder()
-              .append(briefMessage, styleFail)
-              .append(" FAILED.", styleFail)
+              .append(briefMessage, BaseNessieCli.STYLE_FAIL)
+              .append(" FAILED.", BaseNessieCli.STYLE_FAIL)
               .toAnsi(terminal));
 
       detailsHeading = "\nConflicts:\n";
@@ -162,18 +152,21 @@ public class MergeBranchCommand extends NessieCommand<MergeBranchCommandSpec> {
               detail -> {
                 AttributedStringBuilder keyInfo =
                     new AttributedStringBuilder()
-                        .append(format("%-70s ", detail.getKey().toString()), styleKey)
-                        .append(format("%-7s", detail.getMergeBehavior().name()), styleFaint);
+                        .append(
+                            format("%-70s ", detail.getKey().toString()), BaseNessieCli.STYLE_KEY)
+                        .append(
+                            format("%-7s", detail.getMergeBehavior().name()),
+                            BaseNessieCli.STYLE_FAINT);
                 Conflict conflict = detail.getConflict();
                 if (conflict != null) {
                   keyInfo
                       .append(" ")
-                      .append(conflict.message(), styleFail)
-                      .append(" (", styleFaint)
-                      .append(conflict.conflictType().name(), styleFailFaint)
-                      .append(")", styleFaint);
+                      .append(conflict.message(), BaseNessieCli.STYLE_FAIL)
+                      .append(" (", BaseNessieCli.STYLE_FAINT)
+                      .append(conflict.conflictType().name(), BaseNessieCli.STYLE_ERROR)
+                      .append(")", BaseNessieCli.STYLE_FAINT);
                 } else {
-                  keyInfo.append(" ").append("OK", styleSuccess);
+                  keyInfo.append(" ").append("OK", BaseNessieCli.STYLE_SUCCESS);
                 }
                 writer.println(keyInfo.toAnsi(terminal));
               });
@@ -183,9 +176,9 @@ public class MergeBranchCommand extends NessieCommand<MergeBranchCommandSpec> {
       writer.println(
           new AttributedStringBuilder()
               .append("Target branch ")
-              .append(newTarget.getName(), styleSuccess)
+              .append(newTarget.getName(), BaseNessieCli.STYLE_SUCCESS)
               .append(" is now at commit ")
-              .append(newTarget.getHash(), styleInfo)
+              .append(newTarget.getHash(), BaseNessieCli.STYLE_INFO)
               .toAnsi(cli.terminal()));
     }
 

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/NessieCommittingCommand.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/NessieCommittingCommand.java
@@ -15,13 +15,12 @@
  */
 package org.projectnessie.nessie.cli.commands;
 
-import static org.jline.utils.AttributedStyle.CYAN;
-import static org.jline.utils.AttributedStyle.GREEN;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_INFO;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_SUCCESS;
 
 import jakarta.annotation.Nonnull;
 import java.io.PrintWriter;
 import org.jline.utils.AttributedStringBuilder;
-import org.jline.utils.AttributedStyle;
 import org.projectnessie.client.api.CommitMultipleOperationsBuilder;
 import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.model.Branch;
@@ -58,6 +57,9 @@ public abstract class NessieCommittingCommand<SPEC extends CommandSpec>
     commit.branch((Branch) ref);
 
     CommitResponse committed = executeCommitting(cli, spec, branch, commit);
+    if (committed == null) {
+      return;
+    }
 
     if (cli.getCurrentReference().getName().equals(committed.getTargetBranch().getName())) {
       cli.setCurrentReference(committed.getTargetBranch());
@@ -68,10 +70,9 @@ public abstract class NessieCommittingCommand<SPEC extends CommandSpec>
     writer.println(
         new AttributedStringBuilder()
             .append("Target branch ")
-            .append(
-                committed.getTargetBranch().getName(), AttributedStyle.DEFAULT.foreground(GREEN))
+            .append(committed.getTargetBranch().getName(), STYLE_SUCCESS)
             .append(" is now at commit ")
-            .append(committed.getTargetBranch().getHash(), AttributedStyle.DEFAULT.foreground(CYAN))
+            .append(committed.getTargetBranch().getHash(), STYLE_INFO)
             .toAnsi(cli.terminal()));
   }
 

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/RevertContentCommand.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/RevertContentCommand.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.cli.commands;
+
+import static java.util.Objects.requireNonNull;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_BOLD;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_ERROR;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_FAIL;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_FAINT;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_INFO;
+
+import jakarta.annotation.Nonnull;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.jline.terminal.Terminal;
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStringBuilder;
+import org.projectnessie.client.api.CommitMultipleOperationsBuilder;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.CommitResponse;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.GetMultipleContentsResponse;
+import org.projectnessie.model.Operation;
+import org.projectnessie.model.Reference;
+import org.projectnessie.nessie.cli.cli.BaseNessieCli;
+import org.projectnessie.nessie.cli.cli.CliCommandFailedException;
+import org.projectnessie.nessie.cli.cmdspec.RevertContentCommandSpec;
+import org.projectnessie.nessie.cli.grammar.Node;
+import org.projectnessie.nessie.cli.grammar.Token;
+import org.projectnessie.nessie.cli.jsonpretty.JsonPretty;
+
+public class RevertContentCommand extends NessieCommittingCommand<RevertContentCommandSpec> {
+
+  @Override
+  protected CommitResponse executeCommitting(
+      @Nonnull BaseNessieCli cli,
+      RevertContentCommandSpec spec,
+      Branch branch,
+      CommitMultipleOperationsBuilder commit)
+      throws Exception {
+
+    List<ContentKey> contentKeys =
+        spec.getContentKeys().stream().map(ContentKey::fromPathString).collect(Collectors.toList());
+
+    String refName =
+        spec.getSourceRef() != null ? spec.getSourceRef() : cli.getCurrentReference().getName();
+    @SuppressWarnings("resource")
+    GetMultipleContentsResponse contents =
+        cli.mandatoryNessieApi()
+            .getContent()
+            .refName(refName)
+            .hashOnRef(spec.getSourceRefTimestampOrHash())
+            .keys(contentKeys)
+            .getWithResponse();
+
+    Terminal terminal = cli.terminal();
+    PrintWriter writer = cli.writer();
+
+    Map<ContentKey, Content> contentsMap = contents.toContentsMap();
+    Reference effectiveReference =
+        requireNonNull(
+            contents.getEffectiveReference(), "No effective reference, Nessie API v2 required");
+    boolean fail = false;
+    for (ContentKey contentKey : contentKeys) {
+      Content content = contentsMap.get(contentKey);
+      if (content != null) {
+        commit.operation(Operation.Put.of(contentKey, content));
+      } else if (spec.isAllowDeletes()) {
+        commit.operation(Operation.Delete.of(contentKey));
+      } else {
+        writer.println(
+            new AttributedStringBuilder()
+                .append("Content key ", STYLE_ERROR)
+                .append(contentKey.toPathString(), STYLE_FAIL)
+                .append(" does not exist and ALLOW DELETES clause was not specified.", STYLE_ERROR)
+                .toAnsi(terminal));
+        fail = true;
+      }
+    }
+    if (fail) {
+      throw new CliCommandFailedException();
+    }
+
+    String refStr =
+        String.format(
+            "%s %s at %s",
+            effectiveReference.getType().name().toLowerCase(Locale.ROOT),
+            effectiveReference.getName(),
+            effectiveReference.getHash());
+
+    CommitResponse committed;
+    String prevHash;
+    if (spec.isDryRun()) {
+      committed = null;
+      prevHash = branch.getHash();
+    } else {
+      committed =
+          commit
+              .commitMeta(
+                  CommitMeta.fromMessage("Revert " + contentKeys + " to state on " + refStr))
+              .commitWithResponse();
+      prevHash = committed.getTargetBranch().getHash() + "~1";
+    }
+
+    @SuppressWarnings("resource")
+    GetMultipleContentsResponse previousContentsResponse =
+        cli.mandatoryNessieApi()
+            .getContent()
+            .refName(branch.getName())
+            .hashOnRef(prevHash)
+            .keys(contentKeys)
+            .getWithResponse();
+
+    Reference prevRef =
+        requireNonNull(previousContentsResponse.getEffectiveReference(), "Require Nessie API v2");
+
+    writer.println(
+        new AttributedStringBuilder()
+            .append("Reverted content keys ")
+            .append(
+                contentKeys.stream()
+                    .map(ContentKey::toPathString)
+                    .collect(Collectors.joining(", ")),
+                STYLE_BOLD)
+            .append(" to state on ")
+            .append(refStr, STYLE_BOLD)
+            .append(" from hash ")
+            .append(prevRef.getHash(), STYLE_BOLD)
+            .append(" :"));
+
+    JsonPretty jsonPretty = new JsonPretty(terminal, writer);
+
+    Map<ContentKey, Content> previousContents = previousContentsResponse.toContentsMap();
+    for (ContentKey contentKey : contentKeys) {
+      Content content = contentsMap.get(contentKey);
+      if (content != null) {
+        writer.println(
+            new AttributedStringBuilder()
+                .append("  Key ", STYLE_FAINT)
+                .append(contentKey.toPathString(), STYLE_BOLD)
+                .append(" updated from", STYLE_FAINT)
+                .toAnsi(terminal));
+        jsonPretty.prettyPrintObject(previousContents.get(contentKey));
+        writer.println(
+            new AttributedStringBuilder().append("    to ", STYLE_FAINT).toAnsi(terminal));
+        jsonPretty.prettyPrintObject(content);
+      } else if (spec.isAllowDeletes()) {
+        writer.println(
+            new AttributedStringBuilder()
+                .append("  Key ", STYLE_FAINT)
+                .append(contentKey.toPathString(), STYLE_BOLD)
+                .append(" was deleted", STYLE_FAINT)
+                .toAnsi(terminal));
+      }
+    }
+
+    if (spec.isDryRun()) {
+      writer.println(
+          new AttributedString("Dry run, not committing any changes.", STYLE_INFO)
+              .toAnsi(terminal));
+    }
+    return committed;
+  }
+
+  public String name() {
+    return Token.TokenType.REVERT + " " + Token.TokenType.CONTENT;
+  }
+
+  public String description() {
+    return "Create a new namespace.";
+  }
+
+  @Override
+  public List<List<Node.NodeType>> matchesNodeTypes() {
+    return List.of(
+        List.of(Token.TokenType.REVERT), List.of(Token.TokenType.REVERT, Token.TokenType.CONTENT));
+  }
+}

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/ShowContentCommand.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/ShowContentCommand.java
@@ -15,6 +15,9 @@
  */
 package org.projectnessie.nessie.cli.commands;
 
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_BOLD;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_FAINT;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.Nonnull;
@@ -68,8 +71,6 @@ public class ShowContentCommand extends NessieListingCommand<ShowContentCommandS
               + response.getEffectiveReference().getHash());
     }
 
-    AttributedStyle faint = AttributedStyle.DEFAULT.faint();
-
     Terminal terminal = cli.terminal();
 
     StringWriter sw = new StringWriter();
@@ -78,17 +79,17 @@ public class ShowContentCommand extends NessieListingCommand<ShowContentCommandS
       writer.println(
           new AttributedStringBuilder()
               .append("Content type: ")
-              .append(content.getType().name(), faint)
+              .append(content.getType().name(), STYLE_FAINT)
               .toAnsi(terminal));
       writer.println(
           new AttributedStringBuilder()
               .append(" Content Key: ")
-              .append(key.toPathString(), AttributedStyle.BOLD)
+              .append(key.toPathString(), STYLE_BOLD)
               .toAnsi(terminal));
       writer.println(
           new AttributedStringBuilder()
               .append("          ID: ")
-              .append(content.getId(), faint)
+              .append(content.getId(), STYLE_FAINT)
               .toAnsi(terminal));
       terminal.writer().println("        JSON: ");
 

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/ShowLogCommand.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/ShowLogCommand.java
@@ -15,7 +15,8 @@
  */
 package org.projectnessie.nessie.cli.commands;
 
-import static org.jline.utils.AttributedStyle.YELLOW;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_FAINT;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_YELLOW;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -58,9 +59,6 @@ public class ShowLogCommand extends NessieListingCommand<ShowLogCommandSpec> {
       logStream = logStream.limit(spec.getLimit());
     }
 
-    AttributedStyle yellow = AttributedStyle.DEFAULT.foreground(YELLOW);
-    AttributedStyle faint = AttributedStyle.DEFAULT.faint();
-
     DateTimeFormatter dateTimeFormatter =
         DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.LONG)
             .withZone(ZoneId.systemDefault());
@@ -74,26 +72,27 @@ public class ShowLogCommand extends NessieListingCommand<ShowLogCommandSpec> {
 
           Stream<String> header =
               Stream.of(
-                  new AttributedString("commit " + meta.getHash(), yellow).toAnsi(cli.terminal()),
+                  new AttributedString("commit " + meta.getHash(), STYLE_YELLOW)
+                      .toAnsi(cli.terminal()),
                   new AttributedStringBuilder()
-                      .append("Author:  ", faint)
+                      .append("Author:  ", STYLE_FAINT)
                       .append(
                           meta.getAuthor() == null || meta.getAuthor().isEmpty()
                               ? "<no author>"
                               : meta.getAuthor(),
                           meta.getAuthor() == null || meta.getAuthor().isEmpty()
-                              ? faint
+                              ? STYLE_FAINT
                               : AttributedStyle.DEFAULT)
                       .toAnsi(cli.terminal()),
                   new AttributedStringBuilder()
-                      .append("Date:    ", faint)
+                      .append("Date:    ", STYLE_FAINT)
                       .append(dateTimeFormatter.format(authorTimestamp))
-                      .append(" (committed: ", faint)
-                      .append(DateTimeFormatter.ISO_DATE_TIME.format(commitTimestamp), faint)
-                      .append(")", faint)
+                      .append(" (committed: ", STYLE_FAINT)
+                      .append(DateTimeFormatter.ISO_DATE_TIME.format(commitTimestamp), STYLE_FAINT)
+                      .append(")", STYLE_FAINT)
                       .toAnsi(cli.terminal()),
                   new AttributedStringBuilder()
-                      .append("Parents: ", faint)
+                      .append("Parents: ", STYLE_FAINT)
                       .append(String.join(", ", meta.getParentCommitHashes()))
                       .toAnsi(cli.terminal()),
                   "");

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/ShowReferenceCommand.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/ShowReferenceCommand.java
@@ -15,11 +15,12 @@
  */
 package org.projectnessie.nessie.cli.commands;
 
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_FAINT;
+
 import jakarta.annotation.Nonnull;
 import java.util.List;
 import org.jline.terminal.Terminal;
 import org.jline.utils.AttributedStringBuilder;
-import org.jline.utils.AttributedStyle;
 import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
@@ -45,15 +46,13 @@ public class ShowReferenceCommand extends NessieCommand<ShowReferenceCommandSpec
 
     Reference ref = api.getReference().refName(refName).get();
 
-    AttributedStyle faint = AttributedStyle.DEFAULT.faint();
-
     Terminal terminal = cli.terminal();
     terminal
         .writer()
         .println(
             new AttributedStringBuilder()
                 .append("Reference type: ")
-                .append(ref.getType().name(), faint)
+                .append(ref.getType().name(), STYLE_FAINT)
                 .toAnsi(terminal));
     terminal
         .writer()
@@ -67,7 +66,7 @@ public class ShowReferenceCommand extends NessieCommand<ShowReferenceCommandSpec
         .println(
             new AttributedStringBuilder()
                 .append("      Tip/HEAD: ")
-                .append(ref.getHash(), faint)
+                .append(ref.getHash(), STYLE_FAINT)
                 .toAnsi(terminal));
   }
 

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/UseReferenceCommand.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/UseReferenceCommand.java
@@ -15,11 +15,13 @@
  */
 package org.projectnessie.nessie.cli.commands;
 
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_BOLD;
+import static org.projectnessie.nessie.cli.cli.BaseNessieCli.STYLE_FAINT;
+
 import jakarta.annotation.Nonnull;
 import java.io.PrintWriter;
 import java.util.List;
 import org.jline.utils.AttributedStringBuilder;
-import org.jline.utils.AttributedStyle;
 import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.model.Reference;
 import org.projectnessie.nessie.cli.cli.BaseNessieCli;
@@ -46,9 +48,9 @@ public class UseReferenceCommand extends NessieCommand<UseReferenceCommandSpec> 
     writer.println(
         new AttributedStringBuilder()
             .append("Using ")
-            .append(ref.getName(), AttributedStyle.BOLD)
+            .append(ref.getName(), STYLE_BOLD)
             .append(" at ")
-            .append(ref.getHash(), AttributedStyle.DEFAULT.faint()));
+            .append(ref.getHash(), STYLE_FAINT));
   }
 
   public String name() {

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/jsonpretty/JsonPretty.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/jsonpretty/JsonPretty.java
@@ -19,6 +19,8 @@ import static org.jline.utils.AttributedStyle.CYAN;
 import static org.jline.utils.AttributedStyle.GREEN;
 import static org.jline.utils.AttributedStyle.YELLOW;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.PrintWriter;
 import org.jline.terminal.Terminal;
 import org.jline.utils.AttributedString;
@@ -31,16 +33,31 @@ public class JsonPretty {
   private final Terminal terminal;
   private final PrintWriter writer;
 
-  private final AttributedStyle styleBool = AttributedStyle.DEFAULT.bold().foreground(YELLOW);
-  private final AttributedStyle styleNull = AttributedStyle.DEFAULT.bold().foreground(YELLOW);
-  private final AttributedStyle styleString = AttributedStyle.DEFAULT.bold().foreground(GREEN);
-  private final AttributedStyle styleNumber = AttributedStyle.DEFAULT.foreground(CYAN);
-  private final AttributedStyle styleSeparator = AttributedStyle.DEFAULT;
-  private final AttributedStyle styleBracketBrace = AttributedStyle.DEFAULT;
+  private static final AttributedStyle STYLE_BOOL =
+      AttributedStyle.DEFAULT.bold().foreground(YELLOW);
+  private static final AttributedStyle STYLE_NULL =
+      AttributedStyle.DEFAULT.bold().foreground(YELLOW);
+  private static final AttributedStyle STYLE_STRING =
+      AttributedStyle.DEFAULT.bold().foreground(GREEN);
+  private static final AttributedStyle STYLE_NUMBER = AttributedStyle.DEFAULT.foreground(CYAN);
+  private static final AttributedStyle STYLE_SEPARATOR = AttributedStyle.DEFAULT;
+  private static final AttributedStyle STYLE_BRACKET_BRACE = AttributedStyle.DEFAULT;
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   public JsonPretty(Terminal terminal, PrintWriter writer) {
     this.terminal = terminal;
     this.writer = writer;
+  }
+
+  public void prettyPrintObject(Object object) {
+    String str = null;
+    try {
+      str = MAPPER.writeValueAsString(object);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+    prettyPrint(str);
   }
 
   public void prettyPrint(String jsonString) {
@@ -60,7 +77,7 @@ public class JsonPretty {
           //
         case OPEN_BRACKET:
         case OPEN_BRACE:
-          print(t, styleBracketBrace);
+          print(t, STYLE_BRACKET_BRACE);
           indent++;
           newLine(indent);
           break;
@@ -68,28 +85,28 @@ public class JsonPretty {
         case CLOSE_BRACE:
           indent--;
           newLine(indent);
-          print(t, styleBracketBrace);
+          print(t, STYLE_BRACKET_BRACE);
           break;
         case COMMA:
-          print(t, styleSeparator);
+          print(t, STYLE_SEPARATOR);
           newLine(indent);
           break;
         case COLON:
-          print(t, styleSeparator);
+          print(t, STYLE_SEPARATOR);
           printSpace();
           break;
         case NULL:
-          print(t, styleNull);
+          print(t, STYLE_NULL);
           break;
         case TRUE:
         case FALSE:
-          print(t, styleBool);
+          print(t, STYLE_BOOL);
           break;
         case NUMBER:
-          print(t, styleNumber);
+          print(t, STYLE_NUMBER);
           break;
         case STRING_LITERAL:
-          print(t, styleString);
+          print(t, STYLE_STRING);
           break;
           //
         case SINGLE_LINE_COMMENT:

--- a/cli/cli/src/test/java/org/projectnessie/nessie/cli/commands/TestRevertContent.java
+++ b/cli/cli/src/test/java/org/projectnessie/nessie/cli/commands/TestRevertContent.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.cli.commands;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.CommitResponse;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.Namespace;
+import org.projectnessie.model.Operation;
+import org.projectnessie.model.Reference;
+import org.projectnessie.nessie.cli.cli.CliCommandFailedException;
+import org.projectnessie.nessie.cli.cmdspec.ImmutableListContentsCommandSpec;
+import org.projectnessie.nessie.cli.cmdspec.ImmutableRevertContentCommandSpec;
+import org.projectnessie.nessie.cli.cmdspec.ListContentsCommandSpec;
+import org.projectnessie.nessie.cli.cmdspec.RevertContentCommandSpec;
+
+public class TestRevertContent extends BaseTestCommand {
+  @Test
+  public void revertContent() throws Exception {
+    try (NessieCliTester cli = nessieCliTester()) {
+      Branch beginning = (Branch) cli.getCurrentReference();
+
+      ContentKey t1 = ContentKey.of("t1");
+      ContentKey t2 = ContentKey.of("t2");
+      ContentKey t3 = ContentKey.of("t3");
+      IcebergTable t1c1 = IcebergTable.of("t1c1", 1, 2, 3, 4);
+      IcebergTable t1c2 = IcebergTable.of("t1c2", 5, 6, 7, 8);
+      IcebergTable t2c2 = IcebergTable.of("t2c2", 42, 6, 7, 8);
+      IcebergTable t3c1 = IcebergTable.of("t3c1", 66, 6, 7, 8);
+
+      CommitResponse c1 =
+          cli.mandatoryNessieApi()
+              .commitMultipleOperations()
+              .branch(beginning)
+              .operation(Operation.Put.of(t1, t1c1))
+              .operation(Operation.Put.of(t3, t3c1))
+              .commitMeta(CommitMeta.fromMessage("c1"))
+              .commitWithResponse();
+
+      t1c1 = t1c1.withId(c1.toAddedContentsMap().get(t1));
+      t1c2 = t1c2.withId(c1.toAddedContentsMap().get(t1));
+      t3c1 = t3c1.withId(c1.toAddedContentsMap().get(t3));
+
+      CommitResponse c2 =
+          cli.mandatoryNessieApi()
+              .commitMultipleOperations()
+              .branch(c1.getTargetBranch())
+              .operation(Operation.Put.of(t1, t1c2))
+              .operation(Operation.Put.of(t2, t2c2))
+              .commitMeta(CommitMeta.fromMessage("c2"))
+              .commitWithResponse();
+
+      t2c2 = t2c2.withId(c2.toAddedContentsMap().get(t2));
+
+      ListContentsCommandSpec listContents =
+          ImmutableListContentsCommandSpec.of(null, null, null, null, null, null);
+      soft.assertThat(cli.execute(listContents))
+          .containsExactly("  ICEBERG_TABLE t1", "  ICEBERG_TABLE t2", "  ICEBERG_TABLE t3");
+
+      // A dummy commit to have a different "from" hash than c2
+
+      CommitResponse c3 =
+          cli.mandatoryNessieApi()
+              .commitMultipleOperations()
+              .branch(c1.getTargetBranch())
+              .operation(Operation.Put.of(ContentKey.of("dummy"), Namespace.of("dummy")))
+              .commitMeta(CommitMeta.fromMessage("dummy"))
+              .commitWithResponse();
+
+      cli.setCurrentReference(c3.getTargetBranch());
+
+      // DRY run of REVERT CONTENT where all keys exist (no ALLOW DELETES)
+
+      RevertContentCommandSpec revertContentDry1 =
+          ImmutableRevertContentCommandSpec.builder()
+              .sourceRefTimestampOrHash(c2.getTargetBranch().getHash())
+              .contentKeys(List.of(t1.toPathString(), t2.toPathString(), t3.toPathString()))
+              .isDryRun(true)
+              .build();
+      List<String> executedDry1 = cli.execute(revertContentDry1);
+      soft.assertThat(executedDry1)
+          .contains(
+              "Reverted content keys t1, t2, t3 to state on branch main at "
+                  + c2.getTargetBranch().getHash()
+                  + " from hash "
+                  + c3.getTargetBranch().getHash()
+                  + " :")
+          .contains("  Key t1 updated from")
+          .contains("  Key t2 updated from")
+          .contains("  Key t3 updated from")
+          .contains("Dry run, not committing any changes.");
+
+      // REVERT CONTENT where all keys exist (no ALLOW DELETES)
+
+      RevertContentCommandSpec revertContent1 =
+          ImmutableRevertContentCommandSpec.builder()
+              .sourceRefTimestampOrHash(c2.getTargetBranch().getHash())
+              .contentKeys(List.of(t1.toPathString(), t2.toPathString(), t3.toPathString()))
+              .build();
+      List<String> executed1 = cli.execute(revertContent1);
+      soft.assertThat(executed1)
+          .contains(
+              "Reverted content keys t1, t2, t3 to state on branch main at "
+                  + c2.getTargetBranch().getHash()
+                  + " from hash "
+                  + c3.getTargetBranch().getHash()
+                  + " :")
+          .contains("  Key t1 updated from")
+          .contains("  Key t2 updated from")
+          .contains("  Key t3 updated from")
+          .anyMatch(s -> s.startsWith("Target branch main is now at commit "));
+
+      soft.assertThat(
+              cli.mandatoryNessieApi()
+                  .getContent()
+                  .keys(List.of(t1, t2, t3))
+                  .refName(beginning.getName())
+                  .get())
+          .containsAllEntriesOf(Map.of(t1, t1c2, t2, t2c2, t3, t3c1));
+
+      // Must fail without ALLOW DELETES, also for DRY
+
+      RevertContentCommandSpec revertContent2 =
+          ImmutableRevertContentCommandSpec.builder()
+              .sourceRefTimestampOrHash(c1.getTargetBranch().getHash())
+              .contentKeys(List.of(t1.toPathString(), t2.toPathString(), t3.toPathString()))
+              .build();
+      soft.assertThatThrownBy(() -> cli.execute(revertContent2))
+          .isInstanceOf(CliCommandFailedException.class);
+      soft.assertThat(cli.capturedOutput())
+          .contains(
+              "Content key "
+                  + t2.toPathString()
+                  + " does not exist and ALLOW DELETES clause was not specified.");
+
+      RevertContentCommandSpec revertContent2a =
+          ImmutableRevertContentCommandSpec.builder()
+              .sourceRefTimestampOrHash(c1.getTargetBranch().getHash())
+              .contentKeys(List.of(t1.toPathString(), t2.toPathString(), t3.toPathString()))
+              .isDryRun(true)
+              .build();
+      soft.assertThatThrownBy(() -> cli.execute(revertContent2a))
+          .isInstanceOf(CliCommandFailedException.class);
+      soft.assertThat(cli.capturedOutput())
+          .contains(
+              "Content key "
+                  + t2.toPathString()
+                  + " does not exist and ALLOW DELETES clause was not specified.");
+
+      Reference head = cli.mandatoryNessieApi().getReference().refName("main").get();
+
+      // DRY run with ALLOW DELETES
+
+      RevertContentCommandSpec revertContentDry3 =
+          ImmutableRevertContentCommandSpec.builder()
+              .sourceRefTimestampOrHash(c1.getTargetBranch().getHash())
+              .contentKeys(List.of(t1.toPathString(), t2.toPathString(), t3.toPathString()))
+              .isDryRun(true)
+              .isAllowDeletes(true)
+              .build();
+      List<String> executedDry3 = cli.execute(revertContentDry3);
+      soft.assertThat(executedDry3)
+          .contains(
+              "Reverted content keys t1, t2, t3 to state on branch main at "
+                  + c1.getTargetBranch().getHash()
+                  + " from hash "
+                  + head.getHash()
+                  + " :")
+          .contains("  Key t1 updated from")
+          .contains("  Key t2 was deleted")
+          .contains("  Key t3 updated from")
+          .contains("Dry run, not committing any changes.");
+
+      // With ALLOW DELETES
+
+      RevertContentCommandSpec revertContent3 =
+          ImmutableRevertContentCommandSpec.builder()
+              .sourceRefTimestampOrHash(c1.getTargetBranch().getHash())
+              .contentKeys(List.of(t1.toPathString(), t2.toPathString(), t3.toPathString()))
+              .isAllowDeletes(true)
+              .build();
+      List<String> executed3 = cli.execute(revertContent3);
+      soft.assertThat(executed3)
+          .contains(
+              "Reverted content keys t1, t2, t3 to state on branch main at "
+                  + c1.getTargetBranch().getHash()
+                  + " from hash "
+                  + head.getHash()
+                  + " :")
+          .contains("  Key t1 updated from")
+          .contains("  Key t2 was deleted")
+          .contains("  Key t3 updated from")
+          .anyMatch(s -> s.startsWith("Target branch main is now at commit "));
+
+      soft.assertThat(
+              cli.mandatoryNessieApi()
+                  .getContent()
+                  .keys(List.of(t1, t2, t3))
+                  .refName(beginning.getName())
+                  .get())
+          .containsAllEntriesOf(Map.of(t1, t1c1, t3, t3c1))
+          .doesNotContainKey(t2);
+    }
+  }
+}

--- a/cli/grammar/src/main/congocc/nessie/nessie-cli-java.ccc
+++ b/cli/grammar/src/main/congocc/nessie/nessie-cli-java.ccc
@@ -163,6 +163,73 @@ import org.projectnessie.nessie.cli.cmdspec.*;
   }
 }
 
+INJECT RevertContentStatement : implements RevertContentCommandSpec;
+INJECT RevertContentStatement :
+import org.projectnessie.nessie.cli.cmdspec.*;
+{
+
+  @Override
+  public boolean isDryRun() {
+    return getNamedChild("dryRun")!=null;
+  }
+
+  @Override
+  public boolean isAllowDeletes() {
+    return getNamedChild("allowDeletes")!=null;
+  }
+
+  @Override
+  public String getRef() {
+    return stringValueOf("ref");
+  }
+
+  @Override
+  public String getRefType() {
+    Node type = getNamedChild("type");
+    return type != null ? type.getSource().toUpperCase() : null;
+  }
+
+  @Override
+  public String getSourceRef() {
+    return stringValueOf("sourceRef");
+  }
+
+  @Override
+  public String getSourceRefType() {
+    Node type = getNamedChild("sourceType");
+    return type != null ? type.getSource().toUpperCase() : null;
+  }
+
+  @Override
+  public String getSourceRefTimestampOrHash() {
+    return stringValueOf("sourceAt");
+  }
+
+  @Override
+  public List<String> getContentKeys() {
+    List<String> contentKeys = new ArrayList<>();
+    List<Node> children = children();
+    for (int i = 0; i < children.size(); i++) {
+      Node child = children.get(i);
+      if (child.getType() == OF) {
+        for (i++; i < children.size(); ) {
+          Node key = children.get(i++);
+
+          contentKeys.add(
+            ((IdentifierOrLiteral)key).getStringValue()
+          );
+
+          if (children.size() == i || children.get(i++).getType() != AND) {
+              break;
+          }
+        }
+        break;
+      }
+    }
+    return contentKeys;
+  }
+}
+
 INJECT CreateReferenceStatement : implements CreateReferenceCommandSpec;
 INJECT CreateReferenceStatement :
 import org.projectnessie.nessie.cli.cmdspec.*;

--- a/cli/grammar/src/main/congocc/nessie/nessie-cli-lexer.ccc
+++ b/cli/grammar/src/main/congocc/nessie/nessie-cli-lexer.ccc
@@ -29,6 +29,7 @@ TOKEN #Command
   | <MERGE: "MERGE">
   | <ASSIGN: "ASSIGN">
   | <CREATE: "CREATE">
+  | <REVERT: "REVERT">
   | <CONNECT: "CONNECT">
   ;
 
@@ -40,6 +41,7 @@ TOKEN
 TOKEN #Keyword
   : <AT: "AT">
   | <IF: "IF">
+  | <OF: "OF">
   | <ON: "ON">
   | <TO: "TO">
   | <AND: "AND">
@@ -51,8 +53,10 @@ TOKEN #Keyword
   | <INTO: "INTO">
   | <VIEW: "VIEW">
   | <WITH: "WITH">
+  | <ALLOW: "ALLOW">
   | <FORCE: "FORCE">
   | <LIMIT: "LIMIT">
+  | <STATE: "STATE">
   | <TABLE: "TABLE">
   | <USING: "USING">
   | <COMMIT: "COMMIT">
@@ -61,6 +65,7 @@ TOKEN #Keyword
   | <NORMAL: "NORMAL">
   | <REMOVE: "REMOVE">
   | <CONTENT: "CONTENT">
+  | <DELETES: "DELETES">
   | <LICENSE: "LICENSE">
   | <BEHAVIOR: "BEHAVIOR">
   | <CONTENTS: "CONTENTS">

--- a/cli/grammar/src/main/congocc/nessie/nessie-cli.ccc
+++ b/cli/grammar/src/main/congocc/nessie/nessie-cli.ccc
@@ -57,6 +57,7 @@ Statement
   | AlterStatement
   | DropStatement
   | AssignReferenceStatement
+  | RevertContentStatement
   | UseReferenceStatement
   | ListStatement
   | ShowStatement
@@ -77,6 +78,7 @@ HelpStatement
           TokenType.SHOW,
           TokenType.ASSIGN,
           TokenType.MERGE,
+          TokenType.REVERT,
           TokenType.HELP,
           TokenType.EXIT,
           TokenType.LICENSE
@@ -113,6 +115,7 @@ HelpStatement
              { setOptionalNextTokenTypes(); }
            ]
          | <MERGE>
+         | <REVERT>
          | <HELP>
          | <EXIT>
          | <LICENSE>
@@ -188,6 +191,69 @@ CreateNamespaceStatement
           Value
           { setOptionalNextTokenTypes(TokenType.AND); }
         )*
+      ]
+    ;
+
+RevertContentStatement
+    : <REVERT>
+      <CONTENT>
+      { setOptionalNextTokenTypes(TokenType.DRY); }
+      [ /dryRun/=<DRY>
+        { setOptionalNextTokenTypes(); }
+      ]
+      <OF>
+      { setOptionalNextTokenTypes();
+        completionType = CompletionType.CONTENT_KEY; }
+      ContentKey
+      { completionType = CompletionType.NONE;
+        setOptionalNextTokenTypes(TokenType.ON, TokenType.AND); }
+      ( <AND>
+        { completionType = CompletionType.CONTENT_KEY;
+          setOptionalNextTokenTypes(); }
+        ContentKey
+        { completionType = CompletionType.NONE;
+          setOptionalNextTokenTypes(TokenType.ON, TokenType.AND); }
+      )*
+      [ <ON>
+        { setOptionalNextTokenTypes(TokenType.BRANCH); }
+        [ /type/=ReferenceType
+          { setOptionalNextTokenTypes(); }
+          ]
+        { completionType = CompletionType.REFERENCE_NAME; }
+        /ref/=ExistingReference
+        { completionType = CompletionType.NONE; }
+      ]
+      <TO> <STATE>
+      (
+        <ON>
+        { setOptionalNextTokenTypes(TokenType.BRANCH, TokenType.TAG); }
+        [ /sourceType/=ReferenceType
+          { setOptionalNextTokenTypes(); }
+          ]
+        { completionType = CompletionType.REFERENCE_NAME; }
+        /sourceRef/=ExistingReference
+        { completionType = CompletionType.NONE;
+          setOptionalNextTokenTypes(TokenType.ALLOW, TokenType.AT); }
+        [ <AT>
+          { setOptionalNextTokenTypes(TokenType.TIMESTAMP, TokenType.COMMIT); }
+          [ <TIMESTAMP> | <COMMIT>
+            { setOptionalNextTokenTypes(); }
+          ]
+          /sourceAt/=TimestampOrCommit
+          { setOptionalNextTokenTypes(TokenType.ALLOW); }
+        ]
+      |
+        <AT>
+        { setOptionalNextTokenTypes(TokenType.TIMESTAMP, TokenType.COMMIT); }
+        [ <TIMESTAMP> | <COMMIT>
+          { setOptionalNextTokenTypes(); }
+        ]
+        /sourceAt/=TimestampOrCommit
+        { setOptionalNextTokenTypes(TokenType.ALLOW); }
+      )
+      [ <ALLOW>
+        { setOptionalNextTokenTypes(); }
+        /allowDeletes/=<DELETES>
       ]
     ;
 

--- a/cli/grammar/src/main/java/org/projectnessie/nessie/cli/cmdspec/CommandType.java
+++ b/cli/grammar/src/main/java/org/projectnessie/nessie/cli/cmdspec/CommandType.java
@@ -28,6 +28,7 @@ public enum CommandType {
   LIST_CONTENTS("ListContentsStatement"),
   LIST_REFERENCES("ListReferencesStatement"),
   MERGE_BRANCH("MergeBranchStatement"),
+  REVERT_CONTENT("RevertContentStatement"),
   SHOW_LOG("ShowLogStatement"),
   SHOW_CONTENT("ShowContentStatement"),
   SHOW_REFERENCE("ShowReferenceStatement"),

--- a/cli/grammar/src/main/java/org/projectnessie/nessie/cli/cmdspec/RevertContentCommandSpec.java
+++ b/cli/grammar/src/main/java/org/projectnessie/nessie/cli/cmdspec/RevertContentCommandSpec.java
@@ -16,21 +16,21 @@
 package org.projectnessie.nessie.cli.cmdspec;
 
 import jakarta.annotation.Nullable;
-import java.util.Map;
+import java.util.List;
 import org.immutables.value.Value;
 import org.projectnessie.nessie.cli.grammar.Node;
 
 @Value.Immutable
-public interface MergeBranchCommandSpec extends RefWithTypeCommandSpec, RefWithHashCommandSpec {
+public interface RevertContentCommandSpec extends RefWithTypeCommandSpec {
   default CommandType commandType() {
-    return CommandType.MERGE_BRANCH;
+    return CommandType.REVERT_CONTENT;
   }
 
   @Nullable
   @Override
   @Value.Default
   default Node sourceNode() {
-    return RefWithHashCommandSpec.super.sourceNode();
+    return RefWithTypeCommandSpec.super.sourceNode();
   }
 
   @Value.Default
@@ -38,22 +38,26 @@ public interface MergeBranchCommandSpec extends RefWithTypeCommandSpec, RefWithH
     return false;
   }
 
-  @Override
-  @Nullable
-  String getRefType();
+  @Value.Default
+  default boolean isAllowDeletes() {
+    return false;
+  }
 
+  @Nullable
   @Override
   String getRef();
 
   @Nullable
-  @Override
-  String getRefTimestampOrHash();
+  String getRefType();
 
   @Nullable
-  String getInto();
+  String getSourceRef();
 
   @Nullable
-  String getDefaultMergeBehavior();
+  String getSourceRefType();
 
-  Map<String, String> getKeyMergeBehaviors();
+  @Nullable
+  String getSourceRefTimestampOrHash();
+
+  List<String> getContentKeys();
 }

--- a/cli/grammar/src/main/resources/org/projectnessie/nessie/cli/syntax/RevertContentStatement.help.txt
+++ b/cli/grammar/src/main/resources/org/projectnessie/nessie/cli/syntax/RevertContentStatement.help.txt
@@ -1,0 +1,14 @@
+Creates a new commit in Nessie to set the state of the given content-keys to the same state as those content keys
+existed on the `TO STATE` reference.
+
+This command is for example useful when another system has created a Nessie commit but the referenced Iceberg
+metadata object was not written.
+
+It is recommended to use the `DRY` keyword to investigate the changes before actually committing those to Nessie.
+
+Contents that exist on the `TO STATE` are updated in the new Nessie commit to that state.
+contents that do not exist on the `TO STATE` are deleted only if the `ALLOW DELETES` clause is specified, otherwise
+the command will fail.
+
+Note that this command will always create a new commit, even if the actual contents at the "tip" of the target branch
+and the `TO STATE` are equal.

--- a/cli/grammar/src/main/resources/org/projectnessie/nessie/cli/syntax/RevertContentStatement.help.txt
+++ b/cli/grammar/src/main/resources/org/projectnessie/nessie/cli/syntax/RevertContentStatement.help.txt
@@ -7,7 +7,7 @@ metadata object was not written.
 It is recommended to use the `DRY` keyword to investigate the changes before actually committing those to Nessie.
 
 Contents that exist on the `TO STATE` are updated in the new Nessie commit to that state.
-contents that do not exist on the `TO STATE` are deleted only if the `ALLOW DELETES` clause is specified, otherwise
+Contents that do not exist on the `TO STATE` are deleted only if the `ALLOW DELETES` clause is specified, otherwise
 the command will fail.
 
 Note that this command will always create a new commit, even if the actual contents at the "tip" of the target branch

--- a/cli/grammar/src/test/java/org/projectnessie/nessie/cli/completer/TestCliCompleter.java
+++ b/cli/grammar/src/test/java/org/projectnessie/nessie/cli/completer/TestCliCompleter.java
@@ -35,15 +35,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.projectnessie.nessie.cli.cmdspec.AlterNamespaceCommandSpec;
-import org.projectnessie.nessie.cli.cmdspec.AssignReferenceCommandSpec;
 import org.projectnessie.nessie.cli.cmdspec.CommandSpec;
-import org.projectnessie.nessie.cli.cmdspec.ConnectCommandSpec;
-import org.projectnessie.nessie.cli.cmdspec.CreateNamespaceCommandSpec;
-import org.projectnessie.nessie.cli.cmdspec.CreateReferenceCommandSpec;
-import org.projectnessie.nessie.cli.cmdspec.DropContentCommandSpec;
-import org.projectnessie.nessie.cli.cmdspec.DropReferenceCommandSpec;
-import org.projectnessie.nessie.cli.cmdspec.HelpCommandSpec;
 import org.projectnessie.nessie.cli.cmdspec.ImmutableAlterNamespaceCommandSpec;
 import org.projectnessie.nessie.cli.cmdspec.ImmutableAssignReferenceCommandSpec;
 import org.projectnessie.nessie.cli.cmdspec.ImmutableConnectCommandSpec;
@@ -56,17 +48,11 @@ import org.projectnessie.nessie.cli.cmdspec.ImmutableHelpCommandSpec;
 import org.projectnessie.nessie.cli.cmdspec.ImmutableListContentsCommandSpec;
 import org.projectnessie.nessie.cli.cmdspec.ImmutableListReferencesCommandSpec;
 import org.projectnessie.nessie.cli.cmdspec.ImmutableMergeBranchCommandSpec;
+import org.projectnessie.nessie.cli.cmdspec.ImmutableRevertContentCommandSpec;
 import org.projectnessie.nessie.cli.cmdspec.ImmutableShowContentCommandSpec;
 import org.projectnessie.nessie.cli.cmdspec.ImmutableShowLogCommandSpec;
 import org.projectnessie.nessie.cli.cmdspec.ImmutableShowReferenceCommandSpec;
 import org.projectnessie.nessie.cli.cmdspec.ImmutableUseReferenceCommandSpec;
-import org.projectnessie.nessie.cli.cmdspec.ListContentsCommandSpec;
-import org.projectnessie.nessie.cli.cmdspec.ListReferencesCommandSpec;
-import org.projectnessie.nessie.cli.cmdspec.MergeBranchCommandSpec;
-import org.projectnessie.nessie.cli.cmdspec.ShowContentCommandSpec;
-import org.projectnessie.nessie.cli.cmdspec.ShowLogCommandSpec;
-import org.projectnessie.nessie.cli.cmdspec.ShowReferenceCommandSpec;
-import org.projectnessie.nessie.cli.cmdspec.UseReferenceCommandSpec;
 import org.projectnessie.nessie.cli.grammar.CompletionType;
 import org.projectnessie.nessie.cli.grammar.NessieCliLexer;
 import org.projectnessie.nessie.cli.grammar.NessieCliParser;
@@ -199,6 +185,129 @@ public class TestCliCompleter {
   static Stream<Arguments> completer() {
     return Stream.of(
         arguments(
+            "REVERT",
+            true,
+            List.of(),
+            List.of(),
+            List.of("REVERT CONTENT"),
+            CompletionType.NONE,
+            List.of()),
+        arguments(
+            "REVERT CONTENT",
+            true,
+            List.of(),
+            List.of(),
+            List.of("REVERT CONTENT OF", "REVERT CONTENT DRY"),
+            CompletionType.NONE,
+            List.of(TokenType.DRY)),
+        arguments(
+            "REVERT CONTENT DRY",
+            true,
+            List.of(),
+            List.of(),
+            List.of("REVERT CONTENT DRY OF"),
+            CompletionType.NONE,
+            List.of()),
+        arguments(
+            "REVERT CONTENT OF foo ",
+            true,
+            List.of(),
+            List.of(),
+            List.of(
+                "REVERT CONTENT OF foo AND",
+                "REVERT CONTENT OF foo ON",
+                "REVERT CONTENT OF foo TO"),
+            CompletionType.NONE,
+            List.of(
+                TokenType.ON, TokenType.AND)), // Note: TokenType.TO is _mandatory_ (not optional)
+        arguments(
+            "REVERT CONTENT OF foo AND bar ",
+            true,
+            List.of(),
+            List.of(),
+            List.of(
+                "REVERT CONTENT OF foo AND bar AND",
+                "REVERT CONTENT OF foo AND bar ON",
+                "REVERT CONTENT OF foo AND bar TO"),
+            CompletionType.NONE,
+            List.of(
+                TokenType.ON, TokenType.AND)), // Note: TokenType.TO is _mandatory_ (not optional)
+        arguments(
+            "REVERT CONTENT OF foo ON ",
+            true,
+            List.of(),
+            List.of(),
+            List.of("REVERT CONTENT OF foo ON BRANCH"),
+            CompletionType.REFERENCE_NAME,
+            List.of(TokenType.BRANCH)),
+        arguments(
+            "REVERT CONTENT OF foo ON BRANCH main",
+            true,
+            List.of(),
+            List.of(),
+            List.of("REVERT CONTENT OF foo ON BRANCH main TO"),
+            CompletionType.NONE,
+            List.of()),
+        arguments(
+            "REVERT CONTENT OF foo ON BRANCH main TO",
+            true,
+            List.of(),
+            List.of(),
+            List.of("REVERT CONTENT OF foo ON BRANCH main TO STATE"),
+            CompletionType.NONE,
+            List.of()),
+        arguments(
+            "REVERT CONTENT OF foo ON BRANCH main TO STATE",
+            true,
+            List.of(),
+            List.of(),
+            List.of(
+                "REVERT CONTENT OF foo ON BRANCH main TO STATE ON",
+                "REVERT CONTENT OF foo ON BRANCH main TO STATE AT"),
+            CompletionType.NONE,
+            List.of()),
+        arguments(
+            "REVERT CONTENT OF foo ON BRANCH main TO STATE ON",
+            true,
+            List.of(),
+            List.of(),
+            List.of(
+                "REVERT CONTENT OF foo ON BRANCH main TO STATE ON BRANCH",
+                "REVERT CONTENT OF foo ON BRANCH main TO STATE ON TAG"),
+            CompletionType.REFERENCE_NAME,
+            List.of(TokenType.BRANCH, TokenType.TAG)),
+        arguments(
+            "REVERT CONTENT OF foo ON BRANCH main TO STATE ON TAG taggy ",
+            false,
+            List.of(),
+            List.of(),
+            List.of(
+                "REVERT CONTENT OF foo ON BRANCH main TO STATE ON TAG taggy AT",
+                "REVERT CONTENT OF foo ON BRANCH main TO STATE ON TAG taggy ALLOW"),
+            CompletionType.NONE,
+            List.of(TokenType.ALLOW, TokenType.AT)),
+        arguments(
+            "REVERT CONTENT OF foo ON BRANCH main TO STATE ON TAG taggy AT",
+            true,
+            List.of(),
+            List.of(),
+            List.of(
+                "REVERT CONTENT OF foo ON BRANCH main TO STATE ON TAG taggy AT TIMESTAMP",
+                "REVERT CONTENT OF foo ON BRANCH main TO STATE ON TAG taggy AT COMMIT"),
+            CompletionType.NONE,
+            List.of(TokenType.TIMESTAMP, TokenType.COMMIT)),
+        arguments(
+            "REVERT CONTENT OF foo ON BRANCH main TO STATE AT",
+            true,
+            List.of(),
+            List.of(),
+            List.of(
+                "REVERT CONTENT OF foo ON BRANCH main TO STATE AT TIMESTAMP",
+                "REVERT CONTENT OF foo ON BRANCH main TO STATE AT COMMIT"),
+            CompletionType.NONE,
+            List.of(TokenType.TIMESTAMP, TokenType.COMMIT)),
+        //
+        arguments(
             "CONNECT",
             true,
             List.of(),
@@ -299,7 +408,9 @@ public class TestCliCompleter {
             true,
             List.of("HELP"),
             List.of("SHOW"),
-            List.of("CONNECT", "USE", "DROP", "LIST", "EXIT", "MERGE", "ALTER", "ASSIGN", "CREATE"),
+            List.of(
+                "CONNECT", "USE", "DROP", "LIST", "EXIT", "MERGE", "ALTER", "ASSIGN", "CREATE",
+                "REVERT"),
             CompletionType.NONE,
             List.of()),
         arguments(
@@ -317,6 +428,7 @@ public class TestCliCompleter {
                 "help ASSIGN",
                 "help ALTER",
                 "help MERGE",
+                "help REVERT",
                 "help HELP",
                 "help EXIT",
                 "help LICENSE"),
@@ -331,6 +443,7 @@ public class TestCliCompleter {
                 TokenType.SHOW,
                 TokenType.ASSIGN,
                 TokenType.MERGE,
+                TokenType.REVERT,
                 TokenType.HELP,
                 TokenType.EXIT,
                 TokenType.LICENSE)),
@@ -348,6 +461,7 @@ public class TestCliCompleter {
                 "help SHOW",
                 "help ASSIGN",
                 "help MERGE",
+                "help REVERT",
                 "help HELP",
                 "help EXIT",
                 "help LICENSE"),
@@ -362,6 +476,7 @@ public class TestCliCompleter {
                 TokenType.SHOW,
                 TokenType.ASSIGN,
                 TokenType.MERGE,
+                TokenType.REVERT,
                 TokenType.HELP,
                 TokenType.EXIT,
                 TokenType.LICENSE)),
@@ -574,8 +689,8 @@ public class TestCliCompleter {
             List.of(),
             List.of(),
             List.of(
-                "CONNECT", "USE", "DROP", "LIST", "SHOW", "HELP", "ALTER", "EXIT", "MERGE",
-                "ASSIGN", "CREATE"),
+                "CONNECT", "REVERT", "USE", "DROP", "LIST", "SHOW", "HELP", "ALTER", "EXIT",
+                "MERGE", "ASSIGN", "CREATE"),
             CompletionType.NONE,
             List.of()),
         arguments(
@@ -585,6 +700,7 @@ public class TestCliCompleter {
             List.of(),
             List.of(
                 " CONNECT",
+                " REVERT",
                 " USE",
                 " DROP",
                 " LIST",
@@ -602,7 +718,9 @@ public class TestCliCompleter {
             true,
             List.of("CONNECT", "CREATE"),
             List.of(),
-            List.of("USE", "DROP", "LIST", "SHOW", "HELP", "ALTER", "EXIT", "MERGE", "ASSIGN"),
+            List.of(
+                "USE", "DROP", "LIST", "SHOW", "HELP", "ALTER", "EXIT", "MERGE", "ASSIGN",
+                "REVERT"),
             CompletionType.NONE,
             List.of()),
         arguments(
@@ -610,7 +728,9 @@ public class TestCliCompleter {
             true,
             List.of("CONNECT", "CREATE"),
             List.of(),
-            List.of("USE", "DROP", "LIST", "SHOW", "HELP", "ALTER", "EXIT", "MERGE", "ASSIGN"),
+            List.of(
+                "USE", "DROP", "LIST", "SHOW", "HELP", "ALTER", "EXIT", "MERGE", "ASSIGN",
+                "REVERT"),
             CompletionType.NONE,
             List.of()),
         arguments(
@@ -619,7 +739,8 @@ public class TestCliCompleter {
             List.of(" CONNECT", " CREATE"),
             List.of(),
             List.of(
-                " USE", " DROP", " LIST", " SHOW", " HELP", " ALTER", " EXIT", " MERGE", " ASSIGN"),
+                " USE", " DROP", " LIST", " SHOW", " HELP", " ALTER", " EXIT", " MERGE", " ASSIGN",
+                " REVERT"),
             CompletionType.NONE,
             List.of()),
         arguments(
@@ -628,7 +749,8 @@ public class TestCliCompleter {
             List.of(" CONNECT", " CREATE"),
             List.of(),
             List.of(
-                " USE", " DROP", " LIST", " SHOW", " HELP", " ALTER", " EXIT", " MERGE", " ASSIGN"),
+                " USE", " DROP", " LIST", " SHOW", " HELP", " ALTER", " EXIT", " MERGE", " ASSIGN",
+                " REVERT"),
             CompletionType.NONE,
             List.of()),
         arguments(
@@ -638,7 +760,7 @@ public class TestCliCompleter {
             List.of("EXIT"),
             List.of(
                 "CONNECT", "USE", "DROP", "LIST", "SHOW", "HELP", "ALTER", "MERGE", "ASSIGN",
-                "CREATE"),
+                "CREATE", "REVERT"),
             CompletionType.NONE,
             List.of()),
         arguments(
@@ -1018,6 +1140,34 @@ public class TestCliCompleter {
   static Stream<Arguments> parse() {
     return Stream.of(
         arguments(
+            "REVERT CONTENT OF foo AND bar AND \"baz.blah\" TO STATE AT COMMIT deadbeef",
+            List.of(
+                ImmutableRevertContentCommandSpec.builder()
+                    .addContentKeys("foo", "bar", "baz.blah")
+                    .sourceRefTimestampOrHash("deadbeef")
+                    .build())),
+        arguments(
+            "REVERT CONTENT DRY OF foo AND bar AND \"baz.blah\" TO STATE AT COMMIT deadbeef ALLOW DELETES",
+            List.of(
+                ImmutableRevertContentCommandSpec.builder()
+                    .isDryRun(true)
+                    .isAllowDeletes(true)
+                    .addContentKeys("foo", "bar", "baz.blah")
+                    .sourceRefTimestampOrHash("deadbeef")
+                    .build())),
+        arguments(
+            "REVERT CONTENT DRY OF foo AND bar AND \"baz.blah\" ON BRANCH mybranch TO STATE ON TAG taggy AT COMMIT deadbeef",
+            List.of(
+                ImmutableRevertContentCommandSpec.builder()
+                    .isDryRun(true)
+                    .refType("BRANCH")
+                    .ref("mybranch")
+                    .addContentKeys("foo", "bar", "baz.blah")
+                    .sourceRefType("TAG")
+                    .sourceRef("taggy")
+                    .sourceRefTimestampOrHash("deadbeef")
+                    .build())),
+        arguments(
             "CONNECT TO \"http://foo.bar:1234/api/v2\"",
             List.of(
                 ImmutableConnectCommandSpec.builder().uri("http://foo.bar:1234/api/v2").build())),
@@ -1256,97 +1406,52 @@ public class TestCliCompleter {
 
     switch (parsedSpec.commandType()) {
       case HELP:
-        return (T)
-            ImmutableHelpCommandSpec.builder()
-                .from((HelpCommandSpec) parsedSpec)
-                .sourceNode(null)
-                .build();
+        return (T) ImmutableHelpCommandSpec.builder().from(parsedSpec).sourceNode(null).build();
       case EXIT:
         return (T) ImmutableExitCommandSpec.builder().build();
       case CONNECT:
-        return (T)
-            ImmutableConnectCommandSpec.builder()
-                .from((ConnectCommandSpec) parsedSpec)
-                .sourceNode(null)
-                .build();
+        return (T) ImmutableConnectCommandSpec.builder().from(parsedSpec).sourceNode(null).build();
       case ASSIGN_REFERENCE:
         return (T)
-            ImmutableAssignReferenceCommandSpec.builder()
-                .from((AssignReferenceCommandSpec) parsedSpec)
-                .sourceNode(null)
-                .build();
+            ImmutableAssignReferenceCommandSpec.builder().from(parsedSpec).sourceNode(null).build();
       case USE_REFERENCE:
         return (T)
-            ImmutableUseReferenceCommandSpec.builder()
-                .from((UseReferenceCommandSpec) parsedSpec)
-                .sourceNode(null)
-                .build();
+            ImmutableUseReferenceCommandSpec.builder().from(parsedSpec).sourceNode(null).build();
       case LIST_CONTENTS:
         return (T)
-            ImmutableListContentsCommandSpec.builder()
-                .from((ListContentsCommandSpec) parsedSpec)
-                .sourceNode(null)
-                .build();
+            ImmutableListContentsCommandSpec.builder().from(parsedSpec).sourceNode(null).build();
       case LIST_REFERENCES:
         return (T)
-            ImmutableListReferencesCommandSpec.builder()
-                .from((ListReferencesCommandSpec) parsedSpec)
-                .sourceNode(null)
-                .build();
+            ImmutableListReferencesCommandSpec.builder().from(parsedSpec).sourceNode(null).build();
       case SHOW_REFERENCE:
         return (T)
-            ImmutableShowReferenceCommandSpec.builder()
-                .from((ShowReferenceCommandSpec) parsedSpec)
-                .sourceNode(null)
-                .build();
+            ImmutableShowReferenceCommandSpec.builder().from(parsedSpec).sourceNode(null).build();
       case SHOW_CONTENT:
         return (T)
-            ImmutableShowContentCommandSpec.builder()
-                .from((ShowContentCommandSpec) parsedSpec)
-                .sourceNode(null)
-                .build();
+            ImmutableShowContentCommandSpec.builder().from(parsedSpec).sourceNode(null).build();
       case SHOW_LOG:
+        return (T) ImmutableShowLogCommandSpec.builder().from(parsedSpec).sourceNode(null).build();
+      case REVERT_CONTENT:
         return (T)
-            ImmutableShowLogCommandSpec.builder()
-                .from((ShowLogCommandSpec) parsedSpec)
-                .sourceNode(null)
-                .build();
+            ImmutableRevertContentCommandSpec.builder().from(parsedSpec).sourceNode(null).build();
       case DROP_REFERENCE:
         return (T)
-            ImmutableDropReferenceCommandSpec.builder()
-                .from((DropReferenceCommandSpec) parsedSpec)
-                .sourceNode(null)
-                .build();
+            ImmutableDropReferenceCommandSpec.builder().from(parsedSpec).sourceNode(null).build();
       case CREATE_REFERENCE:
         return (T)
-            ImmutableCreateReferenceCommandSpec.builder()
-                .from((CreateReferenceCommandSpec) parsedSpec)
-                .sourceNode(null)
-                .build();
+            ImmutableCreateReferenceCommandSpec.builder().from(parsedSpec).sourceNode(null).build();
       case CREATE_NAMESPACE:
         return (T)
-            ImmutableCreateNamespaceCommandSpec.builder()
-                .from((CreateNamespaceCommandSpec) parsedSpec)
-                .sourceNode(null)
-                .build();
+            ImmutableCreateNamespaceCommandSpec.builder().from(parsedSpec).sourceNode(null).build();
       case ALTER_NAMESPACE:
         return (T)
-            ImmutableAlterNamespaceCommandSpec.builder()
-                .from((AlterNamespaceCommandSpec) parsedSpec)
-                .sourceNode(null)
-                .build();
+            ImmutableAlterNamespaceCommandSpec.builder().from(parsedSpec).sourceNode(null).build();
       case DROP_CONTENT:
         return (T)
-            ImmutableDropContentCommandSpec.builder()
-                .from((DropContentCommandSpec) parsedSpec)
-                .sourceNode(null)
-                .build();
+            ImmutableDropContentCommandSpec.builder().from(parsedSpec).sourceNode(null).build();
       case MERGE_BRANCH:
         return (T)
-            ImmutableMergeBranchCommandSpec.builder()
-                .from((MergeBranchCommandSpec) parsedSpec)
-                .sourceNode(null)
-                .build();
+            ImmutableMergeBranchCommandSpec.builder().from(parsedSpec).sourceNode(null).build();
       default:
         throw new IllegalArgumentException("Unknown type " + parsedSpec.commandType());
     }

--- a/cli/grammar/src/test/java/org/projectnessie/nessie/cli/syntax/TestSyntax.java
+++ b/cli/grammar/src/test/java/org/projectnessie/nessie/cli/syntax/TestSyntax.java
@@ -90,7 +90,7 @@ public class TestSyntax {
                 + "        {PRE:[}\n"
                 + "                {TERMINAL:BRANCH} {SEP:|} {TERMINAL:TAG}\n"
                 + "            {POST:]}\n"
-                + "        {SEP:|} {TERMINAL:MERGE} {SEP:|} {TERMINAL:HELP} {SEP:|} {TERMINAL:EXIT} {SEP:|} {TERMINAL:LICENSE}\n"
+                + "        {SEP:|} {TERMINAL:MERGE} {SEP:|} {TERMINAL:REVERT} {SEP:|} {TERMINAL:HELP} {SEP:|} {TERMINAL:EXIT} {SEP:|} {TERMINAL:LICENSE}\n"
                 + "    {POST:]}\n"
                 + "{POST:\n"
                 + "}"),
@@ -110,6 +110,32 @@ public class TestSyntax {
                 + "{PRE:[} {TERMINAL:BEHAVIORS} {NON_TERMINAL:ContentKey} {TERMINAL:=} {NON_TERMINAL:MergeBehaviorKind}\n"
                 + "    {PRE:{} {TERMINAL:AND} {NON_TERMINAL:ContentKey} {TERMINAL:=} {NON_TERMINAL:MergeBehaviorKind} {POST:}}\n"
                 + "    {POST:]}\n"
+                + "{POST:\n"
+                + "}"),
+        arguments(
+            "RevertContentStatement",
+            "{TERMINAL:REVERT} {TERMINAL:CONTENT}\n"
+                + "{PRE:[} {TERMINAL:DRY} {POST:]}\n"
+                + "{TERMINAL:OF} {NON_TERMINAL:ContentKey}\n"
+                + "{PRE:{} {TERMINAL:AND} {NON_TERMINAL:ContentKey} {POST:}}\n"
+                + "{PRE:[} {TERMINAL:ON}\n"
+                + "    {PRE:[} {NON_TERMINAL:ReferenceType} {POST:]}\n"
+                + "    {NON_TERMINAL:ExistingReference} {POST:]}\n"
+                + "{TERMINAL:TO} {TERMINAL:STATE}\n"
+                + "    {TERMINAL:ON}\n"
+                + "    {PRE:[} {NON_TERMINAL:ReferenceType} {POST:]}\n"
+                + "    {NON_TERMINAL:ExistingReference}\n"
+                + "    {PRE:[} {TERMINAL:AT}\n"
+                + "        {PRE:[}\n"
+                + "                {TERMINAL:TIMESTAMP} {SEP:|} {TERMINAL:COMMIT}\n"
+                + "            {POST:]}\n"
+                + "        {NON_TERMINAL:TimestampOrCommit} {POST:]}\n"
+                + "    {SEP:|} {TERMINAL:AT}\n"
+                + "    {PRE:[}\n"
+                + "            {TERMINAL:TIMESTAMP} {SEP:|} {TERMINAL:COMMIT}\n"
+                + "        {POST:]}\n"
+                + "    {NON_TERMINAL:TimestampOrCommit}\n"
+                + "{PRE:[} {TERMINAL:ALLOW} {TERMINAL:DELETES} {POST:]}\n"
                 + "{POST:\n"
                 + "}"));
   }

--- a/site/in-dev/cli.md
+++ b/site/in-dev/cli.md
@@ -109,6 +109,12 @@ clauses.
 
 {% include './generated-docs/cli-help-MergeBranchStatement.md' %}
 
+### **`REVERT CONTENT`**
+
+{% include './generated-docs/cli-syntax-RevertContentStatement.md' %}
+
+{% include './generated-docs/cli-help-RevertContentStatement.md' %}
+
 ### **`SHOW LOG`**
 
 {% include './generated-docs/cli-syntax-ShowLogStatement.md' %}


### PR DESCRIPTION
Based on a user's idea, this new `REVERT CONTENT` command allows updating one or more individial content keys to a state as in another commit.

The example at hand is that the user's query engine performed a commit to Nessie, but removed the metadata object after that, leaving a Nessie commit w/ an invalid metadata location.