### PR TITLE
Build / IntelliJ: include the project root dir in the IDE window name

### DIFF
--- a/build-logic/src/main/kotlin/nessie-conventions-root.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-conventions-root.gradle.kts
@@ -35,7 +35,8 @@ plugins {
 loadNessieProjects(rootProject)
 
 val projectName = rootProject.file("ide-name.txt").readText().trim()
-val ideName = "$projectName ${rootProject.version.toString().replace(Regex("^([0-9.]+).*"), "$1")}"
+val ideName =
+  "$projectName ${rootProject.version.toString().replace(Regex("^([0-9.]+).*"), "$1")} [${rootProject.rootDir}]"
 
 if (System.getProperty("idea.sync.active").toBoolean()) {
 

--- a/build-logic/src/main/kotlin/nessie-conventions-root.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-conventions-root.gradle.kts
@@ -36,7 +36,7 @@ loadNessieProjects(rootProject)
 
 val projectName = rootProject.file("ide-name.txt").readText().trim()
 val ideName =
-  "$projectName ${rootProject.version.toString().replace(Regex("^([0-9.]+).*"), "$1")} [${rootProject.rootDir}]"
+  "$projectName ${rootProject.version.toString().replace(Regex("^([0-9.]+).*"), "$1")} [in ../${rootProject.rootDir.name}]"
 
 if (System.getProperty("idea.sync.active").toBoolean()) {
 


### PR DESCRIPTION
I'd like to propose that we include the project's directory in the window name for IntelliJ (it's included by default, but our custom name doesn't include it).

The main reason for me is that I have several git workspaces for Nessie being worked on in parallel, and knowing which workspace I'm in saves me a few seconds each time I switch workspaces.

(I also think the version in the title is actually not that useful, because it changes frequently, but the title won't change until you do a Gradle build.)