### PR TITLE
Explicitly prevent empty content keys

### DIFF
--- a/api/model/src/main/java/org/projectnessie/model/Operation.java
+++ b/api/model/src/main/java/org/projectnessie/model/Operation.java
@@ -156,4 +156,11 @@ public interface Operation {
       return ImmutableUnchanged.builder().key(key).build();
     }
   }
+
+  @Value.Check
+  default void check() {
+    if (getKey().getElementCount() == 0) {
+      throw new IllegalStateException("Content key must not be empty");
+    }
+  }
 }

--- a/api/model/src/test/java/org/projectnessie/model/TestOperation.java
+++ b/api/model/src/test/java/org/projectnessie/model/TestOperation.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestOperation {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @Test
+  public void emptyKey() {
+    soft.assertThatIllegalStateException()
+        .isThrownBy(() -> Operation.Put.of(ContentKey.of(), IcebergTable.of("meta", 1, 2, 3, 4)))
+        .withMessage("Content key must not be empty");
+    soft.assertThatIllegalStateException()
+        .isThrownBy(
+            () -> Operation.Put.of(ContentKey.of(List.of()), IcebergTable.of("meta", 1, 2, 3, 4)))
+        .withMessage("Content key must not be empty");
+  }
+}

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Operation.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Operation.java
@@ -40,4 +40,11 @@ public interface Operation {
     DELETE,
     UNCHANGED
   }
+
+  @Value.Check
+  default void check() {
+    if (getKey().getElementCount() == 0) {
+      throw new IllegalStateException("Content key must not be empty");
+    }
+  }
 }

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestOperation.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestOperation.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned;
+
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.IcebergTable;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestOperation {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @Test
+  public void emptyKey() {
+    soft.assertThatIllegalStateException()
+        .isThrownBy(() -> Put.of(ContentKey.of(), IcebergTable.of("meta", 1, 2, 3, 4)))
+        .withMessage("Content key must not be empty");
+    soft.assertThatIllegalStateException()
+        .isThrownBy(() -> Put.of(ContentKey.of(List.of()), IcebergTable.of("meta", 1, 2, 3, 4)))
+        .withMessage("Content key must not be empty");
+  }
+}

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/CommitImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/CommitImpl.java
@@ -256,6 +256,9 @@ class CommitImpl extends BaseCommitHelper {
       ContentKey key = operation.getKey();
       Operation previous = allKeys.put(key, operation);
       checkDuplicateKey(previous, operation);
+      if (key.getElementCount() == 0) {
+        throw new IllegalStateException("Content key must not be empty");
+      }
       StoreKey storeKey = keyToStoreKey(key);
       storeKeys.add(storeKey);
       if (storeKeysForHead != null && operation instanceof Unchanged) {


### PR DESCRIPTION
Empty content keys don't make any sense, but are theoretically possible. Empty content keys _could_ cause weird issues, so disallowing them. Also, empty content with an empty key is not be "addressable" at all in any tool/client, so the chance that any content with an empty key exists in the wild is 0.

Fixes #2648