### PR TITLE
Catalog: use `prefixKey` in "list" operations

### DIFF
--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1NamespaceResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1NamespaceResource.java
@@ -15,7 +15,6 @@
  */
 package org.projectnessie.catalog.service.rest;
 
-import static java.lang.String.format;
 import static org.projectnessie.model.Content.Type.NAMESPACE;
 
 import io.smallrye.common.annotation.Blocking;
@@ -133,16 +132,8 @@ public class IcebergApiV1NamespaceResource extends IcebergApiV1ResourceBase {
     IcebergListNamespacesResponse.Builder response = IcebergListNamespacesResponse.builder();
 
     NamespaceRef namespaceRef = decodeNamespaceRef(prefix, parent);
-    Namespace namespace = namespaceRef.namespace();
-    String celFilter =
-        "entry.contentType == 'NAMESPACE'"
-            + ((namespace != null && !namespace.isEmpty())
-                ? format(
-                    " && size(entry.keyElements) == %d && entry.encodedKey.startsWith('%s.')",
-                    namespace.getElementCount() + 1, namespace.toPathString())
-                : " && size(entry.keyElements) == 1");
 
-    listContent(namespaceRef, pageToken, pageSize, true, celFilter, response::nextPageToken)
+    listContent(namespaceRef, "NAMESPACE", pageToken, pageSize, true, response::nextPageToken)
         .map(EntriesResponse.Entry::getContent)
         .map(Namespace.class::cast)
         .map(IcebergNamespace::fromNessieNamespace)

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1TableResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1TableResource.java
@@ -493,12 +493,8 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
     IcebergListTablesResponse.Builder response = IcebergListTablesResponse.builder();
 
     NamespaceRef namespaceRef = decodeNamespaceRef(prefix, namespace);
-    String celFilter =
-        format(
-            "entry.contentType == 'ICEBERG_TABLE' && entry.encodedKey.startsWith('%s.')",
-            namespaceRef.namespace().toPathString());
 
-    listContent(namespaceRef, pageToken, pageSize, false, celFilter, response::nextPageToken)
+    listContent(namespaceRef, "ICEBERG_TABLE", pageToken, pageSize, false, response::nextPageToken)
         .map(e -> fromNessieContentKey(e.getName()))
         .forEach(response::addIdentifier);
 

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ViewResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ViewResource.java
@@ -181,12 +181,8 @@ public class IcebergApiV1ViewResource extends IcebergApiV1ResourceBase {
     IcebergListTablesResponse.Builder response = IcebergListTablesResponse.builder();
 
     NamespaceRef namespaceRef = decodeNamespaceRef(prefix, namespace);
-    String celFilter =
-        format(
-            "entry.contentType == 'ICEBERG_VIEW' && entry.encodedKey.startsWith('%s.')",
-            namespaceRef.namespace().toPathString());
 
-    listContent(namespaceRef, pageToken, pageSize, false, celFilter, response::nextPageToken)
+    listContent(namespaceRef, "ICEBERG_VIEW", pageToken, pageSize, false, response::nextPageToken)
         .map(e -> fromNessieContentKey(e.getName()))
         .forEach(response::addIdentifier);
 


### PR DESCRIPTION
Providing the `prefixKey` is a pretty good hint for all "list" operations. And also limit to direct children for all list operations