### PR TITLE
Catalog/ADLS: More information if manadory ADLS endpoint is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ as necessary. Empty sections will not end in the release notes.
   vs the n-th commit as the last live one.
 - GC: Record failed "sweep"/"expire" runs in the repository. Before this fix, failures were reported on the console.
 - Catalog/ADLS: Don't let endpoint default to warehouse/object-store URI
+- Catalog/ADLS: More informative error message if mandatory `endpoint` is missing.
 
 ### Commits
 

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsClientSupplier.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsClientSupplier.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.catalog.files.adls;
 
+import static java.lang.String.format;
 import static org.projectnessie.catalog.files.adls.AdlsLocation.adlsLocation;
 
 import com.azure.core.http.HttpClient;
@@ -80,7 +81,16 @@ public final class AdlsClientSupplier {
 
     String accountName = account.map(BasicCredentials::name).orElse(location.storageAccount());
 
-    fileSystemOptions.endpoint().ifPresent(clientBuilder::endpoint);
+    clientBuilder.endpoint(
+        fileSystemOptions
+            .endpoint()
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        format(
+                            "Mandatory ADLS endpoint is not configured for storage account %s%s.",
+                            location.storageAccount(),
+                            location.container().map(c -> ", container " + c).orElse("")))));
 
     if (fileSystemOptions.sasToken().isPresent()) {
       clientBuilder.sasToken(fileSystemOptions.sasToken().get().key());

--- a/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/adls/TestAdlsOptions.java
+++ b/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/adls/TestAdlsOptions.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.files.adls;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.catalog.files.adls.AdlsProgrammaticOptions.AdlsPerFileSystemOptions;
+
+public class TestAdlsOptions {
+  @ParameterizedTest
+  @MethodSource
+  public void missingEndpoint(AdlsOptions<?> options, String keys) {
+    assertThatThrownBy(options::checkEndpoint)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageStartingWith("Mandatory ADLS endpoint is not configured for file system '")
+        .hasMessageEndingWith("'.")
+        .hasMessageContaining(keys);
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  public void goodEndpoint(AdlsOptions<?> options) {
+    assertThatCode(options::checkEndpoint).doesNotThrowAnyException();
+  }
+
+  static Stream<Arguments> missingEndpoint() {
+    return Stream.of(
+        arguments(
+            AdlsProgrammaticOptions.builder()
+                .defaultOptions(AdlsPerFileSystemOptions.builder().build())
+                .putFileSystems("fs1", AdlsPerFileSystemOptions.builder().build())
+                .putFileSystems("fs2", AdlsPerFileSystemOptions.builder().endpoint("ep").build())
+                .build(),
+            "'fs1'"),
+        arguments(
+            AdlsProgrammaticOptions.builder()
+                .defaultOptions(AdlsPerFileSystemOptions.builder().build())
+                .putFileSystems("fs1", AdlsPerFileSystemOptions.builder().build())
+                .putFileSystems("fs2", AdlsPerFileSystemOptions.builder().build())
+                .build(),
+            "'fs1', 'fs2'"),
+        arguments(
+            AdlsProgrammaticOptions.builder()
+                .putFileSystems("fs1", AdlsPerFileSystemOptions.builder().build())
+                .putFileSystems("fs2", AdlsPerFileSystemOptions.builder().endpoint("ep").build())
+                .build(),
+            "'fs1'"),
+        arguments(
+            AdlsProgrammaticOptions.builder()
+                .putFileSystems("fs1", AdlsPerFileSystemOptions.builder().build())
+                .putFileSystems("fs2", AdlsPerFileSystemOptions.builder().build())
+                .build(),
+            "'fs1', 'fs2'"));
+  }
+
+  static Stream<AdlsOptions<?>> goodEndpoint() {
+    return Stream.of(
+        AdlsProgrammaticOptions.builder().build(),
+        AdlsProgrammaticOptions.builder()
+            .defaultOptions(AdlsPerFileSystemOptions.builder().build())
+            .build(),
+        AdlsProgrammaticOptions.builder()
+            .defaultOptions(AdlsPerFileSystemOptions.builder().endpoint("endpoint").build())
+            .putFileSystems("fs1", AdlsPerFileSystemOptions.builder().build())
+            .putFileSystems("fs2", AdlsPerFileSystemOptions.builder().endpoint("ep").build())
+            .build(),
+        AdlsProgrammaticOptions.builder()
+            .defaultOptions(AdlsPerFileSystemOptions.builder().build())
+            .putFileSystems("fs1", AdlsPerFileSystemOptions.builder().endpoint("ep1").build())
+            .putFileSystems("fs2", AdlsPerFileSystemOptions.builder().endpoint("ep2").build())
+            .build(),
+        AdlsProgrammaticOptions.builder()
+            .putFileSystems("fs1", AdlsPerFileSystemOptions.builder().endpoint("ep1").build())
+            .putFileSystems("fs2", AdlsPerFileSystemOptions.builder().endpoint("ep2").build())
+            .build());
+  }
+}

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/catalog/CatalogProducers.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/catalog/CatalogProducers.java
@@ -88,8 +88,14 @@ public class CatalogProducers {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CatalogProducers.class);
 
-  void eagerCatalogConfigValidation(@Observes StartupEvent ev, CatalogConfig catalogConfig) {
+  void eagerCatalogConfigValidation(
+      @Observes StartupEvent ev,
+      CatalogConfig catalogConfig,
+      CatalogS3Config s3Config,
+      CatalogGcsConfig gcsConfig,
+      CatalogAdlsConfig adlsConfig) {
     catalogConfig.check();
+    adlsConfig.checkEndpoint();
   }
 
   @Produces


### PR DESCRIPTION
The `endpoint` attribute is required for ADLS, omitting it causes a rather meaningless NPE via `DataLakeFileSystemClientBuilder.buildClient()` and `DataLakeFileSystemAsyncClient.<init>()` and `DataLakeImplUtils.endpointToDesiredEndpoint()`.