### PR TITLE
OAuth2 client: introduce secret suppliers

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PasswordFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PasswordFlow.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.client.auth.oauth2;
 
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /**
@@ -34,8 +35,8 @@ class PasswordFlow extends AbstractFlow {
         config.getUsername().orElseThrow(() -> new IllegalStateException("Username is required"));
     String password =
         config
-            .getPassword()
-            .map(Secret::getString)
+            .getPasswordSupplier()
+            .map(Supplier::get)
             .orElseThrow(() -> new IllegalStateException("Password is required"));
     PasswordTokenRequest.Builder request =
         PasswordTokenRequest.builder().username(username).password(password);

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/Secret.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/Secret.java
@@ -15,6 +15,12 @@
  */
 package org.projectnessie.client.auth.oauth2;
 
+/**
+ * A secret value.
+ *
+ * @deprecated will be removed in a future release.
+ */
+@Deprecated
 public final class Secret {
 
   private final char[] value;

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
@@ -169,16 +169,6 @@ class TestOAuth2ClientConfig {
                 .clientId("Alice")
                 .clientSecret("s3cr3t")
                 .tokenEndpoint(URI.create("https://example.com/token"))
-                .grantType(GrantType.PASSWORD)
-                .username("Alice")
-                .password(""),
-            singletonList(
-                "password must be set if grant type is 'password' (nessie.authentication.oauth2.password)")),
-        Arguments.of(
-            OAuth2ClientConfig.builder()
-                .clientId("Alice")
-                .clientSecret("s3cr3t")
-                .tokenEndpoint(URI.create("https://example.com/token"))
                 .grantType(GrantType.AUTHORIZATION_CODE),
             singletonList(
                 "either issuer URL or authorization endpoint must be set if grant type is 'authorization_code' (nessie.authentication.oauth2.issuer-url / nessie.authentication.oauth2.auth-endpoint)")),


### PR DESCRIPTION
This allows secrets to be dynamically resolved, and only when necessary.

Also deprecates the org.projectnessie.client.auth.oauth2.Secret class, for removal.