### PR TITLE
Add signer-keys service

### DIFF
--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/api/SignerKeysService.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/api/SignerKeysService.java
@@ -29,12 +29,12 @@ public interface SignerKeysService {
    * the implementation ensures that the returned key will not expire within "too soon" (usually a
    * few days or many hours).
    */
-  SignerKey currentSigningKey();
+  SignerKey currentSignerKey();
 
   /**
    * Retrieve a {@linkplain SignerKey signer key} by name, returns {@code null} if no such signer
    * key exists.
    */
   @Nullable
-  SignerKey getSigningKey(String signingKey);
+  SignerKey getSignerKey(String signerKey);
 }

--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/api/SignerKeysService.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/api/SignerKeysService.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.service.api;
+
+import jakarta.annotation.Nullable;
+import org.projectnessie.catalog.service.objtypes.SignerKey;
+
+/**
+ * Provides a stateless service providing named secret keys, called <em>signer keys</em>. Those
+ * signer keys are for example used to sign the S3 sign endpoint parameters.
+ */
+public interface SignerKeysService {
+
+  /**
+   * Returns the current {@linkplain SignerKey signer key} that can be used for signing purposes,
+   * the implementation ensures that the returned key will not expire within "too soon" (usually a
+   * few days or many hours).
+   */
+  SignerKey currentSigningKey();
+
+  /**
+   * Retrieve a {@linkplain SignerKey signer key} by name, returns {@code null} if no such signer
+   * key exists.
+   */
+  @Nullable
+  SignerKey getSigningKey(String signingKey);
+}

--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/CatalogObjTypeBundle.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/CatalogObjTypeBundle.java
@@ -24,5 +24,6 @@ public class CatalogObjTypeBundle implements ObjTypeBundle {
   public void register(Consumer<ObjType> registrar) {
     registrar.accept(EntityObj.OBJ_TYPE);
     registrar.accept(EntitySnapshotObj.OBJ_TYPE);
+    registrar.accept(SignerKeysObj.OBJ_TYPE);
   }
 }

