### PR TITLE
Add an Operating System check

### DIFF
--- a/site/docs/downloads/index.md
+++ b/site/docs/downloads/index.md
@@ -26,16 +26,16 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
 
     Docker images are multiplatform images for amd64, arm64, ppc64le and s390x.
     They are available from the following repositories:
-    
+
     * [GitHub Container Registry](https://ghcr.io/projectnessie/nessie):
 
     ```bash
     docker pull ghcr.io/projectnessie/nessie:{{ versions.nessie }}
     docker run -p 19120:19120 -p 9000:9000 ghcr.io/projectnessie/nessie:{{ versions.nessie }}
     ```
-    
+
     * [Quay.io](https://quay.io/repository/projectnessie/nessie?tab=tags):
-    
+
     ```bash
     docker pull quay.io/projectnessie/nessie:{{ versions.nessie }}
     docker run -p 19120:19120 -p 9000:9000 quay.io/projectnessie/nessie:{{ versions.nessie }}
@@ -46,7 +46,7 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
     Nessie {{ versions.nessie }} Helm chart is available from the following locations:
 
     * [Nessie Helm Repo](https://charts.projectnessie.org/):
-    
+
     ```bash
     helm repo add nessie https://charts.projectnessie.org/
     helm repo update
@@ -58,8 +58,8 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
 
 === "Standalone Jar"
 
-    Requires Java 17 or newer.
-    
+    Java version: minimum 17, 21 recommended, [supported operating systems](/nessie-latest/configuration/#supported-operating-systems)
+
     ```bash
     curl -L -o nessie-quarkus-{{ versions.nessie }}-runner.jar \
       https://github.com/projectnessie/nessie/releases/download/nessie-{{ versions.nessie }}/nessie-quarkus-{{ versions.nessie }}-runner.jar
@@ -91,7 +91,7 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
 
 === "Standalone Jar"
 
-    Requires Java 11 or newer.
+    Requires Java 11, Java 21 recommended.
 
     ```bash
     curl -L -o nessie-cli-{{ versions.nessie }}.jar \
@@ -124,8 +124,8 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
 
 === "Standalone Jar"
 
-    Requires Java 11, Java 17 recommended.
-    
+    Requires Java 11, Java 21 recommended.
+
     ```bash
     curl -L -o nessie-gc-{{ versions.nessie }}.jar \
       https://github.com/projectnessie/nessie/releases/download/nessie-{{ versions.nessie }}/nessie-gc-{{ versions.nessie }}.jar
@@ -141,7 +141,7 @@ Nessie repository.
 
     Docker images are multiplatform images for amd64, arm64, ppc64le, s390x.
     They are available from the following repositories:
-    
+
     * [GitHub Container Registry](https://github.com/projectnessie/nessie/pkgs/container/nessie-server-admin);
 
     ```bash
@@ -158,8 +158,8 @@ Nessie repository.
 
 === "Standalone Jar"
 
-    Requires Java 17 or newer.
-    
+    Java version: minimum 17, 21 recommended, [supported operating systems](/nessie-latest/configuration/#supported-operating-systems)
+
     ```bash
     curl -L -o nessie-server-admin-tool-{{ versions.nessie }}-runner.jar \
       https://github.com/projectnessie/nessie/releases/download/nessie-{{ versions.nessie }}/nessie-server-admin-tool-{{ versions.nessie }}-runner.jar

--- a/site/in-dev/configuration.md
+++ b/site/in-dev/configuration.md
@@ -64,6 +64,16 @@ especially the `cache.gets` values for `hit`/`miss` and the `cause`s provided by
     especially with Iceberg REST. While the Iceberg REST parts in Nessie are built in a "reactive way",
     most Nessie core APIs are not.
 
+## Supported operating systems
+
+| Operating System | Production         | Development & prototyping | Comments                                                                                 |
+|------------------|--------------------|---------------------------|------------------------------------------------------------------------------------------|
+| Linux            | :heavy_check_mark: | :heavy_check_mark:        | Primarily supported operating systems, assuming recent kernel and distribution versions. |
+| macOS            | :x:                | :heavy_check_mark:        | Supported for development and testing purposes.                                          |
+| AIX              | :x:                | :x:                       | Not tested, might work or not.                                                           |
+| Solaris          | :x:                | :x:                       | Not tested, might work or not.                                                           |
+| Windows          | :x:                | :x:                       | Not supported in any way. Nessie server and admin tool refuse to start.                  |
+
 ## Providing secrets
 
 Instead of providing secrets like passwords in clear text, you can also use a keystore. This

--- a/site/in-dev/index-release.md
+++ b/site/in-dev/index-release.md
@@ -25,16 +25,16 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
 
     Docker images are multiplatform images for amd64, arm64, ppc64le and s390x.
     They are available from the following repositories:
-    
+
     * [GitHub Container Registry](https://ghcr.io/projectnessie/nessie):
 
     ```bash
     docker pull ghcr.io/projectnessie/nessie:::NESSIE_VERSION::
     docker run -p 19120:19120 -p 9000:9000 ghcr.io/projectnessie/nessie:::NESSIE_VERSION::
     ```
-    
+
     * [Quay.io](https://quay.io/repository/projectnessie/nessie?tab=tags):
-    
+
     ```bash
     docker pull quay.io/projectnessie/nessie:::NESSIE_VERSION::
     docker run -p 19120:19120 -p 9000:9000 quay.io/projectnessie/nessie:::NESSIE_VERSION::
@@ -45,7 +45,7 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
     Nessie ::NESSIE_VERSION:: Helm chart is available from the following locations:
 
     * [Nessie Helm Repo](https://charts.projectnessie.org/):
-    
+
     ```bash
     helm repo add nessie https://charts.projectnessie.org/
     helm repo update
@@ -57,8 +57,8 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
 
 === "Standalone Jar"
 
-    Requires Java 17 or newer.
-    
+    Java version: minimum 17, 21 recommended, [supported operating systems](configuration.md#supported-operating-systems)
+
     ```bash
     curl -L -o nessie-quarkus-::NESSIE_VERSION::-runner.jar \
       https://github.com/projectnessie/nessie/releases/download/nessie-::NESSIE_VERSION::/nessie-quarkus-::NESSIE_VERSION::-runner.jar
@@ -74,7 +74,7 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
     Docker images are multiplatform images for amd64, arm64, ppc64le, s390x.
 
     They are available from the following repositories:
-    
+
     * [GitHub Container Registry](https://github.com/projectnessie/nessie/pkgs/container/nessie-cli):
 
     ```bash
@@ -91,7 +91,7 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
 
 === "Standalone Jar"
 
-    Requires Java 11 or newer.
+    Requires Java 11, Java 21 recommended.
 
     ```bash
     curl -L -o nessie-cli-::NESSIE_VERSION::.jar \
@@ -124,8 +124,8 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
 
 === "Standalone Jar"
 
-    Requires Java 11, Java 17 recommended.
-    
+    Requires Java 17, Java 21 recommended, [supported operating systems](configuration.md#supported-operating-systems)
+
     ```bash
     curl -L -o nessie-gc-::NESSIE_VERSION::.jar \
       https://github.com/projectnessie/nessie/releases/download/nessie-::NESSIE_VERSION::/nessie-gc-::NESSIE_VERSION::.jar
@@ -141,7 +141,7 @@ Nessie repository.
 
     Docker images are multiplatform images for amd64, arm64, ppc64le, s390x.
     They are available from the following repositories:
-    
+
     * [GitHub Container Registry](https://github.com/projectnessie/nessie/pkgs/container/nessie-server-admin):
 
     ```bash
@@ -158,8 +158,8 @@ Nessie repository.
 
 === "Standalone Jar"
 
-    Requires Java 17 or newer.
-    
+    Java version: minimum 17, 21 recommended, [supported operating systems](configuration.md#supported-operating-systems)
+
     ```bash
     curl -L -o nessie-server-admin-tool-::NESSIE_VERSION::-runner.jar \
       https://github.com/projectnessie/nessie/releases/download/nessie-::NESSIE_VERSION::/nessie-server-admin-tool-::NESSIE_VERSION::-runner.jar

--- a/site/in-dev/index.md
+++ b/site/in-dev/index.md
@@ -17,11 +17,11 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
 === "Docker Image"
 
     Docker images are multiplatform images for amd64, arm64, ppc64le, s390x.
-    
+
     **The image tags are updated twice per day during weekdays.**
 
     Images are available from the following repositories: 
-    
+
     * [GitHub Container Registry](https://ghcr.io/projectnessie/nessie-unstable):
 
     ```bash
@@ -30,7 +30,7 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
     ```
 
     * [Quay.io](https://quay.io/repository/projectnessie/nessie-unstable?tab=tags):
-    
+
     ```bash
     docker pull quay.io/projectnessie/nessie-unstable
     docker run -p 19120:19120 -p 9000:9000 quay.io/projectnessie/nessie-unstable
@@ -41,11 +41,11 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
 === "Docker Image"
 
     Docker images are multiplatform images for amd64, arm64, ppc64le, s390x.
-    
+
     **The image tags are updated twice per day during weekdays.**
 
     Images are available from the following repositories: 
-    
+
     * [GitHub Container Registry](https://github.com/projectnessie/nessie/pkgs/container/nessie-cli-unstable):
 
     ```bash
@@ -68,9 +68,9 @@ expiration policies.
 === "Docker Image"
 
     Docker images are multiplatform images for amd64, arm64, ppc64le, s390x.
-    
+
     **The image tags are updated twice per day during weekdays.**
-    
+
     Images are available from the following repositories:
 
     * [GitHub Container Registry](https://github.com/projectnessie/nessie/pkgs/container/nessie-gc-unstable):
@@ -99,7 +99,7 @@ Nessie repository.
     **The image tags are updated twice per day during weekdays.**
 
     They are available from the following repositories:
-    
+
     * [GitHub Container Registry](https://github.com/projectnessie/nessie/pkgs/container/nessie-server-admin-unstable):
 
     ```bash


### PR DESCRIPTION
We have seen a few occurences where users ran into various issues when running Nessie server or its admin tool on Windows.

This PR adds a check that happens very early at startup time that checks the operating system. Behaviors:
* Linux: fully supported
* macOS: for development, testing and prototyping
* AIX, Solaris: not supported, may or may not work
* Windows: not supported, startup fails

Also add related notes to the website and recommend Java 21 instead of 17.