### PR TITLE
GC: Manifest file reading with `specById`

### DIFF
--- a/gc/gc-iceberg/src/main/java/org/apache/iceberg/ManifestReaderUtil.java
+++ b/gc/gc-iceberg/src/main/java/org/apache/iceberg/ManifestReaderUtil.java
@@ -16,6 +16,7 @@
 package org.apache.iceberg;
 
 import com.google.common.collect.ImmutableList;
+import java.util.Map;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 
@@ -23,10 +24,13 @@ public final class ManifestReaderUtil {
 
   private ManifestReaderUtil() {}
 
-  public static CloseableIterable<String> readPathsFromManifest(ManifestFile manifest, FileIO io) {
+  public static CloseableIterable<String> readPathsFromManifest(
+      ManifestFile manifest, Map<Integer, PartitionSpec> specsById, FileIO io) {
     // entry.file() is package private. Hence, this Util class under iceberg package.
     return CloseableIterable.transform(
-        ManifestFiles.open(manifest, io, null).select(ImmutableList.of("file_path")).liveEntries(),
+        ManifestFiles.open(manifest, io, specsById)
+            .select(ImmutableList.of("file_path"))
+            .liveEntries(),
         entry -> entry.file().path().toString());
   }
 }


### PR DESCRIPTION
Related to #9042, Iceberg's `o.a.iceberg.ManifestReader.ManifestReader()` extracts the partition spec either via a provided `Map<Integer, PartitionSpec>` or re-constructs it from Avro metadata attributes. pyiceberg until including version 0.6.1 however writes _invalid_ manifest files (see https://github.com/apache/iceberg-python/pull/846) with the `partition-spec` Avro metadata attribute containing the JSON of the whole partition-spec instead of just the partition-spec fields.

This change propagates the mentioned map down to the manifest-reader to work around this pyiceberg issue.

Fixes #9042 