--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/SignerKey.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/SignerKey.java
@@ -44,11 +44,7 @@ public interface SignerKey {
   @JsonIgnore
   @Value.Lazy
   default SecretKeySpec secretKeySpec() {
-    int pre = "NessieSign:".length();
-    int keyLen = secretKey().length;
-    byte[] secretKeyBytes = Arrays.copyOf("NessieSign:".getBytes(UTF_8), pre + keyLen);
-    System.arraycopy(secretKey(), 0, secretKeyBytes, pre, keyLen);
-    return new SecretKeySpec(secretKeyBytes, "hmacSha256");
+    return new SecretKeySpec(secretKey(), "hmacSha256");
   }
 
   @Value.Check

--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/SignerKey.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/SignerKey.java
@@ -16,13 +16,11 @@
 package org.projectnessie.catalog.service.objtypes;
 
 import static com.google.common.base.Preconditions.checkState;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.time.Instant;
-import java.util.Arrays;
 import javax.crypto.spec.SecretKeySpec;
 import org.immutables.value.Value;
 import org.projectnessie.nessie.immutables.NessieImmutable;

--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/SignerKey.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/SignerKey.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.service.objtypes;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.time.Instant;
+import javax.crypto.spec.SecretKeySpec;
+import org.immutables.value.Value;
+import org.projectnessie.nessie.immutables.NessieImmutable;
+
+@NessieImmutable
+@JsonSerialize(as = ImmutableSignerKey.class)
+@JsonDeserialize(as = ImmutableSignerKey.class)
+public interface SignerKey {
+  String name();
+
+  String secretKey();
+
+  Instant creationTime();
+
+  Instant rotationTime();
+
+  Instant expirationTime();
+
+  @JsonIgnore
+  @Value.Lazy
+  default SecretKeySpec secretKeySpec() {
+    byte[] secretKeyBytes = ("NessieSign:" + secretKey()).getBytes(UTF_8);
+    return new SecretKeySpec(secretKeyBytes, "hmacSha256");
+  }
+
+  @Value.Check
+  default void check() {
+    checkState(!name().isEmpty(), "Key name must not be empty");
+    checkState(secretKey().length() >= 8, "Secret key too short");
+    checkState(
+        creationTime().compareTo(rotationTime()) < 0, "creationTime must be before rotationTime");
+    checkState(
+        rotationTime().compareTo(expirationTime()) < 0,
+        "rotationTime must be before expirationTime");
+  }
+
+  static ImmutableSignerKey.Builder builder() {
+    return ImmutableSignerKey.builder();
+  }
+}

--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/SignerKeysObj.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/SignerKeysObj.java
@@ -55,6 +55,12 @@ public interface SignerKeysObj extends UpdateableObj {
     return OBJ_TYPE;
   }
 
+  /**
+   * Signer keys in chronological order, most recent one at the end.
+   *
+   * <p>Implementation note: the whole {@link SignerKeysObj} object is deserialized from the persist
+   * cache for every access, so keeping a map does not help performance.
+   */
   List<SignerKey> signerKeys();
 
   @Value.NonAttribute

--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/SignerKeysObj.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/SignerKeysObj.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.service.objtypes;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.projectnessie.versioned.storage.common.objtypes.CustomObjType.customObjType;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+import org.immutables.value.Value;
+import org.projectnessie.nessie.immutables.NessieImmutable;
+import org.projectnessie.versioned.storage.common.objtypes.UpdateableObj;
+import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
+
+@NessieImmutable
+@JsonSerialize(as = ImmutableSignerKeysObj.class)
+@JsonDeserialize(as = ImmutableSignerKeysObj.class)
+// Suppress: "Constructor parameters should be better defined on the same level of inheritance
+// hierarchy..."
+@SuppressWarnings("immutables:subtype")
+public interface SignerKeysObj extends UpdateableObj {
+  ObjType OBJ_TYPE = customObjType("signer-keys", "sig-keys", SignerKeysObj.class);
+
+  ObjId OBJ_ID = ObjId.objIdFromByteArray("signer-keys-singleton".getBytes(UTF_8));
+
+  static ImmutableSignerKeysObj.Builder builder() {
+    return ImmutableSignerKeysObj.builder();
+  }
+
+  @Override
+  @Value.Default
+  default ObjId id() {
+    return OBJ_ID;
+  }
+
+  @Override
+  @Value.Default
+  default ObjType type() {
+    return OBJ_TYPE;
+  }
+
+  List<SignerKey> signerKeys();
+
+  @Value.NonAttribute
+  default SignerKey getSignerKey(String name) {
+    for (SignerKey signerKey : signerKeys()) {
+      if (signerKey.name().equals(name)) {
+        return signerKey;
+      }
+    }
+    return null;
+  }
+
+  @Value.Check
+  default void check() {
+    checkState(!signerKeys().isEmpty(), "At least one signer-key is required");
+    checkState(
+        signerKeys().stream().map(SignerKey::name).distinct().count() == signerKeys().size(),
+        "Duplicate signer key names");
+  }
+}

--- a/catalog/service/common/src/test/java/org/projectnessie/catalog/service/objtypes/TestSignerKey.java
+++ b/catalog/service/common/src/test/java/org/projectnessie/catalog/service/objtypes/TestSignerKey.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.catalog.service.objtypes;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
@@ -45,7 +46,7 @@ public class TestSignerKey {
     SignerKey key =
         SignerKey.builder()
             .name("key")
-            .secretKey("secret-key")
+            .secretKey("01234567890123456789012345678901".getBytes(UTF_8))
             .creationTime(creation)
             .rotationTime(rotation)
             .expirationTime(expiration)
@@ -63,11 +64,13 @@ public class TestSignerKey {
     Instant rotation = creation.plus(1, DAYS);
     Instant expiration = rotation.plus(1, DAYS);
 
+    byte[] secretKey = "01234567890123456789012345678901".getBytes(UTF_8);
+
     return Stream.of(
         arguments(
             SignerKey.builder()
                 .name("key")
-                .secretKey("secret-key")
+                .secretKey(secretKey)
                 .creationTime(creation)
                 .rotationTime(creation)
                 .expirationTime(expiration),
@@ -75,7 +78,7 @@ public class TestSignerKey {
         arguments(
             SignerKey.builder()
                 .name("key")
-                .secretKey("secret-key")
+                .secretKey(secretKey)
                 .creationTime(rotation)
                 .rotationTime(creation)
                 .expirationTime(expiration),
@@ -83,7 +86,7 @@ public class TestSignerKey {
         arguments(
             SignerKey.builder()
                 .name("key")
-                .secretKey("secret-key")
+                .secretKey(secretKey)
                 .creationTime(creation)
                 .rotationTime(rotation)
                 .expirationTime(rotation),
@@ -91,7 +94,7 @@ public class TestSignerKey {
         arguments(
             SignerKey.builder()
                 .name("key")
-                .secretKey("secret-key")
+                .secretKey(secretKey)
                 .creationTime(creation)
                 .rotationTime(expiration)
                 .expirationTime(rotation),
@@ -99,7 +102,7 @@ public class TestSignerKey {
         arguments(
             SignerKey.builder()
                 .name("")
-                .secretKey("secret-key")
+                .secretKey(secretKey)
                 .creationTime(creation)
                 .rotationTime(rotation)
                 .expirationTime(expiration),
@@ -107,7 +110,7 @@ public class TestSignerKey {
         arguments(
             SignerKey.builder()
                 .name("name")
-                .secretKey("")
+                .secretKey("".getBytes(UTF_8))
                 .creationTime(creation)
                 .rotationTime(rotation)
                 .expirationTime(expiration),
@@ -115,7 +118,7 @@ public class TestSignerKey {
         arguments(
             SignerKey.builder()
                 .name("name")
-                .secretKey("1234567")
+                .secretKey("1234567".getBytes(UTF_8))
                 .creationTime(creation)
                 .rotationTime(rotation)
                 .expirationTime(expiration),

--- a/catalog/service/common/src/test/java/org/projectnessie/catalog/service/objtypes/TestSignerKey.java
+++ b/catalog/service/common/src/test/java/org/projectnessie/catalog/service/objtypes/TestSignerKey.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.service.objtypes;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.time.Instant;
+import java.util.stream.Stream;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TestSignerKey {
+
+  @ParameterizedTest
+  @MethodSource
+  public void signerKeyCheck(ImmutableSignerKey.Builder builder, String message) {
+    assertThatIllegalStateException().isThrownBy(builder::build).withMessage(message);
+  }
+
+  @Test
+  public void signerKeySpec() {
+    Instant creation = Instant.now();
+    Instant rotation = creation.plus(1, DAYS);
+    Instant expiration = rotation.plus(1, DAYS);
+
+    SignerKey key =
+        SignerKey.builder()
+            .name("key")
+            .secretKey("secret-key")
+            .creationTime(creation)
+            .rotationTime(rotation)
+            .expirationTime(expiration)
+            .build();
+
+    assertThat(key)
+        .extracting(SignerKey::secretKeySpec)
+        .isNotNull()
+        .extracting(SecretKeySpec::getAlgorithm, SecretKeySpec::getFormat)
+        .doesNotContainNull();
+  }
+
+  static Stream<Arguments> signerKeyCheck() {
+    Instant creation = Instant.now();
+    Instant rotation = creation.plus(1, DAYS);
+    Instant expiration = rotation.plus(1, DAYS);
+
+    return Stream.of(
+        arguments(
+            SignerKey.builder()
+                .name("key")
+                .secretKey("secret-key")
+                .creationTime(creation)
+                .rotationTime(creation)
+                .expirationTime(expiration),
+            "creationTime must be before rotationTime"),
+        arguments(
+            SignerKey.builder()
+                .name("key")
+                .secretKey("secret-key")
+                .creationTime(rotation)
+                .rotationTime(creation)
+                .expirationTime(expiration),
+            "creationTime must be before rotationTime"),
+        arguments(
+            SignerKey.builder()
+                .name("key")
+                .secretKey("secret-key")
+                .creationTime(creation)
+                .rotationTime(rotation)
+                .expirationTime(rotation),
+            "rotationTime must be before expirationTime"),
+        arguments(
+            SignerKey.builder()
+                .name("key")
+                .secretKey("secret-key")
+                .creationTime(creation)
+                .rotationTime(expiration)
+                .expirationTime(rotation),
+            "rotationTime must be before expirationTime"),
+        arguments(
+            SignerKey.builder()
+                .name("")
+                .secretKey("secret-key")
+                .creationTime(creation)
+                .rotationTime(rotation)
+                .expirationTime(expiration),
+            "Key name must not be empty"),
+        arguments(
+            SignerKey.builder()
+                .name("name")
+                .secretKey("")
+                .creationTime(creation)
+                .rotationTime(rotation)
+                .expirationTime(expiration),
+            "Secret key too short"),
+        arguments(
+            SignerKey.builder()
+                .name("name")
+                .secretKey("1234567")
+                .creationTime(creation)
+                .rotationTime(rotation)
+                .expirationTime(expiration),
+            "Secret key too short"));
+  }
+}

--- a/catalog/service/common/src/test/java/org/projectnessie/catalog/service/objtypes/TestSignerKeysObj.java
+++ b/catalog/service/common/src/test/java/org/projectnessie/catalog/service/objtypes/TestSignerKeysObj.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.catalog.service.objtypes;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -40,9 +41,27 @@ public class TestSignerKeysObj {
     Instant rotation = creation.plus(1, DAYS);
     Instant expiration = rotation.plus(1, DAYS);
 
-    SignerKey key1 = ImmutableSignerKey.of("key1", "secret-key-1", creation, rotation, expiration);
-    SignerKey key2 = ImmutableSignerKey.of("key2", "secret-key-2", creation, rotation, expiration);
-    SignerKey key3 = ImmutableSignerKey.of("key3", "secret-key-3", creation, rotation, expiration);
+    SignerKey key1 =
+        ImmutableSignerKey.of(
+            "key1",
+            "01234567890123456789012345678901".getBytes(UTF_8),
+            creation,
+            rotation,
+            expiration);
+    SignerKey key2 =
+        ImmutableSignerKey.of(
+            "key2",
+            "01234567890123456789012345678902".getBytes(UTF_8),
+            creation,
+            rotation,
+            expiration);
+    SignerKey key3 =
+        ImmutableSignerKey.of(
+            "key3",
+            "01234567890123456789012345678903".getBytes(UTF_8),
+            creation,
+            rotation,
+            expiration);
     SignerKeysObj signerKeys =
         SignerKeysObj.builder().versionToken("foo").addSignerKeys(key1, key2, key3).build();
 
@@ -63,8 +82,20 @@ public class TestSignerKeysObj {
     Instant rotation = creation.plus(1, DAYS);
     Instant expiration = rotation.plus(1, DAYS);
 
-    SignerKey key1 = ImmutableSignerKey.of("key1", "secret-key-1", creation, rotation, expiration);
-    SignerKey key1b = ImmutableSignerKey.of("key1", "secret-key-2", creation, rotation, expiration);
+    SignerKey key1 =
+        ImmutableSignerKey.of(
+            "key1",
+            "01234567890123456789012345678901".getBytes(UTF_8),
+            creation,
+            rotation,
+            expiration);
+    SignerKey key1b =
+        ImmutableSignerKey.of(
+            "key1",
+            "01234567890123456789012345678902".getBytes(UTF_8),
+            creation,
+            rotation,
+            expiration);
 
     return Stream.of(
         arguments(

--- a/catalog/service/common/src/test/java/org/projectnessie/catalog/service/objtypes/TestSignerKeysObj.java
+++ b/catalog/service/common/src/test/java/org/projectnessie/catalog/service/objtypes/TestSignerKeysObj.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.service.objtypes;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.time.Instant;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestSignerKeysObj {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @Test
+  public void signerKeyByName() {
+    Instant creation = Instant.now();
+    Instant rotation = creation.plus(1, DAYS);
+    Instant expiration = rotation.plus(1, DAYS);
+
+    SignerKey key1 = ImmutableSignerKey.of("key1", "secret-key-1", creation, rotation, expiration);
+    SignerKey key2 = ImmutableSignerKey.of("key2", "secret-key-2", creation, rotation, expiration);
+    SignerKey key3 = ImmutableSignerKey.of("key3", "secret-key-3", creation, rotation, expiration);
+    SignerKeysObj signerKeys =
+        SignerKeysObj.builder().versionToken("foo").addSignerKeys(key1, key2, key3).build();
+
+    soft.assertThat(signerKeys.getSignerKey("key1")).isEqualTo(key1);
+    soft.assertThat(signerKeys.getSignerKey("key2")).isEqualTo(key2);
+    soft.assertThat(signerKeys.getSignerKey("key3")).isEqualTo(key3);
+    soft.assertThat(signerKeys.getSignerKey("nah")).isNull();
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  public void signerKeysCheck(ImmutableSignerKeysObj.Builder builder, String message) {
+    assertThatIllegalStateException().isThrownBy(builder::build).withMessage(message);
+  }
+
+  static Stream<Arguments> signerKeysCheck() {
+    Instant creation = Instant.now();
+    Instant rotation = creation.plus(1, DAYS);
+    Instant expiration = rotation.plus(1, DAYS);
+
+    SignerKey key1 = ImmutableSignerKey.of("key1", "secret-key-1", creation, rotation, expiration);
+    SignerKey key1b = ImmutableSignerKey.of("key1", "secret-key-2", creation, rotation, expiration);
+
+    return Stream.of(
+        arguments(
+            SignerKeysObj.builder().versionToken("ver"), "At least one signer-key is required"),
+        arguments(
+            SignerKeysObj.builder().versionToken("ver").addSignerKeys(key1, key1b),
+            "Duplicate signer key names"));
+  }
+}

--- a/catalog/service/impl/build.gradle.kts
+++ b/catalog/service/impl/build.gradle.kts
@@ -69,8 +69,10 @@ dependencies {
   testFixturesApi(project(":nessie-services"))
   testFixturesApi(project(":nessie-services-config"))
   testFixturesApi(project(":nessie-versioned-spi"))
+  testFixturesApi(project(":nessie-versioned-storage-common"))
   testFixturesApi(project(":nessie-versioned-storage-store"))
   testFixturesApi(project(":nessie-rest-services"))
+  testFixturesApi(libs.threeten.extra)
 
   testImplementation(platform(libs.awssdk.bom))
   testImplementation("software.amazon.awssdk:s3")

--- a/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/SignerKeysServiceImpl.java
+++ b/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/SignerKeysServiceImpl.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.service.impl;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.util.UUID.randomUUID;
+
+import com.google.common.annotations.VisibleForTesting;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import org.projectnessie.catalog.service.api.SignerKeysService;
+import org.projectnessie.catalog.service.objtypes.ImmutableSignerKeysObj;
+import org.projectnessie.catalog.service.objtypes.SignerKey;
+import org.projectnessie.catalog.service.objtypes.SignerKeysObj;
+import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
+import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
+import org.projectnessie.versioned.storage.common.objtypes.UpdateableObj;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+
+/**
+ * Signer keys service implementation based on {@link Persist} using a {@link SignerKeysObj} per
+ * Nessie repository. Relies on Nessie's distributed cache invalidation, when used in a horizontally
+ * scaled setup (multiple Nessie processes serving the same repository).
+ */
+@RequestScoped
+public class SignerKeysServiceImpl implements SignerKeysService {
+  public static final long SPIN_LOOP_MIN_SLEEP_MILLIS = 20;
+  public static final long SPIN_LOOP_MAX_SLEEP_MILLIS = 200;
+  public static final Duration NEW_KEY_ROTATE_AFTER = Duration.of(3, DAYS);
+  public static final Duration NEW_KEY_EXPIRE_AFTER = Duration.of(5, DAYS);
+
+  @Inject Persist persist;
+
+  @VisibleForTesting Clock clock = Clock.systemUTC();
+
+  /**
+   * Called for every access to this request-scoped service implementation. Fetches the {@link
+   * SignerKeysObj} or creates a new one with a signer key.
+   */
+  private SignerKeysObj loadOrCreate() {
+    SignerKeysObj signerKeys;
+
+    while (true) {
+      try {
+        signerKeys =
+            persist.fetchTypedObj(
+                SignerKeysObj.OBJ_ID, SignerKeysObj.OBJ_TYPE, SignerKeysObj.class);
+        break;
+      } catch (ObjNotFoundException notFound) {
+        signerKeys = addNewKey(null);
+        try {
+          if (storeInitial(signerKeys)) {
+            break;
+          }
+          persistSpinLoop();
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+
+    return signerKeys;
+  }
+
+  private static void persistSpinLoop() throws InterruptedException {
+    Thread.sleep(
+        ThreadLocalRandom.current()
+            .nextLong(SPIN_LOOP_MIN_SLEEP_MILLIS, SPIN_LOOP_MAX_SLEEP_MILLIS));
+  }
+
+  /**
+   * Updates {@code current} by adding a new {@link SignerKey} to the end of the {@linkplain
+   * SignerKeysObj#signerKeys() signer-keys list} and setting a new {@linkplain
+   * UpdateableObj#versionToken() version token}.
+   */
+  private SignerKeysObj addNewKey(SignerKeysObj current) {
+    Instant now = clock.instant();
+    Instant rotation = now.plus(NEW_KEY_ROTATE_AFTER);
+    Instant expires = now.plus(NEW_KEY_EXPIRE_AFTER);
+
+    byte[] secretBytes = new byte[32];
+    try {
+      SecureRandom.getInstanceStrong().nextBytes(secretBytes);
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+    String secretKey = Base64.getEncoder().encodeToString(secretBytes);
+
+    ImmutableSignerKeysObj.Builder keys = ImmutableSignerKeysObj.builder();
+    if (current != null) {
+      keys.from(current);
+    }
+
+    keys.versionToken(randomUUID().toString()).signerKeys(List.of());
+
+    if (current != null) {
+      for (SignerKey signerKey : current.signerKeys()) {
+        if (signerKey.expirationTime().compareTo(now) > 0) {
+          keys.addSignerKey(signerKey);
+        }
+      }
+    }
+
+    return keys.addSignerKey(
+            SignerKey.builder()
+                .name(randomUUID().toString())
+                .secretKey(secretKey)
+                .creationTime(now)
+                .rotationTime(rotation)
+                .expirationTime(expires)
+                .build())
+        .build();
+  }
+
+  @Override
+  public SignerKey getSigningKey(String signingKey) {
+    SignerKeysObj keys = loadOrCreate();
+    return keys.getSignerKey(signingKey);
+  }
+
+  @Override
+  public SignerKey currentSigningKey() {
+    Instant now = clock.instant();
+
+    while (true) {
+      SignerKeysObj keys = loadOrCreate();
+      if (keys == null) {
+        keys = loadOrCreate();
+      }
+
+      SignerKey current = keys.signerKeys().get(keys.signerKeys().size() - 1);
+      if (current.rotationTime().compareTo(now) <= 0) {
+        SignerKeysObj updated = addNewKey(keys);
+        try {
+          if (!updateKeys(keys, updated)) {
+            persistSpinLoop();
+          }
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+        continue;
+      }
+
+      return current;
+    }
+  }
+
+  @VisibleForTesting
+  boolean storeInitial(SignerKeysObj signerKeys) throws ObjTooLargeException {
+    return persist.storeObj(signerKeys);
+  }
+
+  @VisibleForTesting
+  boolean updateKeys(SignerKeysObj keys, SignerKeysObj updated) throws ObjTooLargeException {
+    return persist.updateConditional(keys, updated);
+  }
+}

--- a/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/SignerKeysServiceImpl.java
+++ b/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/SignerKeysServiceImpl.java
@@ -72,7 +72,6 @@ public class SignerKeysServiceImpl implements SignerKeysService {
           if (storeInitial(signerKeys)) {
             break;
           }
-          persistSpinLoop();
         } catch (Exception e) {
           throw new RuntimeException(e);
         }
@@ -80,12 +79,6 @@ public class SignerKeysServiceImpl implements SignerKeysService {
     }
 
     return signerKeys;
-  }
-
-  private static void persistSpinLoop() throws InterruptedException {
-    Thread.sleep(
-        ThreadLocalRandom.current()
-            .nextLong(SPIN_LOOP_MIN_SLEEP_MILLIS, SPIN_LOOP_MAX_SLEEP_MILLIS));
   }
 
   /**
@@ -169,5 +162,11 @@ public class SignerKeysServiceImpl implements SignerKeysService {
   @VisibleForTesting
   boolean updateKeys(SignerKeysObj keys, SignerKeysObj updated) throws ObjTooLargeException {
     return persist.updateConditional(keys, updated);
+  }
+
+  private static void persistSpinLoop() throws InterruptedException {
+    Thread.sleep(
+        ThreadLocalRandom.current()
+            .nextLong(SPIN_LOOP_MIN_SLEEP_MILLIS, SPIN_LOOP_MAX_SLEEP_MILLIS));
   }
 }

--- a/catalog/service/impl/src/test/java/org/projectnessie/catalog/service/impl/TestSignerKeysServiceImpl.java
+++ b/catalog/service/impl/src/test/java/org/projectnessie/catalog/service/impl/TestSignerKeysServiceImpl.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.service.impl;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.projectnessie.catalog.service.impl.SignerKeysServiceImpl.NEW_KEY_EXPIRE_AFTER;
+import static org.projectnessie.catalog.service.impl.SignerKeysServiceImpl.NEW_KEY_ROTATE_AFTER;
+import static org.projectnessie.catalog.service.objtypes.SignerKeysObj.OBJ_ID;
+import static org.projectnessie.catalog.service.objtypes.SignerKeysObj.OBJ_TYPE;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.catalog.service.objtypes.ImmutableSignerKey;
+import org.projectnessie.catalog.service.objtypes.SignerKey;
+import org.projectnessie.catalog.service.objtypes.SignerKeysObj;
+import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
+import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+import org.projectnessie.versioned.storage.testextension.NessiePersist;
+import org.projectnessie.versioned.storage.testextension.NessiePersistCache;
+import org.projectnessie.versioned.storage.testextension.PersistExtension;
+import org.threeten.extra.MutableClock;
+
+@ExtendWith({PersistExtension.class, SoftAssertionsExtension.class})
+@NessiePersistCache // should test w/ persist-cache to exercise custom obj type serialization
+public class TestSignerKeysServiceImpl {
+
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @NessiePersist protected Persist persist;
+
+  protected Instant initialInstant;
+  protected MutableClock clock;
+
+  protected SignerKeysServiceImpl service;
+
+  protected Function<SignerKeysObj, Boolean> storeInitialTweak;
+  protected BiFunction<SignerKeysObj, SignerKeysObj, Boolean> updateKeysTweak;
+
+  @BeforeEach
+  protected void setup() {
+    initialInstant = Instant.now();
+    clock = MutableClock.of(initialInstant, ZoneId.of("Z"));
+
+    storeInitialTweak = o -> null;
+    updateKeysTweak = (c, u) -> null;
+
+    service =
+        spy(
+            new SignerKeysServiceImpl() {
+              @Override
+              boolean storeInitial(SignerKeysObj signerKeys) throws ObjTooLargeException {
+                Boolean r = storeInitialTweak.apply(signerKeys);
+                return r != null ? r : super.storeInitial(signerKeys);
+              }
+
+              @Override
+              boolean updateKeys(SignerKeysObj keys, SignerKeysObj updated)
+                  throws ObjTooLargeException {
+                Boolean r = updateKeysTweak.apply(keys, updated);
+                return r != null ? r : super.updateKeys(keys, updated);
+              }
+            });
+    service.persist = persist;
+    service.clock = clock;
+  }
+
+  @Test
+  public void lifecycle() throws Exception {
+    soft.assertThatThrownBy(() -> persist.fetchTypedObj(OBJ_ID, OBJ_TYPE, SignerKeysObj.class))
+        .isInstanceOf(ObjNotFoundException.class);
+    soft.assertThat(service.getSigningKey("foo")).isNull();
+    soft.assertThatCode(() -> persist.fetchTypedObj(OBJ_ID, OBJ_TYPE, SignerKeysObj.class))
+        .doesNotThrowAnyException();
+
+    // Notes: NEW_KEY_ROTATE_AFTER is 3 days
+    soft.assertThat(NEW_KEY_ROTATE_AFTER).isEqualTo(Duration.of(3, DAYS));
+    soft.assertThat(NEW_KEY_EXPIRE_AFTER).isEqualTo(Duration.of(5, DAYS));
+
+    // Key 1 rotate, Key 2 create
+    Instant day3 = initialInstant.plus(3, DAYS);
+    // Key 1 expire
+    Instant day5 = initialInstant.plus(5, DAYS);
+    // Key 2 rotate (3 + 3), Key 3 create
+    Instant day6 = initialInstant.plus(6, DAYS);
+    // Key 2 expire (3 + 5)
+    Instant day8 = initialInstant.plus(8, DAYS);
+    // Key 3 expire (6 + 3)
+    Instant day9 = initialInstant.plus(9, DAYS);
+
+    // @ day 0
+
+    SignerKey key1 = service.currentSigningKey();
+    soft.assertThat(key1)
+        .isNotNull()
+        .extracting(SignerKey::creationTime, SignerKey::rotationTime, SignerKey::expirationTime)
+        .containsExactly(
+            clock.instant(),
+            clock.instant().plus(NEW_KEY_ROTATE_AFTER),
+            clock.instant().plus(NEW_KEY_EXPIRE_AFTER));
+
+    // @ right before day 3
+
+    clock.setInstant(day3.minus(1, MILLIS));
+    SignerKey key2 = service.currentSigningKey();
+    soft.assertThat(key2).isEqualTo(key1);
+    SignerKeysObj keys = persist.fetchTypedObj(OBJ_ID, OBJ_TYPE, SignerKeysObj.class);
+    soft.assertThat(keys.signerKeys().size()).isEqualTo(1);
+    soft.assertThat(keys.getSignerKey(key1.name())).isEqualTo(key1);
+
+    // @ day 3
+
+    clock.setInstant(day3);
+    key2 = service.currentSigningKey();
+    soft.assertThat(key2).isNotEqualTo(key1);
+    keys = persist.fetchTypedObj(OBJ_ID, OBJ_TYPE, SignerKeysObj.class);
+    soft.assertThat(keys.signerKeys()).containsExactly(key1, key2);
+    soft.assertThat(keys.getSignerKey(key1.name())).isEqualTo(key1);
+    soft.assertThat(keys.getSignerKey(key2.name())).isEqualTo(key2);
+
+    // @ right before day 5
+
+    clock.setInstant(day5.minus(1, MILLIS));
+    soft.assertThat(service.currentSigningKey()).isEqualTo(key2);
+    keys = persist.fetchTypedObj(OBJ_ID, OBJ_TYPE, SignerKeysObj.class);
+    soft.assertThat(keys.signerKeys()).containsExactly(key1, key2);
+    soft.assertThat(keys.getSignerKey(key1.name())).isEqualTo(key1);
+    soft.assertThat(keys.getSignerKey(key2.name())).isEqualTo(key2);
+
+    // @ day 5 (key1 is still there, because no write due to rotation happened)
+
+    clock.setInstant(day5);
+    soft.assertThat(service.currentSigningKey()).isEqualTo(key2);
+    keys = persist.fetchTypedObj(OBJ_ID, OBJ_TYPE, SignerKeysObj.class);
+    soft.assertThat(keys.signerKeys()).containsExactly(key1, key2);
+    soft.assertThat(keys.getSignerKey(key1.name())).isEqualTo(key1);
+    soft.assertThat(keys.getSignerKey(key2.name())).isEqualTo(key2);
+
+    // @ day 6
+
+    clock.setInstant(day6);
+    SignerKey key3 = service.currentSigningKey();
+    soft.assertThat(key3).isNotEqualTo(key2).isNotEqualTo(key1);
+    keys = persist.fetchTypedObj(OBJ_ID, OBJ_TYPE, SignerKeysObj.class);
+    soft.assertThat(keys.signerKeys()).containsExactly(key2, key3);
+    soft.assertThat(keys.getSignerKey(key1.name())).isNull();
+    soft.assertThat(keys.getSignerKey(key2.name())).isEqualTo(key2);
+    soft.assertThat(keys.getSignerKey(key3.name())).isEqualTo(key3);
+
+    // @ day 8
+
+    clock.setInstant(day8);
+    soft.assertThat(service.currentSigningKey()).isEqualTo(key3);
+    keys = persist.fetchTypedObj(OBJ_ID, OBJ_TYPE, SignerKeysObj.class);
+    soft.assertThat(keys.signerKeys()).containsExactly(key2, key3);
+    soft.assertThat(keys.getSignerKey(key1.name())).isNull();
+    soft.assertThat(keys.getSignerKey(key2.name())).isEqualTo(key2);
+    soft.assertThat(keys.getSignerKey(key3.name())).isEqualTo(key3);
+
+    // @ day 9
+
+    clock.setInstant(day9);
+    SignerKey key4 = service.currentSigningKey();
+    soft.assertThat(key4).isNotEqualTo(key3).isNotEqualTo(key2).isNotEqualTo(key1);
+    keys = persist.fetchTypedObj(OBJ_ID, OBJ_TYPE, SignerKeysObj.class);
+    soft.assertThat(keys.signerKeys()).containsExactly(key3, key4);
+    soft.assertThat(keys.getSignerKey(key1.name())).isNull();
+    soft.assertThat(keys.getSignerKey(key2.name())).isNull();
+    soft.assertThat(keys.getSignerKey(key3.name())).isEqualTo(key3);
+    soft.assertThat(keys.getSignerKey(key4.name())).isEqualTo(key4);
+  }
+
+  @Test
+  public void initialCreateFailed() throws Exception {
+    AtomicBoolean storeInitialCalled = new AtomicBoolean(false);
+
+    storeInitialTweak =
+        o -> {
+          if (storeInitialCalled.compareAndSet(false, true)) {
+            return false;
+          }
+          // continue with real impl
+          return null;
+        };
+
+    soft.assertThatThrownBy(() -> persist.fetchTypedObj(OBJ_ID, OBJ_TYPE, SignerKeysObj.class))
+        .isInstanceOf(ObjNotFoundException.class);
+
+    SignerKey key = service.currentSigningKey();
+    soft.assertThat(key).isNotNull();
+
+    verify(service, times(2)).storeInitial(any());
+  }
+
+  @Test
+  public void initialCreateRace() throws Exception {
+    AtomicBoolean storeInitialCalled = new AtomicBoolean(false);
+
+    SignerKey raceKey =
+        ImmutableSignerKey.of(
+            "key-x",
+            "secret-key-data",
+            initialInstant,
+            initialInstant.plus(NEW_KEY_ROTATE_AFTER),
+            initialInstant.plus(NEW_KEY_EXPIRE_AFTER));
+
+    storeInitialTweak =
+        o -> {
+          if (storeInitialCalled.compareAndSet(false, true)) {
+            SignerKeysObj raceObj =
+                SignerKeysObj.builder().versionToken("foo").addSignerKey(raceKey).build();
+            try {
+              assertThat(persist.storeObj(raceObj)).isTrue();
+            } catch (ObjTooLargeException e) {
+              throw new RuntimeException(e);
+            }
+          }
+          // continue with real impl
+          return null;
+        };
+
+    soft.assertThatThrownBy(() -> persist.fetchTypedObj(OBJ_ID, OBJ_TYPE, SignerKeysObj.class))
+        .isInstanceOf(ObjNotFoundException.class);
+
+    SignerKey key = service.currentSigningKey();
+    soft.assertThat(key).isEqualTo(raceKey);
+
+    verify(service, times(1)).storeInitial(any());
+  }
+
+  @Test
+  public void rotateFailed() throws Exception {
+    SignerKey key1 = service.currentSigningKey();
+    soft.assertThat(key1).isNotNull();
+
+    // force a key rotation / call to updateKeys()
+    clock.setInstant(initialInstant.plus(NEW_KEY_ROTATE_AFTER));
+
+    AtomicBoolean updateKeysCalled = new AtomicBoolean(false);
+
+    updateKeysTweak =
+        (k, u) -> {
+          if (updateKeysCalled.compareAndSet(false, true)) {
+            return false;
+          }
+          // continue with real impl
+          return null;
+        };
+
+    SignerKey key2 = service.currentSigningKey();
+    soft.assertThat(key2).isNotEqualTo(key1);
+
+    SignerKeysObj keys = persist.fetchTypedObj(OBJ_ID, OBJ_TYPE, SignerKeysObj.class);
+    soft.assertThat(keys.signerKeys()).containsExactly(key1, key2);
+
+    verify(service, times(2)).updateKeys(any(), any());
+  }
+
+  @Test
+  public void rotateRace() throws Exception {
+    SignerKey key1 = service.currentSigningKey();
+    soft.assertThat(key1).isNotNull();
+
+    // force a key rotation / call to updateKeys()
+    clock.setInstant(initialInstant.plus(NEW_KEY_ROTATE_AFTER));
+
+    reset(service);
+
+    AtomicBoolean updateKeysCalled = new AtomicBoolean(false);
+
+    Instant raceCreate = initialInstant.plus(NEW_KEY_ROTATE_AFTER);
+    SignerKey raceKey =
+        ImmutableSignerKey.of(
+            "key-x",
+            "secret-key-data",
+            raceCreate,
+            raceCreate.plus(NEW_KEY_ROTATE_AFTER),
+            raceCreate.plus(NEW_KEY_EXPIRE_AFTER));
+
+    updateKeysTweak =
+        (k, u) -> {
+          if (updateKeysCalled.compareAndSet(false, true)) {
+            SignerKeysObj raceObj =
+                SignerKeysObj.builder()
+                    .from(k)
+                    .signerKeys(List.of(key1, raceKey))
+                    .versionToken("foo-updated")
+                    .build();
+            try {
+              assertThat(persist.updateConditional(k, raceObj)).isTrue();
+            } catch (ObjTooLargeException e) {
+              throw new RuntimeException(e);
+            }
+          }
+          // continue with real impl, let it race
+          return null;
+        };
+
+    SignerKey key2 = service.currentSigningKey();
+    soft.assertThat(key2).isNotEqualTo(key1).isEqualTo(raceKey);
+
+    verify(service, times(1)).updateKeys(any(), any());
+  }
+}

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/SignerSignature.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/SignerSignature.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.service.rest;
+
+import static com.google.common.hash.Hashing.hmacSha256;
+import static java.net.URLEncoder.encode;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.hash.Hasher;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.projectnessie.catalog.service.objtypes.SignerKey;
+import org.projectnessie.nessie.immutables.NessieImmutable;
+
+@NessieImmutable
+public abstract class SignerSignature {
+
+  public abstract String prefix();
+
+  public abstract String identifier();
+
+  public abstract String warehouseLocation();
+
+  public abstract List<String> writeLocations();
+
+  public abstract List<String> readLocations();
+
+  public abstract long expirationTimestamp();
+
+  @SuppressWarnings("UnstableApiUsage")
+  public String sign(SignerKey signerKey) {
+    Hasher hasher = hmacSha256(signerKey.secretKeySpec()).newHasher();
+    hasher.putLong(expirationTimestamp());
+    hasher.putString("prefix=" + prefix(), UTF_8);
+    hasher.putString("identifier=" + identifier(), UTF_8);
+    hasher.putString("b=" + warehouseLocation(), UTF_8);
+    for (String writeLocation : writeLocations()) {
+      hasher.putString("w=" + writeLocation, UTF_8);
+    }
+    for (String readLocation : readLocations()) {
+      hasher.putString("r=" + readLocation, UTF_8);
+    }
+    return hasher.hash().toString();
+  }
+
+  public String uriQuery(SignerKey signerKey) {
+    String signature = sign(signerKey);
+
+    StringBuilder query =
+        new StringBuilder()
+            .append("e=")
+            .append(expirationTimestamp())
+            .append("&b=")
+            .append(encode(warehouseLocation(), UTF_8))
+            .append("&k=")
+            .append(encode(signerKey.name(), UTF_8))
+            .append("&s=")
+            .append(encode(signature, UTF_8));
+    for (String loc : writeLocations()) {
+      query.append("&w=").append(encode(loc, UTF_8));
+    }
+    for (String loc : readLocations()) {
+      query.append("&r=").append(encode(loc, UTF_8));
+    }
+    return query.toString();
+  }
+
+  public Optional<String> verify(
+      SignerKey signerKey, @NotNull String signature, @NotNull Instant now) {
+    if (signerKey == null) {
+      return Optional.of("Could not find signingKey");
+    }
+
+    String computed = sign(signerKey);
+
+    if (!computed.equals(signature)) {
+      return Optional.of("Got invalid signature");
+    }
+
+    if (expirationTimestamp() <= now.getEpochSecond()) {
+      return Optional.of("Got expired signature");
+    }
+
+    return Optional.empty();
+  }
+
+  static ImmutableSignerSignature.Builder builder() {
+    return ImmutableSignerSignature.builder();
+  }
+}

--- a/catalog/service/rest/src/test/java/org/projectnessie/catalog/service/rest/TestSignerSignature.java
+++ b/catalog/service/rest/src/test/java/org/projectnessie/catalog/service/rest/TestSignerSignature.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.catalog.service.rest;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.Clock.systemUTC;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.time.temporal.ChronoUnit.HOURS;
@@ -40,7 +41,7 @@ public class TestSignerSignature {
     SignerKey key =
         SignerKey.builder()
             .name("key")
-            .secretKey("secret-thing")
+            .secretKey("01234567890123456789012345678901".getBytes(UTF_8))
             .creationTime(now)
             .rotationTime(now.plus(3, DAYS))
             .expirationTime(now.plus(5, DAYS))

--- a/catalog/service/rest/src/test/java/org/projectnessie/catalog/service/rest/TestSignerSignature.java
+++ b/catalog/service/rest/src/test/java/org/projectnessie/catalog/service/rest/TestSignerSignature.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.service.rest;
+
+import static java.time.Clock.systemUTC;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.HOURS;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.catalog.service.objtypes.SignerKey;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestSignerSignature {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @Test
+  public void signAndVerify() {
+    Instant now = Instant.now();
+
+    SignerKey key =
+        SignerKey.builder()
+            .name("key")
+            .secretKey("secret-thing")
+            .creationTime(now)
+            .rotationTime(now.plus(3, DAYS))
+            .expirationTime(now.plus(5, DAYS))
+            .build();
+
+    long expirationTimestamp = systemUTC().instant().plus(3, ChronoUnit.HOURS).getEpochSecond();
+
+    SignerSignature signerSignature =
+        SignerSignature.builder()
+            .prefix("prefix")
+            .identifier("my.namespaced.table")
+            .warehouseLocation("s3://foo-bucket/")
+            .expirationTimestamp(expirationTimestamp)
+            .addWriteLocation("s3://foo-bucket/write/here/")
+            .addWriteLocation("s3://foo-bucket/write-here-as-well/")
+            .addReadLocation("s3://other/read-there/")
+            .build();
+
+    String signature = signerSignature.sign(key);
+    soft.assertThat(signerSignature.verify(key, signature, now)).isEmpty();
+
+    soft.assertThat(signerSignature.verify(null, signature, now))
+        .contains("Could not find signingKey");
+    soft.assertThat(signerSignature.verify(key, "tampered-signature", now))
+        .contains("Got invalid signature");
+    soft.assertThat(signerSignature.verify(key, signature, now.plus(3, HOURS)))
+        .contains("Got expired signature");
+
+    soft.assertThat(
+            SignerSignature.builder()
+                .from(signerSignature)
+                .prefix("not-the-prefix")
+                .build()
+                .verify(key, signature, now))
+        .contains("Got invalid signature");
+    soft.assertThat(
+            SignerSignature.builder()
+                .from(signerSignature)
+                .identifier("not-the-table")
+                .build()
+                .verify(key, signature, now))
+        .contains("Got invalid signature");
+    soft.assertThat(
+            SignerSignature.builder()
+                .from(signerSignature)
+                .warehouseLocation("not-the-warehouse")
+                .build()
+                .verify(key, signature, now))
+        .contains("Got invalid signature");
+    soft.assertThat(
+            SignerSignature.builder()
+                .from(signerSignature)
+                .expirationTimestamp(Long.MAX_VALUE)
+                .build()
+                .verify(key, signature, now))
+        .contains("Got invalid signature");
+    soft.assertThat(
+            SignerSignature.builder()
+                .from(signerSignature)
+                .addWriteLocation("s3://secret/stuff/")
+                .build()
+                .verify(key, signature, now))
+        .contains("Got invalid signature");
+    soft.assertThat(
+            SignerSignature.builder()
+                .from(signerSignature)
+                .addReadLocation("s3://secret/stuff/")
+                .build()
+                .verify(key, signature, now))
+        .contains("Got invalid signature");
+    soft.assertThat(
+            SignerSignature.builder()
+                .from(signerSignature)
+                .writeLocations(List.of())
+                .build()
+                .verify(key, signature, now))
+        .contains("Got invalid signature");
+    soft.assertThat(
+            SignerSignature.builder()
+                .from(signerSignature)
+                .readLocations(List.of())
+                .build()
+                .verify(key, signature, now))
+        .contains("Got invalid signature");
+  }
+}


### PR DESCRIPTION
Adds a service to provide secret keys that can be used to sign and verify signatures. Keys are rotated automatically and shared across all Nessie instances.

This code is going to be used to sign and verify the Nessie S3 sign endpoint URIs.