### PR TITLE
Release: Fix openapi publishing idempotency

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -328,7 +328,17 @@ jobs:
           SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_API_KEY }}
           SWAGGERHUB_URL: "https://api.swaggerhub.com"
         with:
-          args: api:create projectnessie/nessie -f ./nessie-openapi-${{ env.RELEASE_VERSION }}.yaml --published=publish --setdefault --visibility=public
+          args: api:create projectnessie/nessie -f ./nessie-openapi-${{ env.RELEASE_VERSION }}.yaml --visibility=public
+
+      - name: Unpublish on SwaggerHub
+        uses: smartbear/swaggerhub-cli@20e5eaf4866bbbc44d72e9eb8a48a942c0d9e43b # v0.9.0
+        continue-on-error: true
+        env:
+          XDG_CONFIG_HOME: "/tmp"
+          SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_API_KEY }}
+          SWAGGERHUB_URL: "https://api.swaggerhub.com"
+        with:
+          args: api:unpublish projectnessie/nessie/${{ env.RELEASE_VERSION }}.yaml
 
       - name: Update SwaggerHub
         uses: smartbear/swaggerhub-cli@20e5eaf4866bbbc44d72e9eb8a48a942c0d9e43b # v0.9.0


### PR DESCRIPTION
The change #9264 actually broke openapi publishing, because [`Error: Published APIs can not be overwritten`](https://github.com/projectnessie/nessie/actions/runs/10290645057/job/28481082864).

The fix is to 1st unpublish the API and then update it.