### PR TITLE
Fix illegal access

### DIFF
--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1S3SignResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1S3SignResource.java
@@ -58,7 +58,7 @@ public class IcebergApiV1S3SignResource extends IcebergApiV1ResourceBase {
   @Inject RequestSigner signer;
   @Inject IcebergErrorMapper errorMapper;
   @Inject SignerKeysService signerKeysService;
-  @Inject private UriInfo uriInfo;
+  @Inject UriInfo uriInfo;
 
   Clock clock = Clock.systemUTC();
 


### PR DESCRIPTION
Fixes
```
java.lang.IllegalAccessError: class org.projectnessie.catalog.service.rest.IcebergApiV1S3SignResource_Bean tried to access private field org.projectnessie.catalog.service.rest.IcebergApiV1S3SignResource.uriInfo (org.projectnessie.catalog.service.rest.IcebergApiV1S3SignResource_Bean and org.projectnessie.catalog.service.rest.IcebergApiV1S3SignResource are in unnamed module of loader 'app')
```
see [this failure](https://scans.gradle.com/s/4b2n5ks7qfvdo/tests/task/:nessie:nessie-iceberg:nessie-spark-extensions-3.3_2.12:intTest/details/org.projectnessie.spark.extensions.ITNessieStatementsViaIcebergRest/testCompaction(String%2C%20String)%5B1%5D?top-execution=1)