### PR TITLE
Remove unused config: `quarkus.resteasy-reactive.gzip.enabled=true`

### DIFF
--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -284,7 +284,6 @@ quarkus.http.test-port=0
 quarkus.http.access-log.enabled=true
 # fixed at buildtime
 quarkus.resteasy-reactive.path=/
-quarkus.resteasy-reactive.gzip.enabled=true
 quarkus.http.enable-compression=true
 quarkus.http.enable-decompression=true
 quarkus.http.body.handle-file-uploads=false


### PR DESCRIPTION
```
2024-07-26 17:07:46,870 WARN  [io.qua.config] (main) Unrecognized configuration key "quarkus.rest.gzip.enabled" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
```

Note: `quarkus.http.enable-compression=true` is still set.