### PR TITLE
Replace `quarkus-resteasy-reactive` with `quarkus-rest`

### DIFF
--- a/servers/quarkus-distcache/build.gradle.kts
+++ b/servers/quarkus-distcache/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
 
   implementation(enforcedPlatform(libs.quarkus.bom))
   implementation("io.quarkus:quarkus-core")
-  implementation("io.quarkus:quarkus-resteasy-reactive")
+  implementation("io.quarkus:quarkus-rest")
 
   implementation("com.fasterxml.jackson.core:jackson-databind")
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")

--- a/servers/quarkus-rest/build.gradle.kts
+++ b/servers/quarkus-rest/build.gradle.kts
@@ -31,8 +31,8 @@ dependencies {
 
   implementation(enforcedPlatform(libs.quarkus.bom))
   implementation("io.quarkus:quarkus-core")
-  implementation("io.quarkus:quarkus-resteasy-reactive")
-  implementation("io.quarkus:quarkus-resteasy-reactive-jackson")
+  implementation("io.quarkus:quarkus-rest")
+  implementation("io.quarkus:quarkus-rest-jackson")
 
   implementation("com.fasterxml.jackson.core:jackson-databind")
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -63,8 +63,8 @@ dependencies {
 
   implementation(enforcedPlatform(libs.quarkus.bom))
   implementation(enforcedPlatform(libs.quarkus.amazon.services.bom))
-  implementation("io.quarkus:quarkus-resteasy-reactive")
-  implementation("io.quarkus:quarkus-resteasy-reactive-jackson")
+  implementation("io.quarkus:quarkus-rest")
+  implementation("io.quarkus:quarkus-rest-jackson")
   implementation("io.quarkus:quarkus-reactive-routes")
   implementation("io.quarkus:quarkus-core-deployment")
   implementation("io.quarkus:quarkus-hibernate-validator")

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -283,8 +283,6 @@ quarkus.http.port=19120
 quarkus.http.test-port=0
 quarkus.http.access-log.enabled=true
 # fixed at buildtime
-quarkus.resteasy-reactive.path=/
-quarkus.resteasy-reactive.gzip.enabled=true
 quarkus.http.enable-compression=true
 quarkus.http.enable-decompression=true
 quarkus.http.body.handle-file-uploads=false


### PR DESCRIPTION
The `quarkus-resteasy-reactive` artifacts are already just relocations to the `quarkus-rest` artifacts. The relocations are going away in Quarkus 3.16.