### PR TITLE
Catalog: Implementation for down-scoped GCP/GCS access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ as necessary. Empty sections will not end in the release notes.
 
 - Catalog/ADLS: Added **experimental** support for short-lived SAS tokens passed down to clients. Those
   tokens still have read/write access to the whole file system and are **not** scoped down.
+- Catalog/GCS: Added **experimental** support for short-lived and scoped down access tokens passed down
+  to clients, providing a similar functionality as vended-credentials for S3, including object-storage
+  file layout.
 
 ### Changes
 

--- a/catalog/files/impl/build.gradle.kts
+++ b/catalog/files/impl/build.gradle.kts
@@ -64,6 +64,8 @@ dependencies {
 
   testFixturesApi(project(":nessie-object-storage-mock"))
 
+  testImplementation(platform(libs.cel.bom))
+  testImplementation("org.projectnessie.cel:cel-standalone")
   testRuntimeOnly(libs.logback.classic)
 
   jmhImplementation(libs.jmh.core)

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsBucketOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsBucketOptions.java
@@ -16,6 +16,7 @@
 package org.projectnessie.catalog.files.gcs;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.OptionalInt;
 import org.projectnessie.catalog.secrets.KeySecret;
@@ -71,6 +72,29 @@ public interface GcsBucketOptions {
    * via secrets.
    */
   Optional<TokenSecret> oauth2Token();
+
+  /**
+   * Flag to enable the currently experimental option to send short-lived and scoped-down
+   * credentials to clients.
+   *
+   * <p>The current default is to not enable short-lived and scoped-down credentials, but the
+   * default may change to enable in the future.
+   */
+  Optional<Boolean> downscopedCredentialsEnable();
+
+  /**
+   * The expiration margin for the scoped down OAuth2 token.
+   *
+   * <p>Defaults to the Google defaults.
+   */
+  Optional<Duration> downscopedCredentialsExpirationMargin();
+
+  /**
+   * The refresh margin for the scoped down OAuth2 token.
+   *
+   * <p>Defaults to the Google defaults.
+   */
+  Optional<Duration> downscopedCredentialsRefreshMargin();
 
   /** The read chunk size in bytes. */
   OptionalInt readChunkSize();

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsStorageSupplier.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsStorageSupplier.java
@@ -15,12 +15,40 @@
  */
 package org.projectnessie.catalog.files.gcs;
 
+import static java.lang.String.format;
+import static java.util.regex.Pattern.quote;
+import static org.projectnessie.catalog.files.gcs.GcsClients.buildCredentials;
+
+import com.google.auth.Credentials;
 import com.google.auth.http.HttpTransportFactory;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.CredentialAccessBoundary;
+import com.google.auth.oauth2.CredentialAccessBoundary.AccessBoundaryRule.AvailabilityCondition;
+import com.google.auth.oauth2.DownscopedCredentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.storage.Storage;
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.projectnessie.catalog.files.s3.StorageLocations;
 import org.projectnessie.catalog.secrets.SecretsProvider;
+import org.projectnessie.catalog.secrets.TokenSecret;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class GcsStorageSupplier {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GcsStorageSupplier.class);
+  static final String RANDOMIZED_PART = "([A-Za-z0-9=]+/)?";
+
   private final HttpTransportFactory httpTransportFactory;
   private final GcsOptions gcsOptions;
   private final SecretsProvider secretsProvider;
@@ -40,5 +68,176 @@ public final class GcsStorageSupplier {
 
   public Storage forLocation(GcsBucketOptions bucketOptions) {
     return GcsClients.buildStorage(gcsOptions, bucketOptions, httpTransportFactory);
+  }
+
+  public Optional<TokenSecret> generateDelegationToken(
+      StorageLocations storageLocations, GcsBucketOptions gcsBucketOptions) {
+
+    if (!gcsBucketOptions.downscopedCredentialsEnable().orElse(false)) {
+      return Optional.empty();
+    }
+
+    DownscopedCredentials.Builder downscopedCredentialsBuilder = DownscopedCredentials.newBuilder();
+
+    Credentials bucketCredentials = buildCredentials(gcsBucketOptions, httpTransportFactory);
+    if (bucketCredentials instanceof GoogleCredentials) {
+      GoogleCredentials sourceCredentials = (GoogleCredentials) bucketCredentials;
+      downscopedCredentialsBuilder.setSourceCredential(sourceCredentials);
+    } else if (bucketCredentials instanceof OAuth2Credentials) {
+      // OAuth2Credentials does not extend GoogleCredentials
+      downscopedCredentialsBuilder.setAccessToken(
+          ((OAuth2Credentials) bucketCredentials).getAccessToken());
+    } else {
+      LOGGER.warn(
+          "No suitable credentials to generate a downscoped token to access warehouse {}",
+          storageLocations.warehouseLocation());
+      return Optional.empty();
+    }
+
+    CredentialAccessBoundary accessBoundary = generateAccessBoundaryRules(storageLocations);
+
+    downscopedCredentialsBuilder
+        .setHttpTransportFactory(httpTransportFactory)
+        .setCredentialAccessBoundary(accessBoundary);
+
+    gcsBucketOptions
+        .downscopedCredentialsExpirationMargin()
+        .ifPresent(downscopedCredentialsBuilder::setExpirationMargin);
+    gcsBucketOptions
+        .downscopedCredentialsRefreshMargin()
+        .ifPresent(downscopedCredentialsBuilder::setRefreshMargin);
+
+    DownscopedCredentials downscopedCredentials = downscopedCredentialsBuilder.build();
+
+    try {
+      AccessToken token = downscopedCredentials.refreshAccessToken();
+      return Optional.of(
+          TokenSecret.tokenSecret(
+              token.getTokenValue(), Instant.ofEpochMilli(token.getExpirationTime().getTime())));
+    } catch (IOException e) {
+      LOGGER.error(
+          "Failed refresh access token for downscoped credentials for warehouse {}",
+          storageLocations.warehouseLocation(),
+          e);
+      throw new RuntimeException("Unable to fetch access credentials " + e.getMessage());
+    }
+  }
+
+  @VisibleForTesting
+  public static CredentialAccessBoundary generateAccessBoundaryRules(
+      StorageLocations storageLocations) {
+    Map<String, List<String>> readConditionsMap = new HashMap<>();
+    Map<String, List<String>> writeConditionsMap = new HashMap<>();
+
+    Set<String> readBuckets = new HashSet<>();
+    Set<String> writeBuckets = new HashSet<>();
+    Stream.concat(
+            storageLocations.readonlyLocations().stream(),
+            storageLocations.writeableLocations().stream())
+        .distinct()
+        .forEach(
+            location -> {
+              String bucket = location.requiredAuthority();
+              readBuckets.add(bucket);
+              String path = location.pathWithoutLeadingTrailingSlash();
+              List<String> resourceExpressions =
+                  readConditionsMap.computeIfAbsent(bucket, key -> new ArrayList<>());
+
+              resourceExpressions.add(resourceNameBucketPathExpression(bucket, path));
+
+              // list
+              String listPathExpression =
+                  format(
+                      "api.getAttribute('storage.googleapis.com/objectListPrefix', '').matches('"
+                          + RANDOMIZED_PART
+                          + "%s.*')",
+                      quoteForCelString(path));
+              resourceExpressions.add(listPathExpression);
+
+              if (storageLocations.writeableLocations().contains(location)) {
+                writeBuckets.add(bucket);
+                List<String> writeExpressions =
+                    writeConditionsMap.computeIfAbsent(bucket, key -> new ArrayList<>());
+                writeExpressions.add(resourceNameBucketPathExpression(bucket, path));
+              }
+            });
+
+    CredentialAccessBoundary.Builder accessBoundaryBuilder = CredentialAccessBoundary.newBuilder();
+    readBuckets.stream()
+        .map(b -> accessBoundaryRuleForBucket(readConditionsMap, b))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .map(
+            builder ->
+                builder
+                    .setAvailablePermissions(List.of("inRole:roles/storage.legacyObjectReader"))
+                    // list
+                    .addAvailablePermission("inRole:roles/storage.objectViewer"))
+        .map(CredentialAccessBoundary.AccessBoundaryRule.Builder::build)
+        .forEach(accessBoundaryBuilder::addRule);
+    writeBuckets.stream()
+        .map(b -> accessBoundaryRuleForBucket(writeConditionsMap, b))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .map(
+            builder ->
+                builder.setAvailablePermissions(List.of("inRole:roles/storage.legacyBucketWriter")))
+        .map(CredentialAccessBoundary.AccessBoundaryRule.Builder::build)
+        .forEach(accessBoundaryBuilder::addRule);
+    return accessBoundaryBuilder.build();
+  }
+
+  static String resourceNameBucketPathExpression(String bucket, String path) {
+    return "resource.name.matches('"
+        + quoteForCelString(format("projects/_/buckets/%s/objects/", bucket))
+        + RANDOMIZED_PART
+        + quoteForCelString(path)
+        + ".*')";
+  }
+
+  private static String quoteForCelString(String str) {
+    String quoted = quote(str);
+    StringBuilder sb = new StringBuilder(quoted.length() * 3 / 2);
+
+    int l = quoted.length();
+    for (int i = 0; i < l; i++) {
+      char c = quoted.charAt(i);
+      switch (c) {
+        case '\'':
+          sb.append("\\'");
+          break;
+        case '\"':
+          sb.append("\\\"");
+          break;
+        case '\\':
+          sb.append("\\\\");
+          break;
+        default:
+          sb.append(c);
+          break;
+      }
+    }
+
+    return sb.toString();
+  }
+
+  private static Optional<CredentialAccessBoundary.AccessBoundaryRule.Builder>
+      accessBoundaryRuleForBucket(Map<String, List<String>> conditionsMap, String bucket) {
+    List<String> conditions = conditionsMap.get(bucket);
+    if (conditions == null || conditions.isEmpty()) {
+      return Optional.empty();
+    }
+
+    CredentialAccessBoundary.AccessBoundaryRule.Builder builder =
+        CredentialAccessBoundary.AccessBoundaryRule.newBuilder();
+    builder.setAvailableResource(bucketResource(bucket));
+    builder.setAvailabilityCondition(
+        AvailabilityCondition.newBuilder().setExpression(String.join(" || ", conditions)).build());
+
+    return Optional.of(builder);
+  }
+
+  private static String bucketResource(String bucket) {
+    return "//storage.googleapis.com/projects/_/buckets/" + bucket;
   }
 }

--- a/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/gcs/CelEval.java
+++ b/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/gcs/CelEval.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.files.gcs;
+
+import java.util.List;
+import java.util.Map;
+import org.projectnessie.cel.EnvOption;
+import org.projectnessie.cel.Library;
+import org.projectnessie.cel.ProgramOption;
+import org.projectnessie.cel.checker.Decls;
+import org.projectnessie.cel.common.types.Err;
+import org.projectnessie.cel.common.types.StringT;
+import org.projectnessie.cel.interpreter.functions.FunctionOp;
+import org.projectnessie.cel.interpreter.functions.Overload;
+import org.projectnessie.cel.relocated.com.google.api.expr.v1alpha1.Decl;
+import org.projectnessie.cel.relocated.com.google.api.expr.v1alpha1.Type;
+import org.projectnessie.cel.tools.Script;
+import org.projectnessie.cel.tools.ScriptCreateException;
+import org.projectnessie.cel.tools.ScriptHost;
+import org.projectnessie.cel.types.jackson.JacksonRegistry;
+
+/** CEL Utilities used by {@link TestGcsDownscopedCredentials}. */
+final class CelEval {
+
+  /** Simulates the {@code api.getAttribute()} function in GCP IAM expressions. */
+  static final FunctionOp apiGetAttribute =
+      values -> {
+        try {
+          ApiInterface apiInterface = (ApiInterface) values[0].value();
+          String key = (String) values[1].value();
+          String def = (String) values[2].value();
+          return StringT.stringOf(apiInterface.attributes.getOrDefault(key, def));
+        } catch (RuntimeException e) {
+          return Err.newErr(e, "%s", e.getMessage());
+        }
+      };
+
+  /** Type for {@code api} provided to GCP IAM expressions. */
+  static final Type apiType = Decls.newObjectType(ApiInterface.class.getName());
+
+  /** Type the {@code resource} object provided to GCP IAM expressions. */
+  static final Type resourceType = Decls.newObjectType(ResourceComposite.class.getName());
+
+  /** CEL library for the {@code api} object. */
+  static final Library apiLib =
+      new Library() {
+        @Override
+        public List<EnvOption> getCompileOptions() {
+          return List.of(
+              EnvOption.declarations(
+                  Decls.newFunction(
+                      "getAttribute",
+                      Decls.newInstanceOverload(
+                          "api_get_attribute_str_str_str",
+                          List.of(apiType, Decls.String, Decls.String),
+                          Decls.String))
+                  //
+                  ));
+        }
+
+        @Override
+        public List<ProgramOption> getProgramOptions() {
+          return List.of(
+              ProgramOption.functions(Overload.function("getAttribute", apiGetAttribute))
+              //
+              );
+        }
+      };
+
+  static final List<Decl> decls =
+      List.of(
+          Decls.newVar("resource", resourceType), Decls.newVar("api", apiType)
+          //
+          );
+  static final List<Object> types = List.of(ResourceComposite.class);
+
+  private static final ScriptHost SCRIPT_HOST =
+      ScriptHost.newBuilder().registry(JacksonRegistry.newRegistry()).build();
+
+  public static Script scriptFor(String expr) throws ScriptCreateException {
+    return SCRIPT_HOST
+        .buildScript(expr)
+        .withDeclarations(decls)
+        .withTypes(types)
+        .withLibraries(apiLib)
+        .build();
+  }
+
+  /** Necessary type for the Google CEL IAM {@code api} object. */
+  static final class ApiInterface {
+    final Map<String, String> attributes;
+
+    ApiInterface(Map<String, String> attributes) {
+      this.attributes = attributes;
+    }
+  }
+
+  /** Necessary type for the Google CEL IAM {@code resource} object. */
+  static class ResourceComposite {
+    private String name;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+  }
+}

--- a/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/gcs/TestGcsDownscopedCredentials.java
+++ b/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/gcs/TestGcsDownscopedCredentials.java
@@ -1,0 +1,471 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.files.gcs;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.projectnessie.catalog.files.gcs.GcsStorageSupplier.RANDOMIZED_PART;
+
+import com.google.auth.oauth2.CredentialAccessBoundary;
+import com.google.auth.oauth2.CredentialAccessBoundary.AccessBoundaryRule;
+import com.google.auth.oauth2.CredentialAccessBoundary.AccessBoundaryRule.AvailabilityCondition;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.catalog.files.s3.StorageLocations;
+import org.projectnessie.cel.tools.Script;
+import org.projectnessie.storage.uri.StorageUri;
+
+/**
+ * Contains some "best effort" test cases to validate that the {@link CredentialAccessBoundary}
+ * objects and the CEL expressions used for access checks are correct.
+ */
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestGcsDownscopedCredentials {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  /**
+   * Check whether the {@code CredentialAccessBoundary} objects match the expectation for a set of
+   * read-only and writeable locations..
+   */
+  @ParameterizedTest
+  @MethodSource
+  public void generateAccessBoundaryRules(
+      StorageLocations storageLocations, CredentialAccessBoundary expected) {
+    CredentialAccessBoundary actual =
+        GcsStorageSupplier.generateAccessBoundaryRules(storageLocations);
+    assertThat(
+            actual.getAccessBoundaryRules().stream()
+                .map(
+                    rule ->
+                        tuple(
+                            rule.getAvailabilityCondition().getExpression(),
+                            rule.getAvailableResource(),
+                            rule.getAvailablePermissions()))
+                .collect(Collectors.toList()))
+        .containsExactlyInAnyOrderElementsOf(
+            expected.getAccessBoundaryRules().stream()
+                .map(
+                    rule ->
+                        tuple(
+                            rule.getAvailabilityCondition().getExpression(),
+                            rule.getAvailableResource(),
+                            rule.getAvailablePermissions()))
+                .collect(Collectors.toList()));
+  }
+
+  /**
+   * Validate the CEL syntax in generated {@link CredentialAccessBoundary} object and whether those
+   * CEL expressions execute.
+   */
+  @ParameterizedTest
+  @MethodSource("generateAccessBoundaryRules")
+  public void validateCelSyntax(
+      StorageLocations storageLocations,
+      @SuppressWarnings("unused") CredentialAccessBoundary expected) {
+    CredentialAccessBoundary actual =
+        GcsStorageSupplier.generateAccessBoundaryRules(storageLocations);
+
+    CelEval.ResourceComposite resource = new CelEval.ResourceComposite();
+    resource.setName("gs://bucket/blah");
+
+    for (AccessBoundaryRule rule : actual.getAccessBoundaryRules()) {
+      String expr = rule.getAvailabilityCondition().getExpression();
+
+      soft.assertThatCode(
+              () -> {
+                Script script = CelEval.scriptFor(expr);
+
+                assertThat(
+                        script.execute(
+                            Boolean.class,
+                            Map.of(
+                                "api", new CelEval.ApiInterface(Map.of()), "resource", resource)))
+                    .isNotNull();
+              })
+          .describedAs("Script '%s'", expr)
+          .doesNotThrowAnyException();
+    }
+  }
+
+  /**
+   * Verify whether CEL expressions for a storage location given passes as expected.
+   *
+   * @param resource the storage location used to generate the CEL expression, also base of the
+   *     "positive checks"
+   * @param negativeCheck a storage location that must not pass ("negative check") against the
+   *     generated CEL expression.
+   */
+  @ParameterizedTest
+  @MethodSource
+  public void resourceNameBucketPathExpression(String resource, String negativeCheck)
+      throws Exception {
+
+    String bucketPositive = StorageUri.of(resource).requiredAuthority();
+    String pathPositive = StorageUri.of(resource).pathWithoutLeadingTrailingSlash();
+
+    String bucketNegative = StorageUri.of(negativeCheck).requiredAuthority();
+    String pathNegative = StorageUri.of(negativeCheck).pathWithoutLeadingTrailingSlash();
+
+    for (String res :
+        new String[] {resource, resource + "/hello.txt", resource + "/much/deeper/hello.txt"}) {
+
+      String bucket = StorageUri.of(res).requiredAuthority();
+      String path = StorageUri.of(res).pathWithoutLeadingTrailingSlash();
+
+      CelEval.ResourceComposite r = new CelEval.ResourceComposite();
+
+      String expr =
+          GcsStorageSupplier.resourceNameBucketPathExpression(bucketPositive, pathPositive);
+      Script script = CelEval.scriptFor(expr);
+
+      r.setName(format("projects/_/buckets/%s/objects/%s", bucket, path));
+      soft.assertThat(
+              script.execute(
+                  Boolean.class, Map.of("api", new CelEval.ApiInterface(Map.of()), "resource", r)))
+          .describedAs("positive, resource: %s", res)
+          .isEqualTo(true);
+
+      r.setName(format("projects/_/buckets/%s/objects/deadbeef/%s", bucket, path));
+      soft.assertThat(
+              script.execute(
+                  Boolean.class, Map.of("api", new CelEval.ApiInterface(Map.of()), "resource", r)))
+          .describedAs("positive, object, resource: %s", res)
+          .isEqualTo(true);
+
+      // negative checks
+
+      expr = GcsStorageSupplier.resourceNameBucketPathExpression(bucketNegative, pathNegative);
+      script = CelEval.scriptFor(expr);
+
+      r.setName(format("projects/_/buckets/%s/objects/%s", bucket, path));
+      soft.assertThat(
+              script.execute(
+                  Boolean.class, Map.of("api", new CelEval.ApiInterface(Map.of()), "resource", r)))
+          .describedAs("negative, resource: %s", res)
+          .isEqualTo(false);
+
+      r.setName(format("projects/_/buckets/%s/objects/deadbeef/%s", bucket, path));
+      soft.assertThat(
+              script.execute(
+                  Boolean.class, Map.of("api", new CelEval.ApiInterface(Map.of()), "resource", r)))
+          .describedAs("negative, object, resource: %s", res)
+          .isEqualTo(false);
+    }
+  }
+
+  static Stream<Arguments> resourceNameBucketPathExpression() {
+    return Stream.of(
+        arguments("gs://bucket/foo/bar/baz", "gs://bucket/foo/bar/foo"),
+        //
+        arguments("gs://bucket/foo/b'ar/baz", "gs://bucket/foo/b.ar/baz"),
+        //
+        arguments("gs://bucket/foo/bar/b\"az", "gs://buc,et/foo/bar/b\"az"),
+        //
+        arguments("gs://buck.et/foo/bar/b.az", "gs://buckxet/foo/bar/bxaz"),
+        //
+        arguments("gs://bucket/foo/bar/b.az", "gs://buckxet/foo/bar/bxaz")
+        //
+        );
+  }
+
+  static Stream<Arguments> generateAccessBoundaryRules() {
+    String bucketName = "my-bucket-name";
+    String bucket2 = "bucket2";
+    String bucket3 = "bucket3";
+    String readOnly = "read-only";
+    String read2 = "read2";
+    String read3 = "read3";
+    String writeable = "write-able";
+    String write2 = "write2";
+    String write3 = "write3";
+    return Stream.of(
+        //
+        // [1] one writeable location
+        arguments(
+            StorageLocations.storageLocations(
+                StorageUri.of("s3://not-used/"),
+                List.of(StorageUri.of("gs://" + bucketName + "/" + writeable)),
+                List.of()),
+            CredentialAccessBoundary.newBuilder()
+                .addRule(
+                    AccessBoundaryRule.newBuilder()
+                        .setAvailabilityCondition(
+                            AvailabilityCondition.newBuilder()
+                                .setExpression(
+                                    resourceNameMatches(bucketName, writeable)
+                                        + " || "
+                                        + listPrefix(writeable))
+                                .build())
+                        .setAvailableResource(
+                            "//storage.googleapis.com/projects/_/buckets/" + bucketName)
+                        .addAvailablePermission("inRole:roles/storage.legacyObjectReader")
+                        .addAvailablePermission("inRole:roles/storage.objectViewer")
+                        .build())
+                .addRule(
+                    AccessBoundaryRule.newBuilder()
+                        .setAvailabilityCondition(
+                            AvailabilityCondition.newBuilder()
+                                .setExpression(resourceNameMatches(bucketName, writeable))
+                                .build())
+                        .setAvailableResource(
+                            "//storage.googleapis.com/projects/_/buckets/" + bucketName)
+                        .addAvailablePermission("inRole:roles/storage.legacyBucketWriter")
+                        .build())
+                .build()),
+        //
+        // [2] one read-only
+        arguments(
+            StorageLocations.storageLocations(
+                StorageUri.of("s3://not-used/"),
+                List.of(),
+                List.of(StorageUri.of("gs://" + bucketName + "/" + readOnly))),
+            CredentialAccessBoundary.newBuilder()
+                .addRule(
+                    AccessBoundaryRule.newBuilder()
+                        .setAvailabilityCondition(
+                            AvailabilityCondition.newBuilder()
+                                .setExpression(
+                                    resourceNameMatches(bucketName, readOnly)
+                                        + " || "
+                                        + listPrefix(readOnly))
+                                .build())
+                        .setAvailableResource(
+                            "//storage.googleapis.com/projects/_/buckets/" + bucketName)
+                        .addAvailablePermission("inRole:roles/storage.legacyObjectReader")
+                        .addAvailablePermission("inRole:roles/storage.objectViewer")
+                        .build())
+                .build()),
+        //
+        // [3] one writeable location + one read-only
+        arguments(
+            StorageLocations.storageLocations(
+                StorageUri.of("s3://not-used/"),
+                List.of(StorageUri.of("gs://" + bucketName + "/" + writeable)),
+                List.of(StorageUri.of("gs://" + bucketName + "/" + readOnly))),
+            CredentialAccessBoundary.newBuilder()
+                .addRule(
+                    AccessBoundaryRule.newBuilder()
+                        .setAvailabilityCondition(
+                            AvailabilityCondition.newBuilder()
+                                .setExpression(
+                                    resourceNameMatches(bucketName, readOnly)
+                                        + " || "
+                                        + listPrefix(readOnly)
+                                        + " || "
+                                        + resourceNameMatches(bucketName, writeable)
+                                        + " || "
+                                        + listPrefix(writeable))
+                                .build())
+                        .setAvailableResource(
+                            "//storage.googleapis.com/projects/_/buckets/" + bucketName)
+                        .addAvailablePermission("inRole:roles/storage.legacyObjectReader")
+                        .addAvailablePermission("inRole:roles/storage.objectViewer")
+                        .build())
+                .addRule(
+                    AccessBoundaryRule.newBuilder()
+                        .setAvailabilityCondition(
+                            AvailabilityCondition.newBuilder()
+                                .setExpression(resourceNameMatches(bucketName, writeable))
+                                .build())
+                        .setAvailableResource(
+                            "//storage.googleapis.com/projects/_/buckets/" + bucketName)
+                        .addAvailablePermission("inRole:roles/storage.legacyBucketWriter")
+                        .build())
+                .build()),
+        //
+        // [4] two writeable locations + two read-only locations
+        arguments(
+            StorageLocations.storageLocations(
+                StorageUri.of("s3://not-used/"),
+                List.of(
+                    StorageUri.of("gs://" + bucketName + "/" + writeable),
+                    StorageUri.of("gs://" + bucketName + "/" + write2)),
+                List.of(
+                    StorageUri.of("gs://" + bucketName + "/" + readOnly),
+                    StorageUri.of("gs://" + bucketName + "/" + read2))),
+            CredentialAccessBoundary.newBuilder()
+                .addRule(
+                    AccessBoundaryRule.newBuilder()
+                        .setAvailabilityCondition(
+                            AvailabilityCondition.newBuilder()
+                                .setExpression(
+                                    resourceNameMatches(bucketName, readOnly)
+                                        + " || "
+                                        + listPrefix(readOnly)
+                                        + " || "
+                                        + resourceNameMatches(bucketName, read2)
+                                        + " || "
+                                        + listPrefix(read2)
+                                        + " || "
+                                        + resourceNameMatches(bucketName, writeable)
+                                        + " || "
+                                        + listPrefix(writeable)
+                                        + " || "
+                                        + resourceNameMatches(bucketName, write2)
+                                        + " || "
+                                        + listPrefix(write2))
+                                .build())
+                        .setAvailableResource(
+                            "//storage.googleapis.com/projects/_/buckets/" + bucketName)
+                        .addAvailablePermission("inRole:roles/storage.legacyObjectReader")
+                        .addAvailablePermission("inRole:roles/storage.objectViewer")
+                        .build())
+                .addRule(
+                    AccessBoundaryRule.newBuilder()
+                        .setAvailabilityCondition(
+                            AvailabilityCondition.newBuilder()
+                                .setExpression(
+                                    resourceNameMatches(bucketName, writeable)
+                                        + " || "
+                                        + resourceNameMatches(bucketName, write2))
+                                .build())
+                        .setAvailableResource(
+                            "//storage.googleapis.com/projects/_/buckets/" + bucketName)
+                        .addAvailablePermission("inRole:roles/storage.legacyBucketWriter")
+                        .build())
+                .build()),
+        //
+        // [5] writeable locations across buckets + read-only locations across buckets
+        arguments(
+            StorageLocations.storageLocations(
+                StorageUri.of("s3://not-used/"),
+                List.of(
+                    StorageUri.of("gs://" + bucketName + "/" + writeable),
+                    StorageUri.of("gs://" + bucket2 + "/" + write2),
+                    StorageUri.of("gs://" + bucket3 + "/" + write3)),
+                List.of(
+                    StorageUri.of("gs://" + bucketName + "/" + readOnly),
+                    StorageUri.of("gs://" + bucket2 + "/" + read2),
+                    StorageUri.of("gs://" + bucket3 + "/" + read3))),
+            CredentialAccessBoundary.newBuilder()
+                .addRule(
+                    AccessBoundaryRule.newBuilder()
+                        .setAvailabilityCondition(
+                            AvailabilityCondition.newBuilder()
+                                .setExpression(
+                                    resourceNameMatches(bucketName, readOnly)
+                                        + " || "
+                                        + listPrefix(readOnly)
+                                        + " || "
+                                        + resourceNameMatches(bucketName, writeable)
+                                        + " || "
+                                        + listPrefix(writeable))
+                                .build())
+                        .setAvailableResource(
+                            "//storage.googleapis.com/projects/_/buckets/" + bucketName)
+                        .addAvailablePermission("inRole:roles/storage.legacyObjectReader")
+                        .addAvailablePermission("inRole:roles/storage.objectViewer")
+                        .build())
+                .addRule(
+                    AccessBoundaryRule.newBuilder()
+                        .setAvailabilityCondition(
+                            AvailabilityCondition.newBuilder()
+                                .setExpression(
+                                    resourceNameMatches(bucket2, read2)
+                                        + " || "
+                                        + listPrefix(read2)
+                                        + " || "
+                                        + resourceNameMatches(bucket2, write2)
+                                        + " || "
+                                        + listPrefix(write2))
+                                .build())
+                        .setAvailableResource(
+                            "//storage.googleapis.com/projects/_/buckets/" + bucket2)
+                        .addAvailablePermission("inRole:roles/storage.legacyObjectReader")
+                        .addAvailablePermission("inRole:roles/storage.objectViewer")
+                        .build())
+                .addRule(
+                    AccessBoundaryRule.newBuilder()
+                        .setAvailabilityCondition(
+                            AvailabilityCondition.newBuilder()
+                                .setExpression(
+                                    resourceNameMatches(bucket3, read3)
+                                        + " || "
+                                        + listPrefix(read3)
+                                        + " || "
+                                        + resourceNameMatches(bucket3, write3)
+                                        + " || "
+                                        + listPrefix(write3))
+                                .build())
+                        .setAvailableResource(
+                            "//storage.googleapis.com/projects/_/buckets/" + bucket3)
+                        .addAvailablePermission("inRole:roles/storage.legacyObjectReader")
+                        .addAvailablePermission("inRole:roles/storage.objectViewer")
+                        .build())
+                .addRule(
+                    AccessBoundaryRule.newBuilder()
+                        .setAvailabilityCondition(
+                            AvailabilityCondition.newBuilder()
+                                .setExpression(resourceNameMatches(bucketName, writeable))
+                                .build())
+                        .setAvailableResource(
+                            "//storage.googleapis.com/projects/_/buckets/" + bucketName)
+                        .addAvailablePermission("inRole:roles/storage.legacyBucketWriter")
+                        .build())
+                .addRule(
+                    AccessBoundaryRule.newBuilder()
+                        .setAvailabilityCondition(
+                            AvailabilityCondition.newBuilder()
+                                .setExpression(resourceNameMatches(bucket2, write2))
+                                .build())
+                        .setAvailableResource(
+                            "//storage.googleapis.com/projects/_/buckets/" + bucket2)
+                        .addAvailablePermission("inRole:roles/storage.legacyBucketWriter")
+                        .build())
+                .addRule(
+                    AccessBoundaryRule.newBuilder()
+                        .setAvailabilityCondition(
+                            AvailabilityCondition.newBuilder()
+                                .setExpression(resourceNameMatches(bucket3, write3))
+                                .build())
+                        .setAvailableResource(
+                            "//storage.googleapis.com/projects/_/buckets/" + bucket3)
+                        .addAvailablePermission("inRole:roles/storage.legacyBucketWriter")
+                        .build())
+                .build())
+        //
+        );
+  }
+
+  private static String listPrefix(String readOnly) {
+    return "api.getAttribute('storage.googleapis.com/objectListPrefix', '').matches('"
+        + RANDOMIZED_PART
+        + "\\\\Q"
+        + readOnly
+        + "\\\\E.*')";
+  }
+
+  private static String resourceNameMatches(String bucketName, String writeable) {
+    return "resource.name.matches('\\\\Qprojects/_/buckets/"
+        + bucketName
+        + "/objects/\\\\E"
+        + RANDOMIZED_PART
+        + "\\\\Q"
+        + writeable
+        + "\\\\E.*')";
+  }
+}

--- a/servers/quarkus-config/src/main/java/org/projectnessie/quarkus/config/CatalogGcsBucketConfig.java
+++ b/servers/quarkus-config/src/main/java/org/projectnessie/quarkus/config/CatalogGcsBucketConfig.java
@@ -16,6 +16,8 @@
 package org.projectnessie.quarkus.config;
 
 import io.smallrye.config.WithConverter;
+import io.smallrye.config.WithName;
+import java.time.Duration;
 import java.util.Optional;
 import org.projectnessie.catalog.files.gcs.GcsBucketOptions;
 import org.projectnessie.catalog.secrets.KeySecret;
@@ -36,4 +38,16 @@ public interface CatalogGcsBucketConfig extends GcsBucketOptions {
   @Override
   @WithConverter(KeySecretConverter.class)
   Optional<KeySecret> decryptionKey();
+
+  @Override
+  @WithName("downscoped-credentials.enable")
+  Optional<Boolean> downscopedCredentialsEnable();
+
+  @Override
+  @WithName("downscoped-credentials.expiration-margin")
+  Optional<Duration> downscopedCredentialsExpirationMargin();
+
+  @Override
+  @WithName("downscoped-credentials.refresh-margin")
+  Optional<Duration> downscopedCredentialsRefreshMargin();
 }


### PR DESCRIPTION
Implements the production code for down-scoped access tokens. Currently untested.

Fixes #9298 