### PR TITLE
Catalog: Implementation for short-lived user-delegation SAS tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ as necessary. Empty sections will not end in the release notes.
 
 ### New Features
 
+- Catalog/ADLS: Added **experimental** support for short-lived SAS tokens passed down to clients. Those
+  tokens still have read/write access to the whole file system and are **not** scoped down.
+
 ### Changes
 
 ### Deprecations

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsFileSystemOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsFileSystemOptions.java
@@ -16,11 +16,15 @@
 package org.projectnessie.catalog.files.adls;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import org.projectnessie.catalog.secrets.BasicCredentials;
 import org.projectnessie.catalog.secrets.KeySecret;
 
 public interface AdlsFileSystemOptions {
+
+  Duration DELEGATION_KEY_DEFAULT_EXPIRY = Duration.ofDays(7).minus(1, ChronoUnit.SECONDS);
+  Duration DELEGATION_SAS_DEFAULT_EXPIRY = Duration.ofHours(3);
 
   /** The authentication type to use. */
   Optional<AzureAuthType> authType();
@@ -34,6 +38,30 @@ public interface AdlsFileSystemOptions {
 
   /** SAS token to access the ADLS file system. */
   Optional<KeySecret> sasToken();
+
+  /**
+   * Enable short-lived user-delegation SAS tokens per file-system.
+   *
+   * <p>The current default is to not enable short-lived and scoped-down credentials, but the
+   * default may change to enable in the future.
+   */
+  Optional<Boolean> userDelegationEnable();
+
+  /**
+   * Expiration time / validity duration of the user-delegation <em>key</em>, this key is
+   * <em>not</em> passed to the client.
+   *
+   * <p>Defaults to 7 days minus 1 minute (the maximum), must be >= 1 second.
+   */
+  Optional<Duration> userDelegationKeyExpiry();
+
+  /**
+   * Expiration time / validity duration of the user-delegation <em>SAS token</em>, which
+   * <em>is</em> sent to the client.
+   *
+   * <p>Defaults to 3 hours, must be >= 1 second.
+   */
+  Optional<Duration> userDelegationSasExpiry();
 
   /**
    * Define a custom HTTP endpoint. In case clients need to use a different URI, use the {@code

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergConfigurer.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergConfigurer.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.projectnessie.catalog.files.NormalizedObjectStoreOptions;
+import org.projectnessie.catalog.files.adls.AdlsClientSupplier;
 import org.projectnessie.catalog.files.adls.AdlsFileSystemOptions;
 import org.projectnessie.catalog.files.adls.AdlsLocation;
 import org.projectnessie.catalog.files.adls.AdlsOptions;
@@ -117,6 +118,7 @@ public class IcebergConfigurer {
   @Inject ServerConfig serverConfig;
   @Inject CatalogConfig catalogConfig;
   @Inject S3CredentialsResolver s3CredentialsResolver;
+  @Inject AdlsClientSupplier adlsClientSupplier;
   @Inject @NormalizedObjectStoreOptions S3Options s3Options;
   @Inject @NormalizedObjectStoreOptions GcsOptions gcsOptions;
   @Inject @NormalizedObjectStoreOptions AdlsOptions adlsOptions;
@@ -644,5 +646,12 @@ public class IcebergConfigurer {
     adlsOptions
         .writeBlockSize()
         .ifPresent(s -> configOverrides.put(ADLS_WRITE_BLOCK_SIZE_BYTES, Long.toString(s)));
+
+    if (forTable) {
+      adlsClientSupplier
+          .generateUserDelegationSas(storageLocations, fileSystemOptions)
+          .ifPresent(
+              sasToken -> configOverrides.put(ADLS_SAS_TOKEN_PREFIX + storageAccount, sasToken));
+    }
   }
 }

--- a/servers/quarkus-config/src/main/java/org/projectnessie/quarkus/config/CatalogAdlsFileSystemConfig.java
+++ b/servers/quarkus-config/src/main/java/org/projectnessie/quarkus/config/CatalogAdlsFileSystemConfig.java
@@ -16,6 +16,8 @@
 package org.projectnessie.quarkus.config;
 
 import io.smallrye.config.WithConverter;
+import io.smallrye.config.WithName;
+import java.time.Duration;
 import java.util.Optional;
 import org.projectnessie.catalog.files.adls.AdlsFileSystemOptions;
 import org.projectnessie.catalog.secrets.KeySecret;
@@ -24,4 +26,16 @@ public interface CatalogAdlsFileSystemConfig extends AdlsFileSystemOptions {
   @Override
   @WithConverter(KeySecretConverter.class)
   Optional<KeySecret> sasToken();
+
+  @Override
+  @WithName("user-delegation.enable")
+  Optional<Boolean> userDelegationEnable();
+
+  @Override
+  @WithName("user-delegation.key-expiry")
+  Optional<Duration> userDelegationKeyExpiry();
+
+  @Override
+  @WithName("user-delegation.sas-expiry")
+  Optional<Duration> userDelegationSasExpiry();
 }


### PR DESCRIPTION
Implements the production code for short-lived user-delegation SAS tokens. Sadly, Azurite doesn't work with this, so the code is effectively untested. In a follow-up it feels appropriate to cache the user-delegation-keys, which have a relatively long lifetime and are needed to generate the actual SAS tokens (only the latter are passed down to clients).

Fixes #8909
