### PR TITLE
Catalog: Don't log every client error using `INFO` log level

### DIFF
--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergErrorMapper.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergErrorMapper.java
@@ -89,7 +89,7 @@ public class IcebergErrorMapper {
   private IcebergErrorResponse mapStorageFailure(
       BackendErrorStatus status, Throwable ex, IcebergEntityKind kind) {
     // Log full stack trace on the server side for troubleshooting
-    LOGGER.info("Propagating storage failure to client: {}", status, ex);
+    LOGGER.debug("Propagating storage failure to client: {}", status, ex);
 
     switch (status.statusCode()) {
       case NESSIE_ERROR:

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergErrorMapper.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergErrorMapper.java
@@ -89,7 +89,15 @@ public class IcebergErrorMapper {
   private IcebergErrorResponse mapStorageFailure(
       BackendErrorStatus status, Throwable ex, IcebergEntityKind kind) {
     // Log full stack trace on the server side for troubleshooting
-    LOGGER.debug("Propagating storage failure to client: {}", status, ex);
+    switch (status.statusCode()) {
+      case NESSIE_ERROR:
+      case ICEBERG_ERROR:
+        LOGGER.debug("Propagating storage failure to client: {}", status, ex);
+        break;
+      default:
+        LOGGER.info("Propagating storage failure to client: {}", status, ex);
+        break;
+    }
 
     switch (status.statusCode()) {
       case NESSIE_ERROR:


### PR DESCRIPTION
Currently all errors, including user errors, are logged at `INFO` level with a full stack trace. That's a bit too much.

Example:
```
2024-07-22 17:24:44,964 INFO  [org.pro.cat.ser.res.IcebergErrorMapper] (executor-thread-1) Propagating storage failure to client: BackendErrorStatus{statusCode=NESSIE_ERROR, cause=org.projectnessie.error.NessieNamespaceNotFoundException: Namespace 'my_namespace' does not exist}: org.projectnessie.error.NessieNamespaceNotFoundException: Namespace 'my_namespace' does not exist
	at org.projectnessie.client.api.ns.ClientSideGetNamespace.getWithResponse(ClientSideGetNamespace.java:67)
	at org.projectnessie.client.api.ns.ClientSideGetNamespace.get(ClientSideGetNamespace.java:47)
	at org.projectnessie.catalog.service.rest.IcebergApiV1NamespaceResource.loadNamespaceMetadata(IcebergApiV1NamespaceResource.java:168)
	at org.projectnessie.catalog.service.rest.IcebergApiV1NamespaceResource_ClientProxy.loadNamespaceMetadata(Unknown Source)
	at org.projectnessie.catalog.service.rest.IcebergApiV1NamespaceResource$quarkusrestinvoker$loadNamespaceMetadata_9da30190d829268a2f1acb35736dfe252a3f066e.invoke(Unknown Source)
	at org.jboss.resteasy.reactive.server.handlers.InvocationHandler.handle(InvocationHandler.java:29)
	at io.quarkus.resteasy.reactive.server.runtime.QuarkusResteasyReactiveRequestContext.invokeHandler(QuarkusResteasyReactiveRequestContext.java:141)
	at org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext.run(AbstractResteasyReactiveContext.java:147)
	at io.quarkus.vertx.core.runtime.VertxCoreRecorder$14.runWith(VertxCoreRecorder.java:599)
	at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2516)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2495)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1521)
	at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:11)
	at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:11)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```
