### PR TITLE
Load reference info before processing commits during export

### DIFF
--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportCommon.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportCommon.java
@@ -93,6 +93,7 @@ abstract class ExportCommon {
         this.genericObjBatcher = genericObjBatcher;
 
         exporter.progressListener().progress(ProgressEvent.STARTED);
+        prepare(exportContext);
 
         exporter.progressListener().progress(ProgressEvent.START_COMMITS);
         HeadsAndForks headsAndForks = exportCommits(exportContext);
@@ -145,6 +146,8 @@ abstract class ExportCommon {
   ExportVersion getExportVersion() {
     return exportVersion;
   }
+
+  abstract void prepare(ExportContext exportContext);
 
   abstract void exportReferences(ExportContext exportContext);
 

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportContents.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportContents.java
@@ -71,6 +71,11 @@ final class ExportContents extends ExportCommon {
     store = exporter.versionStore();
   }
 
+  @Override
+  void prepare(ExportContext exportContext) {
+    // nop
+  }
+
   private <T> List<T> take(int n, Iterator<T> it) {
     List<T> result = new ArrayList<>(n);
     while (n-- > 0 && it.hasNext()) {


### PR DESCRIPTION
To make concurrent commits do not advance ref HEADs beyond the set of exported commits.