### PR TITLE
Allow Nessie Web UI to authenticate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ as necessary. Empty sections will not end in the release notes.
 - Nessie commit author(s) and "signed off by" can now be configured for both Nessie clients and Iceberg
   REST clients. More info on
   [projectnessie.org](https://projectnessie.org/guides/iceberg-rest/#customizing-nessie-commit-author-et-al). 
+- Enable authentication for the Nessie Web UI
 
 ### Changes
 

--- a/helm/nessie/templates/configmap.yaml
+++ b/helm/nessie/templates/configmap.yaml
@@ -80,11 +80,15 @@ data:
 
     {{- if .Values.authentication.enabled -}}
     {{- $_ = set $map "nessie.server.authentication.enabled" .Values.authentication.enabled -}}
+    {{- $_ = set $map "quarkus.oidc.ui-app.application-type" "web-app" -}}
+    {{- $_ = set $map "quarkus.oidc.ui-app.tenant-paths" "/,/tree*,/content*,/notfound*,/commits*" -}}
     {{- if .Values.authentication.oidcAuthServerUrl -}}
     {{- $_ = set $map "quarkus.oidc.auth-server-url" .Values.authentication.oidcAuthServerUrl -}}
+    {{- $_ = set $map "quarkus.oidc.ui-app.auth-server-url" .Values.authentication.oidcAuthServerUrl -}}
     {{- end -}}
     {{- if .Values.authentication.oidcClientId -}}
     {{- $_ = set $map "quarkus.oidc.client-id" .Values.authentication.oidcClientId -}}
+    {{- $_ = set $map "quarkus.oidc.ui-app.client-id" .Values.authentication.oidcClientId -}}
     {{- end -}}
     {{- else -}}
     {{- $_ = set $map "quarkus.oidc.tenant-enabled" false -}}

--- a/helm/nessie/templates/deployment.yaml
+++ b/helm/nessie/templates/deployment.yaml
@@ -82,6 +82,7 @@ spec:
             {{- end -}}
             {{- if .Values.authentication.enabled -}}
             {{- include "nessie.secretToEnv" (list .Values.authentication.oidcClientSecret "key" "quarkus.oidc.credentials.secret" . ) | trim | nindent 12 -}}
+            {{- include "nessie.secretToEnv" (list .Values.authentication.oidcClientSecret "key" "quarkus.oidc.ui-app.credentials.secret" . ) | trim | nindent 12 -}}
             {{- end -}}
             {{- if .Values.catalog.enabled -}}
             {{- include "nessie.catalogStorageEnv" . | trim | nindent 12 -}}

--- a/servers/quarkus-auth/src/main/java/org/projectnessie/server/config/QuarkusNessieAuthenticationConfig.java
+++ b/servers/quarkus-auth/src/main/java/org/projectnessie/server/config/QuarkusNessieAuthenticationConfig.java
@@ -34,8 +34,7 @@ public interface QuarkusNessieAuthenticationConfig {
 
   /**
    * Returns the set of HTTP URL paths that are permitted to be serviced without authentication.
-   * Anonymous access is granted, if the URI path is equal to any of the elements or if the path
-   * starts with any of the elements, when each element is appended with a {@code /}.
+   * Anonymous access is granted, if the URI path is equal to any of the elements}.
    *
    * @hidden Not present in docs on web-site.
    */

--- a/servers/quarkus-auth/src/main/java/org/projectnessie/server/config/QuarkusNessieAuthenticationConfig.java
+++ b/servers/quarkus-auth/src/main/java/org/projectnessie/server/config/QuarkusNessieAuthenticationConfig.java
@@ -34,9 +34,21 @@ public interface QuarkusNessieAuthenticationConfig {
 
   /**
    * Returns the set of HTTP URL paths that are permitted to be serviced without authentication.
+   * Anonymous access is granted, if the URI path is equal to any of the elements or if the path
+   * starts with any of the elements, when each element is appended with a {@code /}.
    *
    * @hidden Not present in docs on web-site.
    */
   @WithName("anonymous-paths")
   Optional<Set<String>> anonymousPaths();
+
+  /**
+   * Returns the set of HTTP URL path <em>prefixes</em> that are permitted to be serviced without
+   * authentication. Anonymous access is granted, if the URI path is equal to any of the elements or
+   * if the path starts with any of the elements, when each element is appended with a {@code /}.
+   *
+   * @hidden Not present in docs on web-site.
+   */
+  @WithName("anonymous-path-prefixes")
+  Optional<Set<String>> anonymousPathPrefixes();
 }

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -289,15 +289,31 @@ quarkus.http.body.handle-file-uploads=false
 quarkus.http.compress-media-types=application/json,text/html,text/plain
 
 ## Quarkus auth settings
-#quarkus.oidc.credentials.secret=
 #quarkus.oidc.client-id=
+#quarkus.oidc.credentials.secret=
 nessie.server.authentication.enabled=false
-nessie.server.authentication.anonymous-paths=/iceberg/v1/oauth/tokens
+nessie.server.authentication.anonymous-paths=\
+  /iceberg/v1/oauth/tokens,\
+  /nessie-openapi/openapi.yaml,\
+  /favicon.ico
+nessie.server.authentication.anonymous-path-prefixes=\
+  /tree,\
+  /content,\
+  /notfound,\
+  /commits,\
+  /nessie-openapi
 quarkus.http.auth.basic=false
 # OIDC-enabled is a build-time property (cannot be overwritten at run-time), MUST be true.
 # However, we can overwrite the tenant-enabled property at run-time.
 quarkus.oidc.enabled=true
 quarkus.oidc.tenant-enabled=${nessie.server.authentication.enabled}
+
+#quarkus.oidc.ui-app.client-id=
+#quarkus.oidc.ui-app.credentials.secret=
+#quarkus.oidc.ui-app.auth-server=
+#quarkus.oidc.ui-app.token-issuer=
+#quarkus.oidc.ui-app.application-type=web-app
+#quarkus.oidc.ui-app.tenant-paths=/,/tree*,/content*,/notfound*,/commits*
 
 quarkus.management.enabled=true
 quarkus.management.port=9000

--- a/site/docs/develop/rest.md
+++ b/site/docs/develop/rest.md
@@ -2,7 +2,7 @@
 
 Nessie's REST APIs are how all applications interact with Nessie. The APIs are specified 
 according to the openapi v3 standard and are available when running the server by at the path
-`/nessie-openapi/openapi.yaml` (for example via `curl http://127.0.0.1:19120//nessie-openapi/openapi.yaml`)
+`/nessie-openapi/openapi.yaml` (for example via `curl http://127.0.0.1:19120/nessie-openapi/openapi.yaml`)
 and on the Download/Release pages.
 
 The API can also be inspected at [SwaggerHub](https://app.swaggerhub.com/apis/projectnessie/nessie).

--- a/site/in-dev/authentication.md
+++ b/site/in-dev/authentication.md
@@ -32,6 +32,14 @@ for the Nessie Server process:
 * `quarkus.oidc.auth-server-url=<OpenID Server URL>`
 * `quarkus.oidc.client-id=<Client ID>`
 
+If you also want to use authentication for the Nessie Web UI, the following properties need to
+be set as well:
+
+* `quarkus.oidc.ui-app.auth-server-url=<OpenID Server URL>`
+* `quarkus.oidc.ui-app.client-id=<Client ID>`
+* `quarkus.oidc.ui-app.application-type=web-app`
+* `quarkus.oidc.ui-app.tenant-paths=/,/tree*,/content*,/notfound*,/commits*`
+
 When using Nessie [Docker](../guides/docker.md) images, the authentication options can be specified on
 the `docker` command line as environment variables, for example:
 


### PR DESCRIPTION
Currently the Nessie Web UI cannot be used when authentication is enabled.

This change, which is mostly a set of Quarkus configurations, allows using the Nessie Web UI - however, there's no "login" or "logout" button.

The "trick" is to use a different Quarkus OIDC tenant (called `ui-app`), which is chosen by Quarkus for the static UI-path `/` (and it's single-page-app mapped paths).

Although it's possible to define a different "client" and even a different oauth-server, the Helm chart changes just duplicate the configured settings.

It's important to retain the existing behavior of the "service" (REST API) endpoints and to return `HTTP/401`, whereas the ui-app (a browser) requires `HTTP/302` to the authentication page. This works:
```
$ curl -v http://127.0.0.1:19120/api/v2/config
...
< HTTP/1.1 401 Unauthorized

$ curl -v http://127.0.0.1:19120/favicon.ico
< HTTP/1.1 200 OK

$ curl -v http://127.0.0.1:19120/
< HTTP/1.1 302 Found
< location: http://127.0.0.1:8080/realms/iceberg/protocol/openid-connect/auth?response_type=code&client_id=client1&scope=openid&redirect_uri=http%3A%2F%2F127.0.0.1%3A19120%2F&state=...
```

This change also allows anonymous access to the static Nessie OpenAPI yaml.