### PR TITLE
Remove `@WithDefault` annotations

### DIFF
--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogGcsBucketConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogGcsBucketConfig.java
@@ -16,7 +16,6 @@
 package org.projectnessie.quarkus.config;
 
 import io.smallrye.config.WithConverter;
-import io.smallrye.config.WithDefault;
 import java.util.Optional;
 import org.projectnessie.catalog.files.gcs.GcsBucketOptions;
 import org.projectnessie.catalog.secrets.KeySecret;
@@ -24,7 +23,6 @@ import org.projectnessie.catalog.secrets.KeySecret;
 public interface CatalogGcsBucketConfig extends GcsBucketOptions {
 
   @Override
-  @WithDefault("NONE")
   Optional<GcsAuthType> authType();
 
   @Override

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogS3BucketConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogS3BucketConfig.java
@@ -15,7 +15,6 @@
  */
 package org.projectnessie.quarkus.config;
 
-import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 import java.util.Optional;
 import org.projectnessie.catalog.files.s3.S3BucketOptions;
@@ -25,12 +24,10 @@ import org.projectnessie.catalog.files.s3.S3ServerAuthenticationMode;
 public interface CatalogS3BucketConfig extends S3BucketOptions {
 
   @WithName("server-auth-mode")
-  @WithDefault("STATIC")
   @Override
   Optional<S3ServerAuthenticationMode> serverAuthenticationMode();
 
   @WithName("client-auth-mode")
-  @WithDefault("REQUEST_SIGNING")
   @Override
   Optional<S3ClientAuthenticationMode> clientAuthenticationMode();
 }


### PR DESCRIPTION
... because those default values would be injected by Quarkus for both the default and per-bucket configs, effectively making those explicit so that a bucket's config option cannot fall back to the default bucket option.