### PR TITLE
Migrate to new `shadow` plugin ID

### DIFF
--- a/build-logic/src/main/kotlin/nessie-shadow-jar.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-shadow-jar.gradle.kts
@@ -16,7 +16,7 @@
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
-plugins { id("com.github.johnrengelman.shadow") }
+plugins { id("com.gradleup.shadow") }
 
 val shadowJar = tasks.named<ShadowJar>("shadowJar")
 

--- a/catalog/format/iceberg-bench/build.gradle.kts
+++ b/catalog/format/iceberg-bench/build.gradle.kts
@@ -18,7 +18,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
   id("nessie-conventions-server")
-  id("com.github.johnrengelman.shadow")
+  id("com.gradleup.shadow")
   alias(libs.plugins.jmh)
 }
 

--- a/gc/gc-tool/build.gradle.kts
+++ b/gc/gc-tool/build.gradle.kts
@@ -17,7 +17,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-  id("com.github.johnrengelman.shadow")
+  id("com.gradleup.shadow")
   id("nessie-conventions-client")
   id("nessie-shadow-jar")
   id("nessie-license-report")

--- a/gradle/baselibs.versions.toml
+++ b/gradle/baselibs.versions.toml
@@ -7,5 +7,5 @@ idea-ext = { module = "gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle
 jandex = { module = "com.github.vlsi.gradle:jandex-plugin", version = "1.90" }
 junit-bom = { module = "org.junit:junit-bom", version = "5.11.0" }
 license-report = { module = "com.github.jk1:gradle-license-report", version = "2.9" }
-shadow = { module = "com.github.johnrengelman:shadow", version = "8.1.1" }
+shadow = { module = "com.gradleup.shadow:shadow-gradle-plugin", version = "8.3.0" }
 spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.25.0" }

--- a/servers/services-bench/build.gradle.kts
+++ b/servers/services-bench/build.gradle.kts
@@ -18,7 +18,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
   id("nessie-conventions-unpublished-tool")
-  id("com.github.johnrengelman.shadow")
+  id("com.gradleup.shadow")
   alias(libs.plugins.jmh)
 }
 


### PR DESCRIPTION
See [Shadow release notes](https://github.com/GradleUp/shadow/releases/tag/8.3.0), the new plugin ID and Maven coordinates. Requires a bump of the `me.champeau.jmh` as well.

Fixes #7912 