### PR TITLE
Remove OIDC from dependencies of nessie-catalog-service-rest

### DIFF
--- a/catalog/service/rest/build.gradle.kts
+++ b/catalog/service/rest/build.gradle.kts
@@ -45,7 +45,6 @@ dependencies {
   implementation(enforcedPlatform(libs.quarkus.bom))
   implementation("io.quarkus.resteasy.reactive:resteasy-reactive-common")
   implementation("io.quarkus.resteasy.reactive:resteasy-reactive")
-  implementation("io.quarkus:quarkus-oidc")
 
   implementation(platform(libs.jackson.bom))
   implementation("com.fasterxml.jackson.core:jackson-databind")


### PR DESCRIPTION
It was not necessary.