### PR TITLE
Initial Trino integration testing

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     api(project(":nessie-tasks-api"))
     api(project(":nessie-tasks-service-async"))
     api(project(":nessie-tasks-service-impl"))
+    api(project(":nessie-trino-testcontainer"))
     api(project(":nessie-versioned-spi"))
     api(project(":nessie-versioned-storage-batching"))
     api(project(":nessie-versioned-storage-bigtable"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -117,6 +117,7 @@ mongodb-driver-sync = { module = "org.mongodb:mongodb-driver-sync", version = "5
 nessie-runner-common = { module = "org.projectnessie.nessie-runner:nessie-runner-common", version = "0.32.2" }
 nessie-ui = { module = "org.projectnessie.nessie.ui:nessie-ui", version = "0.64.1" }
 netty-bom = { module = "io.netty:netty-bom", version.ref = "netty" }
+okhttp3 = { module = "com.squareup.okhttp3:okhttp", version = "4.12.0" }
 opentelemetry-bom = { module = "io.opentelemetry:opentelemetry-bom", version.ref = "opentelemetry" }
 opentelemetry-bom-alpha = { module = "io.opentelemetry:opentelemetry-bom-alpha", version.ref = "opentelemetryAlpha" }
 opentelemetry-instrumentation-bom-alpha = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetryAlpha" }
@@ -152,6 +153,7 @@ spark-sql-v35-v213 = { module = "org.apache.spark:spark-sql_2_13", version = { s
 testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version = "1.20.0" }
 testcontainers-keycloak = { module = "com.github.dasniko:testcontainers-keycloak", version = "3.4.0" }
 threeten-extra = { module = "org.threeten:threeten-extra", version = "1.8.0" }
+trino-client = { module = "io.trino:trino-client", version = "452" }
 undertow-core = { module = "io.undertow:undertow-core", version.ref = "undertow" }
 undertow-servlet = { module = "io.undertow:undertow-servlet", version.ref = "undertow" }
 vertx-core = { module = "io.vertx:vertx-core", version = "4.5.9" }

--- a/gradle/projects.main.properties
+++ b/gradle/projects.main.properties
@@ -54,6 +54,7 @@ nessie-storage-uri=tools/storage/uri
 nessie-tasks-api=tasks/api
 nessie-tasks-service-async=tasks/service/async
 nessie-tasks-service-impl=tasks/service/impl
+nessie-trino-testcontainer=testing/trino-container
 nessie-versioned-spi=versioned/spi
 nessie-versioned-storage-batching=versioned/storage/batching
 nessie-versioned-storage-bigtable=versioned/storage/bigtable

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -159,6 +159,7 @@ dependencies {
   testFixturesApi(project(":nessie-azurite-testcontainer"))
   testFixturesApi(project(":nessie-gcs-testcontainer"))
   testFixturesApi(project(":nessie-minio-testcontainer"))
+  testFixturesApi(project(":nessie-trino-testcontainer"))
   testFixturesApi(project(":nessie-object-storage-mock"))
   testFixturesApi(project(":nessie-catalog-format-iceberg"))
   testFixturesApi(project(":nessie-catalog-format-iceberg-fixturegen"))

--- a/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/s3/ITTrinoS3.java
+++ b/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/s3/ITTrinoS3.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.server.catalog.s3;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import java.net.URI;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.nessie.testing.trino.TrinoContainer;
+import org.projectnessie.nessie.testing.trino.TrinoResults;
+import org.projectnessie.server.catalog.MinioTestResourceLifecycleManager;
+import org.projectnessie.server.catalog.WarehouseLocation;
+import org.testcontainers.Testcontainers;
+
+@QuarkusTestResource(
+    restrictToAnnotatedClass = true,
+    value = MinioTestResourceLifecycleManager.class)
+@QuarkusIntegrationTest
+public class ITTrinoS3 {
+  static TrinoContainer trinoContainer;
+
+  @WarehouseLocation static URI warehouseLocation;
+
+  static String icebergRestUri;
+
+  @BeforeEach
+  void maybeStartTrino() {
+    if (trinoContainer != null) {
+      return;
+    }
+
+    int quarkusPort = Integer.getInteger("quarkus.http.port", 19120);
+
+    Testcontainers.exposeHostPorts(quarkusPort);
+
+    icebergRestUri = format("http://host.testcontainers.internal:%d/iceberg/main", quarkusPort);
+
+    trinoContainer = new TrinoContainer();
+    trinoContainer.withAccessToHost(true);
+    trinoContainer.withCatalog(
+        "nessie",
+        Map.of(
+            "connector.name",
+            "iceberg",
+            "iceberg.catalog.type",
+            "rest",
+            "iceberg.rest-catalog.uri",
+            icebergRestUri));
+    trinoContainer.start();
+  }
+
+  @AfterAll
+  static void stopTrino() {
+    if (trinoContainer != null) {
+      trinoContainer.stop();
+    }
+  }
+
+  @Test
+  public void smoke() {
+    try (TrinoResults catalogs = trinoContainer.query("SHOW CATALOGS")) {
+      assertThat(catalogs)
+          .toIterable()
+          .extracting(l -> l.get(0).toString())
+          .contains("memory")
+          .contains("nessie");
+    }
+    try (TrinoResults createSchema = trinoContainer.query("CREATE SCHEMA nessie.my_namespace")) {
+      assertThat(createSchema).isExhausted();
+    }
+    try (TrinoResults schemas = trinoContainer.query("SHOW SCHEMAS FROM nessie")) {
+      assertThat(schemas)
+          .toIterable()
+          .extracting(l -> l.get(0).toString())
+          .containsExactlyInAnyOrder("information_schema", "my_namespace");
+    }
+
+    // Following fails with 'location must be set for my_namespace'
+    // try (TrinoResults createTable =
+    //       trinoContainer.query(
+    //         """
+    //           CREATE TABLE nessie.my_namespace.yearly_clicks (year, clicks)
+    //             WITH (partitioning = ARRAY['year']) AS VALUES (2021, 10000), (2022, 20000)
+    //           """)) {
+    //  assertThat(createTable).isExhausted();
+    // }
+  }
+}

--- a/testing/trino-container/build.gradle.kts
+++ b/testing/trino-container/build.gradle.kts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins { id("nessie-conventions-iceberg") }
+
+publishingHelper { mavenName = "Nessie - Trino testcontainer" }
+
+description = "JUnit extension providing a Trino instance."
+
+dependencies {
+  implementation(platform(libs.testcontainers.bom))
+  implementation("org.testcontainers:testcontainers")
+  implementation(project(":nessie-container-spec-helper"))
+
+  implementation(libs.guava)
+
+  implementation(libs.trino.client)
+  implementation(libs.okhttp3)
+
+  compileOnly(libs.errorprone.annotations)
+  compileOnly(libs.immutables.value.annotations)
+
+  intTestImplementation(libs.bundles.junit.testing)
+  intTestRuntimeOnly(libs.logback.classic)
+}

--- a/testing/trino-container/src/main/java/org/projectnessie/nessie/testing/trino/Trino.java
+++ b/testing/trino-container/src/main/java/org/projectnessie/nessie/testing/trino/Trino.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.testing.trino;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface Trino {}

--- a/testing/trino-container/src/main/java/org/projectnessie/nessie/testing/trino/TrinoAccess.java
+++ b/testing/trino-container/src/main/java/org/projectnessie/nessie/testing/trino/TrinoAccess.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.testing.trino;
+
+import io.trino.client.StatementClient;
+import java.util.List;
+
+public interface TrinoAccess {
+
+  /** Host and port, separated by '{@code :}'. */
+  String hostPort();
+
+  /** Preferred way to issue SQL statements to Trino. */
+  TrinoResults query(String query);
+
+  List<List<Object>> queryResults(String query);
+
+  /**
+   * Low level way to issue SQL statements to Trino, if needed. If in doubt, use {@link
+   * #query(String)}.
+   */
+  StatementClient statementClient(String query);
+}

--- a/testing/trino-container/src/main/java/org/projectnessie/nessie/testing/trino/TrinoContainer.java
+++ b/testing/trino-container/src/main/java/org/projectnessie/nessie/testing/trino/TrinoContainer.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.testing.trino;
+
+import static java.lang.String.format;
+import static org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess;
+
+import io.trino.client.ClientSession;
+import io.trino.client.StatementClient;
+import io.trino.client.StatementClientFactory;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import okhttp3.Cache;
+import okhttp3.OkHttpClient;
+import org.projectnessie.nessie.testing.containerspec.ContainerSpecHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.utility.Base58;
+
+public final class TrinoContainer extends GenericContainer<TrinoContainer> implements TrinoAccess {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TrinoContainer.class);
+
+  private static final int TRINO_PORT = 8080;
+  private static final String STATUS_ENDPOINT = "/v1/info";
+
+  public static final String HOST_FROM_CONTAINER = "host.nessie-testing.internal";
+
+  private volatile OkHttpClient httpClient;
+
+  private final Properties logProperties = new Properties();
+  private final Properties trinoConfig = new Properties();
+
+  @SuppressWarnings("unused")
+  public TrinoContainer() {
+    this(null);
+  }
+
+  @SuppressWarnings("resource")
+  public TrinoContainer(String image) {
+    super(
+        ContainerSpecHelper.builder()
+            .name("trino")
+            .containerClass(TrinoContainer.class)
+            .build()
+            .dockerImageName(image));
+
+    trinoConfig.put("coordinator", "true");
+    trinoConfig.put("node-scheduler.include-coordinator", "true");
+    trinoConfig.put("http-server.http.port", Integer.toString(TRINO_PORT));
+    trinoConfig.put("discovery.uri", format("http://localhost:%d", TRINO_PORT));
+    trinoConfig.put("catalog.management", "${ENV:CATALOG_MANAGEMENT}");
+
+    withNetworkAliases(randomString("trino"));
+    withLogConsumer(new Slf4jLogConsumer(LOGGER).withPrefix("Trino"));
+    addExposedPort(TRINO_PORT);
+    withExtraHost(HOST_FROM_CONTAINER, "host-gateway");
+    withCopyToContainer(new PropertiesTransferable(logProperties), "/etc/trino/log.properties");
+    withCopyToContainer(new PropertiesTransferable(trinoConfig), "/etc/trino/config.properties");
+    withStartupAttempts(3);
+    setWaitStrategy(
+        new WaitAllStrategy()
+            .withStrategy(
+                new HttpWaitStrategy()
+                    .forPort(TRINO_PORT)
+                    .forPath(STATUS_ENDPOINT)
+                    .withStartupTimeout(Duration.ofMinutes(2)))
+            .withStrategy(
+                new AbstractWaitStrategy() {
+                  @Override
+                  protected void waitUntilReady() {
+                    retryUntilSuccess(
+                        (int) super.startupTimeout.toMillis(),
+                        TimeUnit.MILLISECONDS,
+                        () -> {
+                          try (StatementClient client = statementClient("SHOW CATALOGS")) {
+                            while (client.isRunning()) {
+                              Iterable<List<Object>> data = client.currentData().getData();
+
+                              client.advance();
+
+                              if (data == null) {
+                                Thread.sleep(200);
+                                LOGGER.info("No data for wait statement yet");
+                              } else {
+                                LOGGER.info("Got data from Trino ... assuming it's started up.");
+                                return null;
+                              }
+                            }
+                          }
+                          throw new RuntimeException("No legit result from Trino yet");
+                        });
+                  }
+                }));
+  }
+
+  static final class PropertiesTransferable implements Transferable {
+    private final Properties props;
+
+    PropertiesTransferable(Properties props) {
+      this.props = props;
+    }
+
+    @Override
+    public byte[] getBytes() {
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      try {
+        props.store(out, "");
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      return out.toByteArray();
+    }
+
+    @Override
+    public long getSize() {
+      return getBytes().length;
+    }
+  }
+
+  private static String randomString(String prefix) {
+    return prefix + "-" + Base58.randomString(6).toLowerCase(Locale.ROOT);
+  }
+
+  /**
+   * Functionality to add a catalog to Trino via a properties in the Trino container's {@code
+   * /etc/trino/catalogs/} folder.
+   */
+  public TrinoContainer withCatalog(String name, Map<String, String> properties) {
+    Properties props = new Properties();
+    props.putAll(properties);
+
+    return withCatalog(name, props);
+  }
+
+  public TrinoContainer withCatalog(String name, Properties properties) {
+    return withCopyToContainer(
+        new PropertiesTransferable(properties), format("/etc/trino/catalog/%s.properties", name));
+  }
+
+  public TrinoContainer withGlobalConfig(Map<String, String> config) {
+    trinoConfig.putAll(config);
+    return this;
+  }
+
+  public TrinoContainer withLogProperty(String key, String value) {
+    logProperties.put(key, value);
+    return this;
+  }
+
+  public TrinoContainer withLogProperty(Map<String, String> logProperties) {
+    this.logProperties.putAll(logProperties);
+    return this;
+  }
+
+  @Override
+  public String hostPort() {
+    return format("%s:%d", getHost(), getMappedPort(TRINO_PORT));
+  }
+
+  @Override
+  public StatementClient statementClient(String query) {
+    if (httpClient == null) {
+      synchronized (this) {
+        if (httpClient == null) {
+          httpClient = new OkHttpClient();
+        }
+      }
+    }
+
+    ClientSession session =
+        ClientSession.builder()
+            .server(URI.create(format("http://%s:%d/", getHost(), getMappedPort(TRINO_PORT))))
+            .timeZone(ZoneId.of("UTC"))
+            .user(Optional.of("user"))
+            .build();
+
+    return StatementClientFactory.newStatementClient(httpClient, session, query, Optional.empty());
+  }
+
+  @Override
+  public TrinoResults query(String query) {
+    return new TrinoResultsImpl(statementClient(query));
+  }
+
+  @Override
+  public List<List<Object>> queryResults(String query) {
+    try (TrinoResults trinoResults = query(query)) {
+      return trinoResults.allRows();
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      try {
+        try {
+          if (httpClient != null) {
+            try {
+              httpClient.connectionPool().evictAll();
+            } finally {
+              Cache cache = httpClient.cache();
+              if (cache != null) {
+                cache.close();
+              }
+            }
+          }
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      } finally {
+        stop();
+      }
+    } finally {
+      httpClient = null;
+    }
+  }
+}

--- a/testing/trino-container/src/main/java/org/projectnessie/nessie/testing/trino/TrinoResults.java
+++ b/testing/trino-container/src/main/java/org/projectnessie/nessie/testing/trino/TrinoResults.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.testing.trino;
+
+import io.trino.client.Column;
+import io.trino.client.StatementClient;
+import java.util.Iterator;
+import java.util.List;
+
+public interface TrinoResults extends AutoCloseable, Iterator<List<Object>> {
+  StatementClient client();
+
+  List<Column> columns();
+
+  List<List<Object>> allRows();
+
+  @Override
+  void close();
+}

--- a/testing/trino-container/src/main/java/org/projectnessie/nessie/testing/trino/TrinoResultsImpl.java
+++ b/testing/trino-container/src/main/java/org/projectnessie/nessie/testing/trino/TrinoResultsImpl.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.testing.trino;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.AbstractIterator;
+import io.trino.client.Column;
+import io.trino.client.QueryError;
+import io.trino.client.QueryStatusInfo;
+import io.trino.client.StatementClient;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+final class TrinoResultsImpl extends AbstractIterator<List<Object>> implements TrinoResults {
+  private final StatementClient client;
+  private final AtomicBoolean closed = new AtomicBoolean();
+
+  private Iterator<List<Object>> currentPage;
+
+  TrinoResultsImpl(StatementClient client) {
+    this.client = client;
+  }
+
+  @Override
+  protected List<Object> computeNext() {
+    if (closed.get()) {
+      return endOfData();
+    }
+
+    while (true) {
+      if (currentPage != null) {
+        if (currentPage.hasNext()) {
+          return currentPage.next();
+        }
+        currentPage = null;
+      }
+
+      QueryStatusInfo results;
+      QueryError error;
+      while (client.isRunning()) {
+        results = client.currentStatusInfo();
+        error = results.getError();
+        if (error != null) {
+          throw error.getFailureInfo().toException();
+        }
+        Iterable<List<Object>> data = client.currentData().getData();
+
+        client.advance();
+
+        if (data != null) {
+          currentPage = data.iterator();
+          break;
+        } else {
+          try {
+            Thread.sleep(100L);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+          }
+        }
+      }
+
+      if (currentPage != null) {
+        continue;
+      }
+
+      checkState(client.isFinished(), "Got no data, but client has finished");
+      results = client.finalStatusInfo();
+      error = results.getError();
+      if (error != null) {
+        throw error.getFailureInfo().toException();
+      }
+
+      close();
+
+      return endOfData();
+    }
+  }
+
+  @Override
+  public void close() {
+    if (closed.compareAndSet(false, true)) {
+      client.close();
+    }
+  }
+
+  @Override
+  public StatementClient client() {
+    return client;
+  }
+
+  @Override
+  public List<Column> columns() {
+    return client.currentStatusInfo().getColumns();
+  }
+
+  @Override
+  public List<List<Object>> allRows() {
+    List<List<Object>> result = new ArrayList<>();
+    this.forEachRemaining(result::add);
+    return result;
+  }
+}

--- a/testing/trino-container/src/main/resources/org/projectnessie/nessie/testing/trino/Dockerfile-trino-version
+++ b/testing/trino-container/src/main/resources/org/projectnessie/nessie/testing/trino/Dockerfile-trino-version
@@ -1,0 +1,3 @@
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM docker.io/trinodb/trino:452


### PR DESCRIPTION
This change adds a new `TrinoContainer` to test Nessie Catalog against Trino.

It would have been easier to just use `trino-jdbc`, but that clashes horribly with Quarkus, because `trino-jdbc` has OpenTelemetry instrumentation built in using shaded classes, but not all of them - and the opentelementry-semconv from Quarkus is incompatible with the one hardly required by `trino-jdbc`. To have "something", this change adds rudimental support to run queries, which is hopefully enough for testing. Beside, having to pull in okhttp isn't especially great, but there's no way around :(

The `ITTrinoS3` class uses a somewhat awkward mechanism to let Trino connect to Nessie, but it works using testcontainer's mechanism to expose host ports to containers.