### PR TITLE
Catalog/ADLS: change 'ping' endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ as necessary. Empty sections will not end in the release notes.
 - GC: Fix handling of broken manifest files written by pyiceberg up to 0.6.1
 - Catalog/ADLS: Don't let endpoint default to warehouse/object-store URI
 - Catalog/ADLS: More informative error message if mandatory `endpoint` is missing.
+- Catalog/ADLS: Use a less restrictive endpoint in the 'ObjectIO.ping' function used for health checks.
 
 ### Commits
 

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsObjectIO.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsObjectIO.java
@@ -45,7 +45,7 @@ public class AdlsObjectIO implements ObjectIO {
     AdlsLocation location = adlsLocation(uri);
 
     DataLakeFileSystemClient fileSystem = clientSupplier.fileSystemClient(location);
-    fileSystem.getAccessPolicy();
+    fileSystem.getProperties();
   }
 
   @Override


### PR DESCRIPTION
Use `getProperties` instead of `getAccessPolicy`, because latter may require more privileges.