### PR TITLE
Fix missing OAuth token for GCS IT

### DIFF
--- a/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/gcs/ITGcsIcebergCatalog.java
+++ b/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/gcs/ITGcsIcebergCatalog.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
 import org.projectnessie.server.catalog.AbstractIcebergCatalogIntTests;
 import org.projectnessie.server.catalog.GcsEmulatorTestResourceLifecycleManager;
+import org.projectnessie.server.catalog.GcsToken;
 import org.projectnessie.server.catalog.WarehouseLocation;
 
 @QuarkusTestResource(
@@ -33,10 +34,15 @@ import org.projectnessie.server.catalog.WarehouseLocation;
 public class ITGcsIcebergCatalog extends AbstractIcebergCatalogIntTests {
 
   @WarehouseLocation URI warehouseLocation;
+  @GcsToken String gcsToken;
 
   @Override
   protected Map<String, String> catalogOptions() {
-    return Map.of(CatalogProperties.WAREHOUSE_LOCATION, warehouseLocation.toString());
+    return Map.of(
+        CatalogProperties.WAREHOUSE_LOCATION,
+        warehouseLocation.toString(),
+        "gcs.oauth2.token",
+        gcsToken);
   }
 
   @Override

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/GcsEmulatorTestResourceLifecycleManager.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/GcsEmulatorTestResourceLifecycleManager.java
@@ -52,5 +52,7 @@ public class GcsEmulatorTestResourceLifecycleManager
     testInjector.injectIntoFields(
         warehouseLocation,
         new TestInjector.AnnotatedAndMatchesType(WarehouseLocation.class, URI.class));
+    testInjector.injectIntoFields(
+        gcs.oauth2token(), new TestInjector.AnnotatedAndMatchesType(GcsToken.class, String.class));
   }
 }

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/GcsToken.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/GcsToken.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.server.catalog;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface GcsToken {}


### PR DESCRIPTION
`ITGcsIcebergCatalog` currently fails due to the missing OAuth2 token, related to #9100.