### PR TITLE
Include LoggingConfigSourceInterceptor to help diagnose configuration issues

### DIFF
--- a/servers/quarkus-common/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
+++ b/servers/quarkus-common/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
@@ -17,3 +17,4 @@
 org.projectnessie.quarkus.config.OpenTelemetryConfigSourceInterceptor
 org.projectnessie.quarkus.config.datasource.DataSourceActivator
 org.projectnessie.quarkus.config.datasource.JdbcUrlInterceptor
+io.smallrye.config.LoggingConfigSourceInterceptor

--- a/site/in-dev/configuration.md
+++ b/site/in-dev/configuration.md
@@ -459,3 +459,15 @@ The extensive list of supported environment variables can be found
 | `HTTPS_PROXY`                    | The location of the https proxy. (example: "myuser@127.0.0.1:8080")                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | `HTTP_PROXY`                     | The location of the http proxy. (example: "myuser@127.0.0.1:8080")                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `NO_PROXY`                       | A comma separated lists of hosts, IP addresses or domains that can be accessed directly. (example: "foo.example.com,bar.example.com")                                                                                                                                                                                                                                                                                                                                                                                                                            |
+
+
+## Troubleshooting configuration issues
+
+If you encounter issues with the configuration, you can ask Nessie to print out the configuration it
+is using. To do this, set the log level for the `io.smallrye.config` category to `DEBUG`, and also
+set the console appender level to `DEBUG`:
+
+```properties
+quarkus.log.console.level=DEBUG
+quarkus.log.category."io.smallrye.config".level=DEBUG
+```


### PR DESCRIPTION
This logger is by default disabled since it operates at DEBUG level, so nothing changes in the logging configuration or in the startup speed, unless the user explicitly sets `quarkus.log.category."io.smallrye.config".level=DEBUG`.