### PR TITLE
Mitigate OOM during `:nessie-server-admin-tool:intTest`

### DIFF
--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/ShutdownHandlers.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/ShutdownHandlers.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.quarkus.providers;
+
+import io.quarkus.runtime.ShutdownEvent;
+import jakarta.enterprise.event.Observes;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.concurrent.ScheduledExecutorService;
+
+/** Helper class to stop some "static final" thread references, leading to class-loader OOMs. */
+@SuppressWarnings("unused")
+public class ShutdownHandlers {
+
+  public void onShutdown(@Observes ShutdownEvent event) {
+    mongoDefaultBufferPollPruner();
+  }
+
+  /**
+   * Shutdown the "static final" {@link ScheduledExecutorService} referencing the periodic call to
+   * {@code com.mongodb.internal.connection.PowerOfTwoBufferPool#prune()}.
+   */
+  private void mongoDefaultBufferPollPruner() {
+    try {
+      Class<?> c = Class.forName("com.mongodb.internal.connection.PowerOfTwoBufferPool");
+      Field fieldDefault = c.getDeclaredField("DEFAULT");
+      Object defaultBufferPool = fieldDefault.get(null);
+      Method disablePruning = c.getDeclaredMethod("disablePruning");
+      disablePruning.setAccessible(true);
+      disablePruning.invoke(defaultBufferPool);
+    } catch (ReflectiveOperationException ignore) {
+      //
+    }
+  }
+}

--- a/tools/server-admin/build.gradle.kts
+++ b/tools/server-admin/build.gradle.kts
@@ -175,9 +175,6 @@ if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
 }
 
 tasks.named<Test>("intTest").configure {
-  // Reduce likelihood of OOM due to too many Quarkus apps in memory;
-  // Ideally, set this number to the number of IT classes to run for each backend.
-  forkEvery = 5
   // Optional; comma-separated list of backend names to test against;
   // see NessieServerAdminTestBackends for valid values.
   systemProperty("backends", System.getProperty("backends"))

--- a/tools/server-admin/src/main/resources/application.properties
+++ b/tools/server-admin/src/main/resources/application.properties
@@ -161,4 +161,18 @@ quarkus.arc.ignored-split-packages=\
 
 quarkus.http.test-port=0
 
+# Disable a "lot of things" that are not needed for integration testing. Disabled in an effort to get hold
+# of the class-loader OOM leak described in https://github.com/projectnessie/nessie/issues/8571
+# Many of these settings are probably unnecessary, but otoh don't hurt.
 %test.quarkus.devservices.enabled=false
+%test.quarkus.micrometer.enabled=false
+%test.quarkus.micrometer.registry-enabled-default=false
+%test.quarkus.mongodb.metrics.enabled=false
+%test.quarkus.otel.enabled=false
+%test.quarkus.otel.sdk.disabled=true
+%test.quarkus.otel.exporter.otlp.enabled=false
+%test.quarkus.otel.metrics.enabled=false
+%test.quarkus.otel.metrics.exporter=none
+%test.quarkus.otel.traces.eusp.enabled=false
+%test.quarkus.otel.traces.exporter=none
+%test.nessie.version.store.persist.bigtable.enable-telemetry=false


### PR DESCRIPTION
Looking into an `.hprof` file, there are a many suspicious `ScheduledThreadPoolExecutor`s active - each with one task in its queue - and multiple instances of these executors for the same task type (but different instances).
* `io.opentelemetry.sdk.metrics.export.PeriodicMetricReader.Scheduled`
* `com.google.api.gax.rpc.Watchdog`
* (lambda to) `com.mongodb.internal.connection.PowerOfTwoBufferPool#prune`

Since those are active/running, they keep references to the class loader, in turn "everything".

Fixes #8571