### PR TITLE
Bump timeout in release workflows

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -83,7 +83,7 @@ jobs:
     name: Publish to Maven Central
     runs-on: ubuntu-22.04
     environment: release
-    timeout-minutes: 150
+    timeout-minutes: 240
     needs:
       - prepare
     env:

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -14,7 +14,7 @@ jobs:
   publish-to-maven:
     name: Publish to Maven Central
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 240
     env:
       SPARK_LOCAL_IP: localhost
     if: github.repository == 'projectnessie/nessie'


### PR DESCRIPTION
... due to recent release workflow runs cancelled by Github.