### PR TITLE
Fix a Gradle deprecation

### DIFF
--- a/cli/cli/build.gradle.kts
+++ b/cli/cli/build.gradle.kts
@@ -125,7 +125,7 @@ tasks.named<Test>("intTest").configure {
   inputs.files(nessieQuarkusServer)
   val execJarProvider =
     configurations.named("nessieQuarkusServer").map { c ->
-      val file = c.fileCollection(*c.dependencies.toTypedArray()).files.first()
+      val file = c.incoming.artifactView {}.files.first()
       listOf("-Dnessie.exec-jar=${file.absolutePath}")
     }
   jvmArgumentProviders.add(CommandLineArgumentProvider { execJarProvider.get() })

--- a/integrations/spark-extensions/build.gradle.kts
+++ b/integrations/spark-extensions/build.gradle.kts
@@ -91,11 +91,10 @@ tasks.named<Test>("intTest").configure {
   // Spark keeps a lot of stuff around in the JVM, breaking tests against different Iceberg catalogs, so give every test class its own JVM
   forkEvery = 1
   inputs.files(nessieQuarkusServer)
-  val execJarProvider = configurations.named("nessieQuarkusServer").map { c ->
-    val file = c.fileCollection(*c.dependencies.toTypedArray()).files.first()
-    listOf("-Dnessie.exec-jar=${file.absolutePath}")
-  }
-  jvmArgumentProviders.add(CommandLineArgumentProvider {
-    execJarProvider.get()
-  })
+  val execJarProvider =
+    configurations.named("nessieQuarkusServer").map { c ->
+      val file = c.incoming.artifactView {}.files.first()
+      listOf("-Dnessie.exec-jar=${file.absolutePath}")
+    }
+  jvmArgumentProviders.add(CommandLineArgumentProvider { execJarProvider.get() })
 }


### PR DESCRIPTION
```
w: file:///.../integrations/spark-extensions/build.gradle.kts:97:18: 'fileCollection(vararg Dependency!): FileCollection!' is deprecated. Deprecated in Java
```