### PR TITLE
Add `referenced` attribute to persisted `Obj`s

### DIFF
--- a/versioned/storage/batching/src/main/java/org/projectnessie/versioned/storage/batching/BatchingPersistImpl.java
+++ b/versioned/storage/batching/src/main/java/org/projectnessie/versioned/storage/batching/BatchingPersistImpl.java
@@ -448,4 +448,9 @@ final class BatchingPersistImpl implements BatchingPersist, ValidatingPersist {
       @Nonnull @javax.annotation.Nonnull Set<ObjType> returnedObjTypes) {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public boolean isCaching() {
+    return delegate().isCaching();
+  }
 }

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableConstants.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableConstants.java
@@ -28,6 +28,7 @@ final class BigTableConstants {
 
   static final ByteString QUALIFIER_OBJ_TYPE = ByteString.copyFromUtf8("t");
   static final ByteString QUALIFIER_OBJ_VERS = ByteString.copyFromUtf8("V");
+  static final ByteString QUALIFIER_OBJ_REFERENCED = ByteString.copyFromUtf8("z");
   static final ByteString QUALIFIER_OBJS = ByteString.copyFromUtf8("o");
   static final ByteString QUALIFIER_REFS = ByteString.copyFromUtf8("r");
   // regex for scan

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CacheBackend.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CacheBackend.java
@@ -53,6 +53,11 @@ public interface CacheBackend {
         public ObjId id() {
           throw new UnsupportedOperationException();
         }
+
+        @Override
+        public Obj withReferenced(long referenced) {
+          throw new UnsupportedOperationException();
+        }
       };
 
   /**

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CachingPersistImpl.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CachingPersistImpl.java
@@ -511,4 +511,9 @@ class CachingPersistImpl implements Persist {
 
     return r;
   }
+
+  @Override
+  public boolean isCaching() {
+    return true;
+  }
 }

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
@@ -137,7 +137,7 @@ class CaffeineCacheBackend implements CacheBackend {
     if (value == NON_EXISTING_SENTINEL) {
       return NOT_FOUND_OBJ_SENTINEL;
     }
-    return ProtoSerialization.deserializeObj(id, value, null);
+    return ProtoSerialization.deserializeObj(id, 0L, value, null);
   }
 
   @Override

--- a/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCachingInmemoryPersist.java
+++ b/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCachingInmemoryPersist.java
@@ -45,7 +45,8 @@ public class TestCachingInmemoryPersist extends AbstractPersistTests {
 
     @Test
     public void getImmediate() throws Exception {
-      Obj obj = contentValue(randomObjId(), randomContentId(), 1, ByteString.copyFromUtf8("hello"));
+      Obj obj =
+          contentValue(randomObjId(), 420L, randomContentId(), 1, ByteString.copyFromUtf8("hello"));
       soft.assertThat(persist.getImmediate(obj.id())).isNull();
       persist.storeObj(obj);
       soft.assertThat(persist.getImmediate(obj.id())).isEqualTo(obj);

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraConstants.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraConstants.java
@@ -36,12 +36,23 @@ public final class CassandraConstants {
   static final CqlColumn COL_OBJ_ID = new CqlColumn("obj_id", CqlColumnType.OBJ_ID);
   static final CqlColumn COL_OBJ_TYPE = new CqlColumn("obj_type", CqlColumnType.NAME);
   static final CqlColumn COL_OBJ_VERS = new CqlColumn("obj_vers", CqlColumnType.VARCHAR);
+  static final CqlColumn COL_OBJ_REFERENCED = new CqlColumn("obj_ref", CqlColumnType.BIGINT);
 
   static final String DELETE_OBJ =
       "DELETE FROM %s." + TABLE_OBJS + " WHERE " + COL_REPO_ID + "=? AND " + COL_OBJ_ID + "=?";
 
   public static final String UPDATE_COND_PREFIX =
-      "UPDATE %s." + TABLE_OBJS + " SET " + COL_OBJ_VERS + "=:" + COL_OBJ_VERS + ", ";
+      "UPDATE %s."
+          + TABLE_OBJS
+          + " SET "
+          + COL_OBJ_VERS
+          + "=:"
+          + COL_OBJ_VERS
+          + ", "
+          + COL_OBJ_REFERENCED
+          + "=:"
+          + COL_OBJ_REFERENCED
+          + ", ";
   public static final String UPDATE_COND_WHERE =
       COL_REPO_ID + "=:" + COL_REPO_ID + " AND " + COL_OBJ_ID + "=:" + COL_OBJ_ID;
   public static final String EXPECTED_SUFFIX = "_expected";
@@ -78,6 +89,8 @@ public final class CassandraConstants {
           + ", "
           + COL_OBJ_ID
           + ", "
+          + COL_OBJ_REFERENCED
+          + ", "
           + COL_OBJ_TYPE
           + ", "
           + COL_OBJ_VERS
@@ -89,15 +102,33 @@ public final class CassandraConstants {
           + ", :"
           + COL_OBJ_ID
           + ", :"
+          + COL_OBJ_REFERENCED
+          + ", :"
           + COL_OBJ_TYPE
           + ", :"
           + COL_OBJ_VERS
           + ", ";
   public static final String STORE_OBJ_SUFFIX = " IF NOT EXISTS";
 
+  public static final String UPDATE_OBJ_REFERENCED =
+      "UPDATE %s."
+          + TABLE_OBJS
+          + " SET "
+          + COL_OBJ_REFERENCED
+          + "=:"
+          + COL_OBJ_REFERENCED
+          + " WHERE "
+          + COL_REPO_ID
+          + "=:"
+          + COL_REPO_ID
+          + " AND "
+          + COL_OBJ_ID
+          + "=:"
+          + COL_OBJ_ID;
+
   static final Set<CqlColumn> COLS_OBJS_ALL =
       Stream.concat(
-              Stream.of(COL_OBJ_ID, COL_OBJ_TYPE, COL_OBJ_VERS),
+              Stream.of(COL_OBJ_ID, COL_OBJ_REFERENCED, COL_OBJ_TYPE, COL_OBJ_VERS),
               ObjSerializers.ALL_SERIALIZERS.stream()
                   .flatMap(serializer -> serializer.columns().stream())
                   .sorted(Comparator.comparing(CqlColumn::name)))

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/CommitObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/CommitObjSerializer.java
@@ -135,10 +135,12 @@ public class CommitObjSerializer extends ObjSerializer<CommitObj> {
   }
 
   @Override
-  public CommitObj deserialize(Row row, ObjType type, ObjId id, String versionToken) {
+  public CommitObj deserialize(
+      Row row, ObjType type, ObjId id, long referenced, String versionToken) {
     CommitObj.Builder b =
         CommitObj.commitBuilder()
             .id(id)
+            .referenced(referenced)
             .created(row.getLong(COL_COMMIT_CREATED.name()))
             .seq(row.getLong(COL_COMMIT_SEQ.name()))
             .message(row.getString(COL_COMMIT_MESSAGE.name()))

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/ContentValueObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/ContentValueObjSerializer.java
@@ -58,11 +58,13 @@ public class ContentValueObjSerializer extends ObjSerializer<ContentValueObj> {
   }
 
   @Override
-  public ContentValueObj deserialize(Row row, ObjType type, ObjId id, String versionToken) {
+  public ContentValueObj deserialize(
+      Row row, ObjType type, ObjId id, long referenced, String versionToken) {
     ByteString value = CassandraSerde.deserializeBytes(row, COL_VALUE_DATA.name());
     if (value != null) {
       return contentValue(
           id,
+          referenced,
           row.getString(COL_VALUE_CONTENT_ID.name()),
           row.getInt(COL_VALUE_PAYLOAD.name()),
           value);

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/CustomObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/CustomObjSerializer.java
@@ -58,9 +58,9 @@ public class CustomObjSerializer extends ObjSerializer<Obj> {
   }
 
   @Override
-  public Obj deserialize(Row row, ObjType type, ObjId id, String versionToken) {
+  public Obj deserialize(Row row, ObjType type, ObjId id, long referenced, String versionToken) {
     ByteBuffer buffer = Objects.requireNonNull(row.getByteBuffer(COL_CUSTOM_DATA.name()));
     return SmileSerialization.deserializeObj(
-        id, versionToken, buffer, type, row.getString(COL_CUSTOM_COMPRESSION.name()));
+        id, versionToken, buffer, type, referenced, row.getString(COL_CUSTOM_COMPRESSION.name()));
   }
 }

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/IndexObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/IndexObjSerializer.java
@@ -58,10 +58,11 @@ public class IndexObjSerializer extends ObjSerializer<IndexObj> {
   }
 
   @Override
-  public IndexObj deserialize(Row row, ObjType type, ObjId id, String versionToken) {
+  public IndexObj deserialize(
+      Row row, ObjType type, ObjId id, long referenced, String versionToken) {
     ByteString indexValue = CassandraSerde.deserializeBytes(row, COL_INDEX_INDEX.name());
     if (indexValue != null) {
-      return index(id, indexValue);
+      return index(id, referenced, indexValue);
     }
     throw new IllegalStateException("Index value of obj " + id + " of type INDEX is null");
   }

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/IndexSegmentsObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/IndexSegmentsObjSerializer.java
@@ -72,7 +72,8 @@ public class IndexSegmentsObjSerializer extends ObjSerializer<IndexSegmentsObj> 
   }
 
   @Override
-  public IndexSegmentsObj deserialize(Row row, ObjType type, ObjId id, String versionToken) {
+  public IndexSegmentsObj deserialize(
+      Row row, ObjType type, ObjId id, long referenced, String versionToken) {
     try {
       Stripes stripes = Stripes.parseFrom(row.getByteBuffer(COL_SEGMENTS_STRIPES.name()));
       List<IndexStripe> stripeList =
@@ -84,7 +85,7 @@ public class IndexSegmentsObjSerializer extends ObjSerializer<IndexSegmentsObj> 
                           keyFromString(s.getLastKey()),
                           objIdFromByteBuffer(s.getSegment().asReadOnlyByteBuffer())))
               .collect(Collectors.toList());
-      return indexSegments(id, stripeList);
+      return indexSegments(id, referenced, stripeList);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/ObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/ObjSerializer.java
@@ -78,5 +78,6 @@ public abstract class ObjSerializer<O extends Obj> {
       O obj, BoundStatementBuilder stmt, int incrementalIndexLimit, int maxSerializedIndexSize)
       throws ObjTooLargeException;
 
-  public abstract O deserialize(Row row, ObjType type, ObjId id, String versionToken);
+  public abstract O deserialize(
+      Row row, ObjType type, ObjId id, long referenced, String versionToken);
 }

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/RefObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/RefObjSerializer.java
@@ -64,9 +64,10 @@ public class RefObjSerializer extends ObjSerializer<RefObj> {
   }
 
   @Override
-  public RefObj deserialize(Row row, ObjType type, ObjId id, String versionToken) {
+  public RefObj deserialize(Row row, ObjType type, ObjId id, long referenced, String versionToken) {
     return ref(
         id,
+        referenced,
         row.getString(COL_REF_NAME.name()),
         CassandraSerde.deserializeObjId(row.getString(COL_REF_INITIAL_POINTER.name())),
         row.getLong(COL_REF_CREATED_AT.name()),

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/StringObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/StringObjSerializer.java
@@ -73,9 +73,11 @@ public class StringObjSerializer extends ObjSerializer<StringObj> {
   }
 
   @Override
-  public StringObj deserialize(Row row, ObjType type, ObjId id, String versionToken) {
+  public StringObj deserialize(
+      Row row, ObjType type, ObjId id, long referenced, String versionToken) {
     return stringData(
         id,
+        referenced,
         row.getString(COL_STRING_CONTENT_TYPE.name()),
         Compression.valueOf(row.getString(COL_STRING_COMPRESSION.name())),
         row.getString(COL_STRING_FILENAME.name()),

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/TagObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/TagObjSerializer.java
@@ -74,7 +74,7 @@ public class TagObjSerializer extends ObjSerializer<TagObj> {
   }
 
   @Override
-  public TagObj deserialize(Row row, ObjType type, ObjId id, String versionToken) {
+  public TagObj deserialize(Row row, ObjType type, ObjId id, long referenced, String versionToken) {
     CommitHeaders tagHeaders = null;
     try {
       Headers headers = Headers.parseFrom(row.getByteBuffer(COL_TAG_HEADERS.name()));
@@ -93,6 +93,7 @@ public class TagObjSerializer extends ObjSerializer<TagObj> {
 
     return tag(
         id,
+        referenced,
         row.getString(COL_TAG_MESSAGE.name()),
         tagHeaders,
         CassandraSerde.deserializeBytes(row, COL_TAG_SIGNATURE.name()));

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/UniqueIdObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/UniqueIdObjSerializer.java
@@ -54,9 +54,11 @@ public class UniqueIdObjSerializer extends ObjSerializer<UniqueIdObj> {
   }
 
   @Override
-  public UniqueIdObj deserialize(Row row, ObjType type, ObjId id, String versionToken) {
+  public UniqueIdObj deserialize(
+      Row row, ObjType type, ObjId id, long referenced, String versionToken) {
     return uniqueId(
         id,
+        referenced,
         row.getString(COL_UNIQUE_SPACE.name()),
         CassandraSerde.deserializeBytes(row, COL_UNIQUE_VALUE.name()));
   }

--- a/versioned/storage/cassandra2/src/main/java/org/projectnessie/versioned/storage/cassandra2/Cassandra2Constants.java
+++ b/versioned/storage/cassandra2/src/main/java/org/projectnessie/versioned/storage/cassandra2/Cassandra2Constants.java
@@ -30,6 +30,7 @@ public final class Cassandra2Constants {
   static final CqlColumn COL_OBJ_TYPE = new CqlColumn("obj_type", CqlColumnType.NAME);
   static final CqlColumn COL_OBJ_VERS = new CqlColumn("obj_vers", CqlColumnType.VARCHAR);
   static final CqlColumn COL_OBJ_VALUE = new CqlColumn("obj_value", CqlColumnType.VARBINARY);
+  static final CqlColumn COL_OBJ_REFERENCED = new CqlColumn("obj_ref", CqlColumnType.BIGINT);
 
   static final String DELETE_OBJ =
       "DELETE FROM %s." + TABLE_OBJS + " WHERE " + COL_REPO_ID + "=? AND " + COL_OBJ_ID + "=?";
@@ -49,6 +50,8 @@ public final class Cassandra2Constants {
           + COL_OBJ_VERS
           + ", "
           + COL_OBJ_VALUE
+          + ", "
+          + COL_OBJ_REFERENCED
           + ") VALUES (:"
           + COL_REPO_ID
           + ", :"
@@ -59,6 +62,8 @@ public final class Cassandra2Constants {
           + COL_OBJ_VERS
           + ", :"
           + COL_OBJ_VALUE
+          + ", :"
+          + COL_OBJ_REFERENCED
           + ")";
 
   static final String STORE_OBJ = UPSERT_OBJ + " IF NOT EXISTS";
@@ -74,6 +79,10 @@ public final class Cassandra2Constants {
           + COL_OBJ_VALUE
           + "=:"
           + COL_OBJ_VALUE
+          + ", "
+          + COL_OBJ_REFERENCED
+          + "=:"
+          + COL_OBJ_REFERENCED
           + " WHERE "
           + COL_REPO_ID
           + "=:"
@@ -129,6 +138,10 @@ public final class Cassandra2Constants {
           + COL_OBJ_VALUE
           + " "
           + COL_OBJ_VALUE.type().cqlName()
+          + ",\n    "
+          + COL_OBJ_REFERENCED
+          + " "
+          + COL_OBJ_REFERENCED.type().cqlName()
           + ",\n    PRIMARY KEY (("
           + COL_REPO_ID
           + ", "
@@ -291,6 +304,8 @@ public final class Cassandra2Constants {
           + COL_OBJ_VERS
           + ", "
           + COL_OBJ_VALUE
+          + ", "
+          + COL_OBJ_REFERENCED
           + " FROM %s."
           + TABLE_OBJS
           + " WHERE "
@@ -308,6 +323,8 @@ public final class Cassandra2Constants {
           + COL_OBJ_VERS
           + ", "
           + COL_OBJ_VALUE
+          + ", "
+          + COL_OBJ_REFERENCED
           + " FROM %s."
           + TABLE_OBJS
           + " WHERE "
@@ -344,6 +361,22 @@ public final class Cassandra2Constants {
           + " = ? AND "
           + COL_REFS_NAME
           + " = ?";
+
+  public static final String UPDATE_OBJ_REFERENCED =
+      "UPDATE %s."
+          + TABLE_OBJS
+          + " SET "
+          + COL_OBJ_REFERENCED
+          + "=:"
+          + COL_OBJ_REFERENCED
+          + " WHERE "
+          + COL_REPO_ID
+          + "=:"
+          + COL_REPO_ID
+          + " AND "
+          + COL_OBJ_ID
+          + "=:"
+          + COL_OBJ_ID;
 
   private Cassandra2Constants() {}
 }

--- a/versioned/storage/common-proto/src/main/proto/org/projectnessie/versioned/storage/common/proto/storage.proto
+++ b/versioned/storage/common-proto/src/main/proto/org/projectnessie/versioned/storage/common/proto/storage.proto
@@ -115,6 +115,7 @@ message ObjProto {
     CustomProto custom = 9;
     UniqueIdProto uniqueId = 10;
   }
+  optional int64 referenced = 11;
 }
 
 message Headers {

--- a/versioned/storage/common-serialize/src/main/java/org/projectnessie/versioned/storage/serialize/SmileSerialization.java
+++ b/versioned/storage/common-serialize/src/main/java/org/projectnessie/versioned/storage/serialize/SmileSerialization.java
@@ -41,9 +41,15 @@ public final class SmileSerialization {
   private SmileSerialization() {}
 
   public static Obj deserializeObj(
-      ObjId id, String versionToken, byte[] data, ObjType type, Compression compression) {
+      ObjId id,
+      String versionToken,
+      byte[] data,
+      ObjType type,
+      long referenced,
+      Compression compression) {
     try {
-      ObjectReader reader = readerWithObjIdAndVersionToken(SMILE_MAPPER, type, id, versionToken);
+      ObjectReader reader =
+          readerWithObjIdAndVersionToken(SMILE_MAPPER, type, id, versionToken, referenced);
       data = uncompress(compression, data);
       return reader.readValue(data, type.targetClass());
     } catch (IOException e) {
@@ -52,22 +58,38 @@ public final class SmileSerialization {
   }
 
   public static Obj deserializeObj(
-      ObjId id, String versionToken, byte[] data, ObjType type, String compression) {
-    return deserializeObj(id, versionToken, data, type, Compression.fromValue(compression));
+      ObjId id,
+      String versionToken,
+      byte[] data,
+      ObjType type,
+      long referenced,
+      String compression) {
+    return deserializeObj(
+        id, versionToken, data, type, referenced, Compression.fromValue(compression));
   }
 
   public static Obj deserializeObj(
-      ObjId id, String versionToken, ByteBuffer data, ObjType type, Compression compression) {
+      ObjId id,
+      String versionToken,
+      ByteBuffer data,
+      ObjType type,
+      long referenced,
+      Compression compression) {
     byte[] bytes = new byte[data.remaining()];
     data.get(bytes);
-    return deserializeObj(id, versionToken, bytes, type, compression);
+    return deserializeObj(id, versionToken, bytes, type, referenced, compression);
   }
 
   public static Obj deserializeObj(
-      ObjId id, String versionToken, ByteBuffer data, ObjType type, String compression) {
+      ObjId id,
+      String versionToken,
+      ByteBuffer data,
+      ObjType type,
+      long referenced,
+      String compression) {
     byte[] bytes = new byte[data.remaining()];
     data.get(bytes);
-    return deserializeObj(id, versionToken, bytes, type, compression);
+    return deserializeObj(id, versionToken, bytes, type, referenced, compression);
   }
 
   public static byte[] serializeObj(Obj obj, Consumer<Compression> compression) {

--- a/versioned/storage/common-serialize/src/main/java/org/projectnessie/versioned/storage/serialize/SmileSerialization.java
+++ b/versioned/storage/common-serialize/src/main/java/org/projectnessie/versioned/storage/serialize/SmileSerialization.java
@@ -15,7 +15,7 @@
  */
 package org.projectnessie.versioned.storage.serialize;
 
-import static org.projectnessie.versioned.storage.common.json.ObjIdHelper.readerWithObjIdAndVersionToken;
+import static org.projectnessie.versioned.storage.common.json.ObjIdHelper.contextualReader;
 import static org.projectnessie.versioned.storage.common.util.Compressions.compressDefault;
 import static org.projectnessie.versioned.storage.common.util.Compressions.uncompress;
 
@@ -48,8 +48,7 @@ public final class SmileSerialization {
       long referenced,
       Compression compression) {
     try {
-      ObjectReader reader =
-          readerWithObjIdAndVersionToken(SMILE_MAPPER, type, id, versionToken, referenced);
+      ObjectReader reader = contextualReader(SMILE_MAPPER, type, id, versionToken, referenced);
       data = uncompress(compression, data);
       return reader.readValue(data, type.targetClass());
     } catch (IOException e) {

--- a/versioned/storage/common-serialize/src/test/java/org/projectnessie/versioned/storage/serialize/TestProtoSerialization.java
+++ b/versioned/storage/common-serialize/src/test/java/org/projectnessie/versioned/storage/serialize/TestProtoSerialization.java
@@ -110,11 +110,11 @@ public class TestProtoSerialization {
   @MethodSource("objs")
   void objs(Obj obj) throws Exception {
     byte[] serialized = serializeObj(obj, Integer.MAX_VALUE, Integer.MAX_VALUE, true);
-    Obj deserialized = deserializeObj(obj.id(), serialized, null);
-    Obj deserializedByteBuffer = deserializeObj(obj.id(), ByteBuffer.wrap(serialized), null);
+    Obj deserialized = deserializeObj(obj.id(), 0L, serialized, null);
+    Obj deserializedByteBuffer = deserializeObj(obj.id(), 0L, ByteBuffer.wrap(serialized), null);
     byte[] reserialized = serializeObj(deserialized, Integer.MAX_VALUE, Integer.MAX_VALUE, true);
     soft.assertThat(deserialized).isEqualTo(obj).isEqualTo(deserializedByteBuffer);
-    Obj deserialized2 = deserializeObj(obj.id(), reserialized, null);
+    Obj deserialized2 = deserializeObj(obj.id(), 0L, reserialized, null);
     soft.assertThat(deserialized2).isEqualTo(obj);
     soft.assertThat(serialized).isEqualTo(reserialized);
 
@@ -132,7 +132,8 @@ public class TestProtoSerialization {
           .isEmpty();
 
       UpdateableObj deserializedWithoutVersionToken =
-          (UpdateableObj) deserializeObj(obj.id(), serializedWithoutVersionToken, "my-foo-bar-baz");
+          (UpdateableObj)
+              deserializeObj(obj.id(), 420L, serializedWithoutVersionToken, "my-foo-bar-baz");
       soft.assertThat(deserializedWithoutVersionToken.versionToken())
           .isEqualTo("my-foo-bar-baz")
           .isNotEqualTo(((UpdateableObj) obj).versionToken());
@@ -159,8 +160,8 @@ public class TestProtoSerialization {
     soft.assertThat(serializePreviousPointers(null)).isNull();
 
     soft.assertThat(serializeObj(null, Integer.MAX_VALUE, Integer.MAX_VALUE, true)).isNull();
-    soft.assertThat(deserializeObj(randomObjId(), (byte[]) null, null)).isNull();
-    soft.assertThat(deserializeObj(randomObjId(), (ByteBuffer) null, null)).isNull();
+    soft.assertThat(deserializeObj(randomObjId(), 420L, (byte[]) null, null)).isNull();
+    soft.assertThat(deserializeObj(randomObjId(), 420L, (ByteBuffer) null, null)).isNull();
   }
 
   static Stream<List<Reference.PreviousPointer>> previousPointers() {
@@ -192,11 +193,12 @@ public class TestProtoSerialization {
 
   static Stream<Obj> objs() {
     return Stream.of(
-        ref(randomObjId(), "hello", randomObjId(), 42L, randomObjId()),
+        ref(randomObjId(), 420L, "hello", randomObjId(), 42L, randomObjId()),
         CommitObj.commitBuilder()
             .id(randomObjId())
             .seq(1L)
             .created(42L)
+            .referenced(1234L)
             .message("msg")
             .headers(EMPTY_COMMIT_HEADERS)
             .incrementalIndex(emptyImmutableIndex(COMMIT_OP_SERIALIZER).serialize())
@@ -219,26 +221,30 @@ public class TestProtoSerialization {
             .build(),
         tag(
             randomObjId(),
+            420L,
             "tab-msg",
             newCommitHeaders().add("Foo", "bar").build(),
             ByteString.copyFrom(new byte[1])),
-        contentValue(randomObjId(), "cid", 0, ByteString.copyFrom(new byte[1])),
+        contentValue(randomObjId(), 420L, "cid", 0, ByteString.copyFrom(new byte[1])),
         stringData(
             randomObjId(),
+            420L,
             "foo",
             Compression.NONE,
             "foo",
             emptyList(),
             ByteString.copyFrom(new byte[1])),
-        indexSegments(randomObjId(), emptyList()),
+        indexSegments(randomObjId(), 420L, emptyList()),
         indexSegments(
             randomObjId(),
+            420L,
             asList(
                 indexStripe(key("a"), key("b"), randomObjId()),
                 indexStripe(key("c"), key("d"), randomObjId()))),
-        index(randomObjId(), emptyImmutableIndex(COMMIT_OP_SERIALIZER).serialize()),
+        index(randomObjId(), 420L, emptyImmutableIndex(COMMIT_OP_SERIALIZER).serialize()),
         JsonObj.json(
             randomObjId(),
+            420L,
             ImmutableJsonTestModel.builder()
                 .parent(randomObjId())
                 .text("foo")

--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBasePersistTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBasePersistTests.java
@@ -157,9 +157,10 @@ public class AbstractBasePersistTests {
     String versionToken =
         (realObj instanceof UpdateableObj) ? ((UpdateableObj) realObj).versionToken() : null;
     String json = mapper.writeValueAsString(realObj);
+    long referenced = 42L;
 
     Obj genericObj =
-        readerWithObjIdAndVersionToken(mapper, genericType, idGeneric, versionToken)
+        readerWithObjIdAndVersionToken(mapper, genericType, idGeneric, versionToken, referenced)
             .readValue(json, genericType.targetClass());
     soft.assertThat(persist.storeObj(genericObj)).isTrue();
 
@@ -577,30 +578,32 @@ public class AbstractBasePersistTests {
         VersionedTestObj.builder().id(randomObjId()).someValue("foo").versionToken("1").build(),
         // JSON objects
         // scalar types
-        json(randomObjId(), "text"),
-        json(randomObjId(), 123),
-        json(randomObjId(), 123.456d),
-        json(randomObjId(), true),
-        json(randomObjId(), String.class, "text"),
-        json(randomObjId(), Integer.class, 123),
-        json(randomObjId(), Number.class, 123),
-        json(randomObjId(), Double.class, 123.456d),
-        json(randomObjId(), Boolean.class, true),
+        json(randomObjId(), 42L, "text"),
+        json(randomObjId(), 42L, 123),
+        json(randomObjId(), 42L, 123.456d),
+        json(randomObjId(), 42L, true),
+        json(randomObjId(), 42L, String.class, "text"),
+        json(randomObjId(), 42L, Integer.class, 123),
+        json(randomObjId(), 42L, Number.class, 123),
+        json(randomObjId(), 42L, Double.class, 123.456d),
+        json(randomObjId(), 42L, Boolean.class, true),
         // arrays / maps
-        json(randomObjId(), List.of("a", "b", "c")),
-        json(randomObjId(), List.class, List.of("a", "b", "c")),
-        json(randomObjId(), "java.util.List<java.lang.String>", List.of("a", "b", "c")),
-        json(randomObjId(), ImmutableList.class, List.of("a", "b", "c")),
-        json(randomObjId(), Map.of("k1", "v1", "k2", "v2")),
-        json(randomObjId(), Map.class, Map.of("k1", "v1", "k2", "v2")),
+        json(randomObjId(), 42L, List.of("a", "b", "c")),
+        json(randomObjId(), 42L, List.class, List.of("a", "b", "c")),
+        json(randomObjId(), 42L, "java.util.List<java.lang.String>", List.of("a", "b", "c")),
+        json(randomObjId(), 42L, ImmutableList.class, List.of("a", "b", "c")),
+        json(randomObjId(), 42L, Map.of("k1", "v1", "k2", "v2")),
+        json(randomObjId(), 42L, Map.class, Map.of("k1", "v1", "k2", "v2")),
         json(
             randomObjId(),
+            42L,
             "java.util.Map<java.lang.String,java.lang.String>",
             Map.of("k1", "v1", "k2", "v2")),
-        json(randomObjId(), ImmutableMap.class, Map.of("k1", "v1", "k2", "v2")),
+        json(randomObjId(), 42L, ImmutableMap.class, Map.of("k1", "v1", "k2", "v2")),
         // objects
         json(
             randomObjId(),
+            42L,
             ImmutableJsonTestBean.builder()
                 .parent(randomObjId())
                 .text("foo")
@@ -612,6 +615,7 @@ public class AbstractBasePersistTests {
                 .build()),
         json(
             randomObjId(),
+            42L,
             JsonTestBean.class,
             ImmutableJsonTestBean.builder()
                 .parent(randomObjId())
@@ -625,6 +629,7 @@ public class AbstractBasePersistTests {
         // large objects
         json(
             randomObjId(),
+            42L,
             ImmutableJsonTestBean.builder()
                 .parent(randomObjId())
                 .text("foo".repeat(4000))
@@ -637,6 +642,7 @@ public class AbstractBasePersistTests {
         // lists and maps of objects
         json(
             randomObjId(),
+            42L,
             "java.util.List<org.projectnessie.versioned.storage.commontests.objtypes.JsonTestBean>",
             List.of(
                 ImmutableJsonTestBean.builder()
@@ -659,6 +665,7 @@ public class AbstractBasePersistTests {
                     .build())),
         json(
             randomObjId(),
+            42L,
             "java.util.Map<java.lang.String,org.projectnessie.versioned.storage.commontests.objtypes.JsonTestBean>",
             Map.of(
                 "foo",
@@ -682,13 +689,13 @@ public class AbstractBasePersistTests {
                     .instant(null)
                     .build())),
         // empty objects / null
-        json(randomObjId(), ImmutableJsonTestBean.builder().build()),
-        json(randomObjId(), JsonTestBean.class, ImmutableJsonTestBean.builder().build()),
-        json(randomObjId(), String.class, null),
-        json(randomObjId(), List.class, null),
-        json(randomObjId(), Map.class, null),
-        json(randomObjId(), JsonTestBean.class, null),
-        json(randomObjId(), "java.util.List<java.lang.String>", null));
+        json(randomObjId(), 42L, ImmutableJsonTestBean.builder().build()),
+        json(randomObjId(), 42L, JsonTestBean.class, ImmutableJsonTestBean.builder().build()),
+        json(randomObjId(), 42L, String.class, null),
+        json(randomObjId(), 42L, List.class, null),
+        json(randomObjId(), 42L, Map.class, null),
+        json(randomObjId(), 42L, JsonTestBean.class, null),
+        json(randomObjId(), 42L, "java.util.List<java.lang.String>", null));
   }
 
   static StandardObjType typeDifferentThan(ObjType type) {
@@ -727,6 +734,91 @@ public class AbstractBasePersistTests {
       return INDEX;
     }
     throw new IllegalArgumentException(type.name());
+  }
+
+  @ParameterizedTest
+  @MethodSource("allObjectTypeSamples")
+  public void referencedLifecycle(Obj obj) throws Exception {
+    assumeThat(persist.isCaching())
+        .describedAs("'referenced' not tested against a caching Persist")
+        .isFalse();
+
+    obj = obj.withReferenced(0L);
+
+    long t = persist.config().currentTimeMicros();
+
+    soft.assertThat(persist.storeObj(obj)).isTrue();
+    Obj stored = persist.fetchObj(obj.id());
+    soft.assertThat(stored.referenced()).isGreaterThan(t);
+
+    soft.assertThat(persist.storeObj(obj)).isFalse();
+    Obj restored = persist.fetchObj(obj.id());
+    soft.assertThat(restored.referenced()).isGreaterThan(stored.referenced());
+
+    persist.upsertObj(obj);
+    Obj upserted = persist.fetchObj(obj.id());
+    soft.assertThat(upserted.referenced()).isGreaterThan(restored.referenced());
+  }
+
+  @Test
+  public void referencedLifecycleAll() throws Exception {
+    assumeThat(persist.isCaching())
+        .describedAs("'referenced' not tested against a caching Persist")
+        .isFalse();
+
+    Obj[] objs = allObjectTypeSamples().toArray(Obj[]::new);
+    ObjId[] ids = stream(objs).map(Obj::id).toArray(ObjId[]::new);
+
+    long t = persist.config().currentTimeMicros();
+
+    soft.assertThat(persist.storeObjs(objs)).doesNotContain(false);
+    Obj[] stored = persist.fetchObjs(ids);
+    for (Obj obj : stored) {
+      soft.assertThat(obj.referenced()).isGreaterThan(t);
+    }
+
+    soft.assertThat(persist.storeObjs(objs)).doesNotContain(true);
+    Obj[] restored = persist.fetchObjs(ids);
+    for (int i = 0; i < stored.length; i++) {
+      soft.assertThat(restored[i].referenced()).isGreaterThan(stored[i].referenced());
+    }
+
+    persist.upsertObjs(objs);
+    Obj[] upserted = persist.fetchObjs(ids);
+    for (int i = 0; i < stored.length; i++) {
+      soft.assertThat(upserted[i].referenced()).isGreaterThan(restored[i].referenced());
+    }
+  }
+
+  @Test
+  public void referencedLifecycleForUpdateable() throws Exception {
+    assumeThat(persist.isCaching())
+        .describedAs("'referenced' not tested against a caching Persist")
+        .isFalse();
+
+    VersionedTestObj obj =
+        VersionedTestObj.builder().id(randomObjId()).versionToken("123").someValue("value").build();
+    VersionedTestObj updatedObj =
+        VersionedTestObj.builder().from(obj).versionToken("234").someValue("some").build();
+
+    long t = persist.config().currentTimeMicros();
+
+    soft.assertThat(persist.storeObj(obj)).isTrue();
+    Obj stored = persist.fetchObj(obj.id());
+    soft.assertThat(stored.referenced()).isGreaterThan(t);
+
+    soft.assertThat(persist.storeObj(obj)).isFalse();
+    Obj restored = persist.fetchObj(obj.id());
+    soft.assertThat(restored.referenced()).isGreaterThan(stored.referenced());
+
+    persist.upsertObj(obj);
+    Obj upserted = persist.fetchObj(obj.id());
+    soft.assertThat(upserted.referenced()).isGreaterThan(restored.referenced());
+
+    soft.assertThat(persist.updateConditional(obj, updatedObj)).isTrue();
+    VersionedTestObj updated = persist.fetchTypedObj(obj.id(), obj.type(), VersionedTestObj.class);
+    soft.assertThat(updated).isEqualTo(updatedObj);
+    soft.assertThat(updated.referenced()).isGreaterThan(upserted.referenced());
   }
 
   @ParameterizedTest
@@ -820,7 +912,7 @@ public class AbstractBasePersistTests {
   public void storeAndFetchMany() throws Exception {
     List<TagObj> objects =
         IntStream.range(0, 957) // 957 is an arbitrary number, just not something "round"
-            .mapToObj(i -> tag(randomObjId(), null, null, ByteString.copyFrom(new byte[42])))
+            .mapToObj(i -> tag(randomObjId(), 42L, null, null, ByteString.copyFrom(new byte[42])))
             .collect(Collectors.toList());
 
     boolean[] results = persist.storeObjs(objects.toArray(new Obj[0]));
@@ -836,11 +928,11 @@ public class AbstractBasePersistTests {
 
   @Test
   public void multipleStoreObjs() throws Exception {
-    Obj obj1 = tag(randomObjId(), null, null, ByteString.EMPTY);
-    Obj obj2 = tag(randomObjId(), null, null, ByteString.EMPTY);
-    Obj obj3 = tag(randomObjId(), null, null, ByteString.EMPTY);
-    Obj obj4 = tag(randomObjId(), null, null, ByteString.EMPTY);
-    Obj obj5 = tag(randomObjId(), null, null, ByteString.EMPTY);
+    Obj obj1 = tag(randomObjId(), 42L, null, null, ByteString.EMPTY);
+    Obj obj2 = tag(randomObjId(), 42L, null, null, ByteString.EMPTY);
+    Obj obj3 = tag(randomObjId(), 42L, null, null, ByteString.EMPTY);
+    Obj obj4 = tag(randomObjId(), 42L, null, null, ByteString.EMPTY);
+    Obj obj5 = tag(randomObjId(), 42L, null, null, ByteString.EMPTY);
 
     soft.assertThat(persist.storeObjs(new Obj[] {obj1})).containsExactly(true);
     soft.assertThat(persist.fetchObj(requireNonNull(obj1.id()))).isEqualTo(obj1);
@@ -981,7 +1073,7 @@ public class AbstractBasePersistTests {
   }
 
   private void verifyObjSizeLimit(Persist persist, StoreIndex<CommitOp> index) {
-    soft.assertThatThrownBy(() -> persist.storeObj(index(randomObjId(), index.serialize())))
+    soft.assertThatThrownBy(() -> persist.storeObj(index(randomObjId(), 42L, index.serialize())))
         .isInstanceOf(ObjTooLargeException.class);
     soft.assertThatThrownBy(
             () ->
@@ -1166,31 +1258,32 @@ public class AbstractBasePersistTests {
               .incompleteIndex(!c.incompleteIndex())
               .build();
         case VALUE:
-          return contentValue(obj.id(), randomContentId(), 123, copyFromUtf8("updated stuff"));
+          return contentValue(obj.id(), 42L, randomContentId(), 123, copyFromUtf8("updated stuff"));
         case REF:
-          return ref(obj.id(), "hello", randomObjId(), 42L, randomObjId());
+          return ref(obj.id(), 42L, "hello", randomObjId(), 42L, randomObjId());
         case INDEX:
           index = newStoreIndex(COMMIT_OP_SERIALIZER);
           index.add(
               indexElement(key("updated", "added", "key"), commitOp(ADD, 123, randomObjId())));
           index.add(
               indexElement(key("updated", "removed", "key"), commitOp(REMOVE, 123, randomObjId())));
-          return index(obj.id(), index.serialize());
+          return index(obj.id(), 42L, index.serialize());
         case INDEX_SEGMENTS:
           return indexSegments(
-              obj.id(), singletonList(indexStripe(key("abc"), key("def"), randomObjId())));
+              obj.id(), 42L, singletonList(indexStripe(key("abc"), key("def"), randomObjId())));
         case TAG:
-          return tag(obj.id(), null, null, copyFromUtf8("updated-tag"));
+          return tag(obj.id(), 42L, null, null, copyFromUtf8("updated-tag"));
         case STRING:
           return stringData(
               obj.id(),
+              42L,
               "text/plain",
               Compression.LZ4,
               "filename",
               asList(randomObjId(), randomObjId(), randomObjId(), randomObjId()),
               ByteString.copyFrom(new byte[123]));
         case UNIQUE:
-          return uniqueId(obj.id(), "other_space", uuidToBytes(UUID.randomUUID()));
+          return uniqueId(obj.id(), 42L, "other_space", uuidToBytes(UUID.randomUUID()));
         default:
           // fall through
       }
@@ -1225,6 +1318,7 @@ public class AbstractBasePersistTests {
     if (obj instanceof JsonObj) {
       return json(
           obj.id(),
+          42L,
           ImmutableJsonTestBean.builder()
               .parent(randomObjId())
               .text("updated")

--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBasePersistTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBasePersistTests.java
@@ -35,7 +35,7 @@ import static org.projectnessie.versioned.storage.common.config.StoreConfig.CONF
 import static org.projectnessie.versioned.storage.common.indexes.StoreIndexElement.indexElement;
 import static org.projectnessie.versioned.storage.common.indexes.StoreIndexes.newStoreIndex;
 import static org.projectnessie.versioned.storage.common.indexes.StoreKey.key;
-import static org.projectnessie.versioned.storage.common.json.ObjIdHelper.readerWithObjIdAndVersionToken;
+import static org.projectnessie.versioned.storage.common.json.ObjIdHelper.contextualReader;
 import static org.projectnessie.versioned.storage.common.objtypes.CommitHeaders.EMPTY_COMMIT_HEADERS;
 import static org.projectnessie.versioned.storage.common.objtypes.CommitHeaders.newCommitHeaders;
 import static org.projectnessie.versioned.storage.common.objtypes.CommitObj.commitBuilder;
@@ -160,7 +160,7 @@ public class AbstractBasePersistTests {
     long referenced = 42L;
 
     Obj genericObj =
-        readerWithObjIdAndVersionToken(mapper, genericType, idGeneric, versionToken, referenced)
+        contextualReader(mapper, genericType, idGeneric, versionToken, referenced)
             .readValue(json, genericType.targetClass());
     soft.assertThat(persist.storeObj(genericObj)).isTrue();
 

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/json/ObjIdHelper.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/json/ObjIdHelper.java
@@ -35,18 +35,21 @@ public final class ObjIdHelper {
 
   public static final String OBJ_TYPE_KEY = "nessie.storage.ObjType";
 
+  public static final String OBJ_REFERENCED_KEY = "nessie.storage.ObjReferenced";
+
   /**
    * Returns an {@link ObjectReader} for the given target {@link ObjType}, with the given {@link
    * ObjId} injectable under the key {@value #OBJ_ID_KEY} and version token using the key {@value
    * #OBJ_VERS_KEY}.
    */
   public static ObjectReader readerWithObjIdAndVersionToken(
-      ObjectMapper mapper, ObjType objType, ObjId id, String objVersionToken) {
+      ObjectMapper mapper, ObjType objType, ObjId id, String objVersionToken, long objReferenced) {
     InjectableValues values =
         new InjectableValues.Std()
             .addValue(OBJ_ID_KEY, id)
             .addValue(OBJ_VERS_KEY, objVersionToken)
-            .addValue(OBJ_TYPE_KEY, objType);
+            .addValue(OBJ_TYPE_KEY, objType)
+            .addValue(OBJ_REFERENCED_KEY, objReferenced);
     return mapper.reader(values).forType(objType.targetClass());
   }
 

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/json/ObjIdHelper.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/json/ObjIdHelper.java
@@ -39,10 +39,10 @@ public final class ObjIdHelper {
 
   /**
    * Returns an {@link ObjectReader} for the given target {@link ObjType}, with the given {@link
-   * ObjId} injectable under the key {@value #OBJ_ID_KEY} and version token using the key {@value
-   * #OBJ_VERS_KEY}.
+   * ObjId} injectable under the key {@value #OBJ_ID_KEY}, version token using the key {@value
+   * #OBJ_VERS_KEY} and referenced timestamp using the key {@value #OBJ_REFERENCED_KEY}.
    */
-  public static ObjectReader readerWithObjIdAndVersionToken(
+  public static ObjectReader contextualReader(
       ObjectMapper mapper, ObjType objType, ObjId id, String objVersionToken, long objReferenced) {
     InjectableValues values =
         new InjectableValues.Std()

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogic.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogic.java
@@ -62,8 +62,9 @@ public interface CommitLogic {
    * @param createCommit parameters for {@link #buildCommitObj(CreateCommit, ConflictHandler,
    *     CommitOpHandler, ValueReplacement, ValueReplacement)}
    * @param additionalObjects additional {@link Obj}s to store, for example {@link ContentValueObj}
-   * @return the non-null commit, if the commit was stored as a new record, or {@code null} if an
-   *     object with the same ID already exists.
+   * @return the non-{@code null} commit, if it was stored as a new record or already existed with
+   *     the same values. Returns {@code null} if an object with the same ID already exists
+   *     (collision).
    */
   @Nullable
   CommitObj doCommit(@Nonnull CreateCommit createCommit, @Nonnull List<Obj> additionalObjects)
@@ -76,7 +77,9 @@ public interface CommitLogic {
    *
    * @param commit commit to store
    * @param additionalObjects additional {@link Obj}s to store, for example {@link ContentValueObj}
-   * @return the persisted {@link CommitObj} if successful
+   * @return container holding the information whether the {@link CommitObj} was persisted as a new
+   *     commit object, existed with the same values or was not persisted due to a commit-ID/hash
+   *     collision.
    * @see #doCommit(CreateCommit, List)
    * @see #buildCommitObj(CreateCommit, ConflictHandler, CommitOpHandler, ValueReplacement,
    *     ValueReplacement)

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogic.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogic.java
@@ -20,6 +20,7 @@ import static org.projectnessie.versioned.storage.common.logic.ConflictHandler.C
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
@@ -39,6 +40,7 @@ import org.projectnessie.versioned.storage.common.objtypes.ContentValueObj;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 import org.projectnessie.versioned.storage.common.persist.Reference;
+import org.projectnessie.versioned.storage.common.persist.StoredObjResult;
 
 /** Logic to read commits and perform commits including conflict checks. */
 public interface CommitLogic {
@@ -80,8 +82,9 @@ public interface CommitLogic {
    *     ValueReplacement)
    * @see #updateCommit(CommitObj)
    */
-  @Nullable
-  CommitObj storeCommit(@Nonnull CommitObj commit, @Nonnull List<Obj> additionalObjects);
+  @NotNull
+  StoredObjResult<CommitObj> storeCommit(
+      @Nonnull CommitObj commit, @Nonnull List<Obj> additionalObjects);
 
   /**
    * Updates an <em>existing</em> commit and handles storing the (external) {@link

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/RepositoryLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/RepositoryLogicImpl.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.versioned.storage.common.logic;
 
+import static java.time.OffsetDateTime.now;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static org.projectnessie.versioned.storage.common.logic.CommitRetry.commitRetry;
@@ -27,7 +28,6 @@ import static org.projectnessie.versioned.storage.common.logic.Logics.commitLogi
 import static org.projectnessie.versioned.storage.common.logic.Logics.indexesLogic;
 import static org.projectnessie.versioned.storage.common.logic.Logics.referenceLogic;
 import static org.projectnessie.versioned.storage.common.logic.Logics.stringLogic;
-import static org.projectnessie.versioned.storage.common.objtypes.CommitHeaders.EMPTY_COMMIT_HEADERS;
 import static org.projectnessie.versioned.storage.common.persist.ObjId.EMPTY_OBJ_ID;
 import static org.projectnessie.versioned.storage.common.persist.Reference.reference;
 import static org.projectnessie.versioned.storage.common.util.Ser.SHARED_OBJECT_MAPPER;
@@ -50,6 +50,7 @@ import org.projectnessie.versioned.storage.common.indexes.StoreIndex;
 import org.projectnessie.versioned.storage.common.indexes.StoreIndexElement;
 import org.projectnessie.versioned.storage.common.logic.CommitRetry.RetryException;
 import org.projectnessie.versioned.storage.common.logic.StringLogic.StringValue;
+import org.projectnessie.versioned.storage.common.objtypes.CommitHeaders;
 import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
 import org.projectnessie.versioned.storage.common.objtypes.CommitOp;
 import org.projectnessie.versioned.storage.common.objtypes.CommitType;
@@ -244,7 +245,11 @@ final class RepositoryLogicImpl implements RepositoryLogic {
       CreateCommit.Builder c =
           newCommitBuilder()
               .parentCommitId(EMPTY_OBJ_ID)
-              .headers(EMPTY_COMMIT_HEADERS)
+              .headers(
+                  CommitHeaders.newCommitHeaders()
+                      .add("repo.id", persist.config().repositoryId())
+                      .add("timestamp", now())
+                      .build())
               .message("Initialize reference " + internalRef.name())
               .commitType(CommitType.INTERNAL);
 

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/CommitObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/CommitObj.java
@@ -92,6 +92,9 @@ public interface CommitObj extends Obj {
     Builder id(@Nullable ObjId id);
 
     @CanIgnoreReturnValue
+    Builder referenced(long referenced);
+
+    @CanIgnoreReturnValue
     Builder created(long created);
 
     @CanIgnoreReturnValue
@@ -138,6 +141,7 @@ public interface CommitObj extends Obj {
   }
 
   /** Creation timestamp in microseconds since epoch. */
+  @Value.Auxiliary
   long created();
 
   /**

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/ContentValueObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/ContentValueObj.java
@@ -37,6 +37,11 @@ public interface ContentValueObj extends Obj {
   @Value.Parameter(order = 1)
   ObjId id();
 
+  @Override
+  @Value.Parameter(order = 1)
+  @Value.Auxiliary
+  long referenced();
+
   @Value.Parameter(order = 2)
   String contentId();
 
@@ -46,9 +51,10 @@ public interface ContentValueObj extends Obj {
   @Value.Parameter(order = 4)
   ByteString data();
 
-  static ContentValueObj contentValue(ObjId id, String contentId, int payload, ByteString data) {
+  static ContentValueObj contentValue(
+      ObjId id, long referenced, String contentId, int payload, ByteString data) {
     checkArgument(payload >= 0 && payload <= 127);
-    return ImmutableContentValueObj.of(id, contentId, payload, data);
+    return ImmutableContentValueObj.of(id, referenced, contentId, payload, data);
   }
 
   static ContentValueObj contentValue(String contentId, int payload, ByteString data) {
@@ -58,6 +64,7 @@ public interface ContentValueObj extends Obj {
             .hash(payload)
             .hash(data.asReadOnlyByteBuffer())
             .generate(),
+        0L,
         contentId,
         payload,
         data);

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/IndexObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/IndexObj.java
@@ -39,16 +39,21 @@ public interface IndexObj extends Obj {
   @Nullable
   ObjId id();
 
+  @Override
+  @Value.Parameter(order = 1)
+  @Value.Auxiliary
+  long referenced();
+
   @Value.Parameter(order = 1)
   ByteString index();
 
   @Nonnull
-  static IndexObj index(@Nullable ObjId id, @Nonnull ByteString index) {
-    return ImmutableIndexObj.of(id, index);
+  static IndexObj index(@Nullable ObjId id, long referenced, @Nonnull ByteString index) {
+    return ImmutableIndexObj.of(id, referenced, index);
   }
 
   @Nonnull
   static IndexObj index(@Nonnull ByteString index) {
-    return index(objIdHasher(INDEX).hash(index.asReadOnlyByteBuffer()).generate(), index);
+    return index(objIdHasher(INDEX).hash(index.asReadOnlyByteBuffer()).generate(), 0L, index);
   }
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/IndexSegmentsObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/IndexSegmentsObj.java
@@ -39,16 +39,23 @@ public interface IndexSegmentsObj extends Obj {
   @Nullable
   ObjId id();
 
+  @Override
+  @Value.Parameter(order = 1)
+  @Value.Auxiliary
+  long referenced();
+
   @Value.Parameter(order = 2)
   List<IndexStripe> stripes();
 
   @Nonnull
-  static IndexSegmentsObj indexSegments(@Nullable ObjId id, @Nonnull List<IndexStripe> stripes) {
-    return ImmutableIndexSegmentsObj.of(id, stripes);
+  static IndexSegmentsObj indexSegments(
+      @Nullable ObjId id, long referenced, @Nonnull List<IndexStripe> stripes) {
+    return ImmutableIndexSegmentsObj.of(id, referenced, stripes);
   }
 
   @Nonnull
   static IndexSegmentsObj indexSegments(@Nonnull List<IndexStripe> stripes) {
-    return indexSegments(objIdHasher(INDEX_SEGMENTS).hashCollection(stripes).generate(), stripes);
+    return indexSegments(
+        objIdHasher(INDEX_SEGMENTS).hashCollection(stripes).generate(), 0L, stripes);
   }
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/JsonObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/JsonObj.java
@@ -77,23 +77,24 @@ public interface JsonObj extends Obj {
   /**
    * Creates a {@link JsonObj} for the given bean.
    *
-   * <p>This method is NOT suitable for null beans: use either {@link #json(ObjId, Class, Object)}
-   * or {@link #json(ObjId, String, Object)} in order to properly capture the type of the object.
+   * <p>This method is NOT suitable for null beans: use either {@link #json(ObjId, long, Class,
+   * Object)} or {@link #json(ObjId, long, String, Object)} in order to properly capture the type of
+   * the object.
    *
    * <p>This method is NOT suitable either for generic bean types such as {@code MyBean<String>} :
-   * use {@link #json(ObjId, String, Object)} instead.
+   * use {@link #json(ObjId, long, String, Object)} instead.
    */
-  static JsonObj json(ObjId id, @Nonnull Object bean) {
-    return json(id, bean.getClass(), bean);
+  static JsonObj json(ObjId id, long referenced, @Nonnull Object bean) {
+    return json(id, referenced, bean.getClass(), bean);
   }
 
   /**
    * Creates a {@link JsonObj} for the given bean and raw type.
    *
-   * <p>For generic types, use {@link #json(ObjId, String, Object)} instead.
+   * <p>For generic types, use {@link #json(ObjId, long, String, Object)} instead.
    */
-  static JsonObj json(ObjId id, Class<?> type, @Nullable Object bean) {
-    return json(id, type.getName(), bean);
+  static JsonObj json(ObjId id, long referenced, Class<?> type, @Nullable Object bean) {
+    return json(id, referenced, type.getName(), bean);
   }
 
   /**
@@ -102,7 +103,7 @@ public interface JsonObj extends Obj {
    * <p>The type must be parseable by Jackson's TypeParser. For generic types, use the following
    * general format: {@code "com.example.MyType<com.example.OtherType>"}.
    */
-  static JsonObj json(ObjId id, String type, @Nullable Object bean) {
+  static JsonObj json(ObjId id, long referenced, String type, @Nullable Object bean) {
     return ImmutableJsonObj.builder()
         .id(id)
         .bean(ImmutableJsonBean.builder().object(bean).type(type).build())

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/JsonObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/JsonObj.java
@@ -106,6 +106,7 @@ public interface JsonObj extends Obj {
   static JsonObj json(ObjId id, long referenced, String type, @Nullable Object bean) {
     return ImmutableJsonObj.builder()
         .id(id)
+        .referenced(referenced)
         .bean(ImmutableJsonBean.builder().object(bean).type(type).build())
         .build();
   }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/RefObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/RefObj.java
@@ -45,6 +45,11 @@ public interface RefObj extends Obj {
   @Nullable
   ObjId id();
 
+  @Override
+  @Value.Parameter(order = 1)
+  @Value.Auxiliary
+  long referenced();
+
   /**
    * The tip/HEAD of the reference at reference creation. This value does <em>not</em> track the
    * <em>current</em> tip/HEAD of the reference. This value is used to implement create-reference
@@ -62,8 +67,14 @@ public interface RefObj extends Obj {
   ObjId extendedInfoObj();
 
   static RefObj ref(
-      ObjId id, String name, ObjId initialPointer, long createdAtMicros, ObjId extendedInfoObj) {
-    return ImmutableRefObj.of(name, id, initialPointer, createdAtMicros, extendedInfoObj);
+      ObjId id,
+      long referenced,
+      String name,
+      ObjId initialPointer,
+      long createdAtMicros,
+      ObjId extendedInfoObj) {
+    return ImmutableRefObj.of(
+        name, id, referenced, initialPointer, createdAtMicros, extendedInfoObj);
   }
 
   static RefObj ref(
@@ -74,6 +85,7 @@ public interface RefObj extends Obj {
             .hash(initialPointer.asByteArray())
             .hash(createdAtMicros)
             .generate(),
+        0L,
         name,
         initialPointer,
         createdAtMicros,

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/StringObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/StringObj.java
@@ -40,6 +40,11 @@ public interface StringObj extends Obj {
   @Nullable
   ObjId id();
 
+  @Override
+  @Value.Parameter(order = 1)
+  @Value.Auxiliary
+  long referenced();
+
   @Value.Parameter(order = 2)
   String contentType();
 
@@ -71,12 +76,14 @@ public interface StringObj extends Obj {
 
   static StringObj stringData(
       ObjId id,
+      long referenced,
       String contentType,
       Compression compression,
       @Nullable String filename,
       List<ObjId> predecessors,
       ByteString text) {
-    return ImmutableStringObj.of(id, contentType, compression, filename, predecessors, text);
+    return ImmutableStringObj.of(
+        id, referenced, contentType, compression, filename, predecessors, text);
   }
 
   static StringObj stringData(
@@ -90,6 +97,7 @@ public interface StringObj extends Obj {
     predecessors.forEach(id -> hasher.hash(id.asByteArray()));
     hasher.hash(text.asReadOnlyByteBuffer());
 
-    return stringData(hasher.generate(), contentType, compression, filename, predecessors, text);
+    return stringData(
+        hasher.generate(), 0L, contentType, compression, filename, predecessors, text);
   }
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/TagObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/TagObj.java
@@ -39,6 +39,11 @@ public interface TagObj extends Obj {
   @Nullable
   ObjId id();
 
+  @Override
+  @Value.Parameter(order = 1)
+  @Value.Auxiliary
+  long referenced();
+
   /** The tag message as plain text. */
   @Value.Parameter(order = 2)
   @Nullable
@@ -53,8 +58,9 @@ public interface TagObj extends Obj {
   @Nullable
   ByteString signature();
 
-  static TagObj tag(ObjId id, String message, CommitHeaders headers, ByteString signature) {
-    return ImmutableTagObj.of(id, message, headers, signature);
+  static TagObj tag(
+      ObjId id, long referenced, String message, CommitHeaders headers, ByteString signature) {
+    return ImmutableTagObj.of(id, referenced, message, headers, signature);
   }
 
   static TagObj tag(String message, CommitHeaders headers, ByteString signature) {
@@ -69,6 +75,6 @@ public interface TagObj extends Obj {
       hasher.hash(signature.asReadOnlyByteBuffer());
     }
 
-    return tag(hasher.generate(), message, headers, signature);
+    return tag(hasher.generate(), 0L, message, headers, signature);
   }
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/UniqueIdObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/UniqueIdObj.java
@@ -45,6 +45,11 @@ public interface UniqueIdObj extends Obj {
   @Nullable
   ObjId id();
 
+  @Override
+  @Value.Parameter(order = 1)
+  @Value.Auxiliary
+  long referenced();
+
   /** The "ID space", for example {@code content-id}. */
   @Value.Parameter(order = 2)
   String space();
@@ -61,13 +66,14 @@ public interface UniqueIdObj extends Obj {
     return new UUID(msb, lsb);
   }
 
-  static UniqueIdObj uniqueId(ObjId id, String space, ByteString value) {
-    return ImmutableUniqueIdObj.of(id, space, value);
+  static UniqueIdObj uniqueId(ObjId id, long referenced, String space, ByteString value) {
+    return ImmutableUniqueIdObj.of(id, referenced, space, value);
   }
 
   static UniqueIdObj uniqueId(String space, ByteString value) {
     return uniqueId(
         objIdHasher(UNIQUE).hash(space).hash(value.asReadOnlyByteBuffer()).generate(),
+        0L,
         space,
         value);
   }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Obj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Obj.java
@@ -36,6 +36,8 @@ public interface Obj {
    * Contains the timestamp in microseconds since epoch when the object was last written, only
    * intended for repository cleanup mechanisms.
    *
+   * <p>The value of this attribute is generated exclusively by the {@link Persist} implementations.
+   *
    * <p>This attribute is <em>not</em> consistent when using a caching {@link Persist}.
    */
   @JsonIgnore

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Obj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Obj.java
@@ -16,9 +16,11 @@
 package org.projectnessie.versioned.storage.common.persist;
 
 import static org.projectnessie.versioned.storage.common.json.ObjIdHelper.OBJ_ID_KEY;
+import static org.projectnessie.versioned.storage.common.json.ObjIdHelper.OBJ_REFERENCED_KEY;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.immutables.value.Value;
 
 public interface Obj {
 
@@ -29,4 +31,21 @@ public interface Obj {
 
   @JsonIgnore
   ObjType type();
+
+  /**
+   * Contains the timestamp in microseconds since epoch when the object was last written, only
+   * intended for repository cleanup mechanisms.
+   *
+   * <p>This attribute is <em>not</em> consistent when using a caching {@link Persist}.
+   */
+  @JsonIgnore
+  @JacksonInject(OBJ_REFERENCED_KEY)
+  @Value.Default
+  @Value.Auxiliary
+  default long referenced() {
+    return 0L;
+  }
+
+  // no generics, we're good
+  Obj withReferenced(long referenced);
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObservingPersist.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObservingPersist.java
@@ -304,4 +304,9 @@ public class ObservingPersist implements Persist {
   public void erase() {
     delegate.erase();
   }
+
+  @Override
+  public boolean isCaching() {
+    return delegate.isCaching();
+  }
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Persist.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Persist.java
@@ -439,4 +439,8 @@ public interface Persist {
    * can lead to a <em>very</em> long runtime of this method.
    */
   void erase();
+
+  default boolean isCaching() {
+    return false;
+  }
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/StoredObjResult.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/StoredObjResult.java
@@ -21,9 +21,17 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 public interface StoredObjResult<T> {
+  /**
+   * Either contains the newly persisted or already existing object or is empty, if the object was
+   * not persisted due to a {@link ObjId} collision.
+   */
   @Value.Parameter
   Optional<T> obj();
 
+  /**
+   * Flag whether the object was persisted as a new object, {@link #obj()} will have a value if
+   * {@code stored} is {@code true}.
+   */
   @Value.Parameter
   boolean stored();
 

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/StoredObjResult.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/StoredObjResult.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.common.persist;
+
+import jakarta.annotation.Nullable;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface StoredObjResult<T> {
+  @Value.Parameter
+  Optional<T> obj();
+
+  @Value.Parameter
+  boolean stored();
+
+  static <T> StoredObjResult<T> storedObjResult(@Nullable T obj, boolean stored) {
+    return ImmutableStoredObjResult.of(Optional.ofNullable(obj), stored);
+  }
+}

--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/logic/TestCommitConflicts.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/logic/TestCommitConflicts.java
@@ -46,6 +46,7 @@ import static org.projectnessie.versioned.storage.common.objtypes.CommitOp.Actio
 import static org.projectnessie.versioned.storage.common.objtypes.CommitOp.commitOp;
 import static org.projectnessie.versioned.storage.common.persist.ObjId.objIdFromString;
 import static org.projectnessie.versioned.storage.common.persist.ObjId.randomObjId;
+import static org.projectnessie.versioned.storage.common.persist.StoredObjResult.storedObjResult;
 import static org.projectnessie.versioned.storage.commontests.AbstractCommitLogicTests.stdCommit;
 
 import java.util.ArrayList;
@@ -478,7 +479,8 @@ public class TestCommitConflicts {
         .containsEntry(fooKey, fooAddId)
         .containsEntry(barKey, barAddId);
 
-    soft.assertThat(commitLogic.storeCommit(firstCommit, emptyList())).isEqualTo(firstCommit);
+    soft.assertThat(commitLogic.storeCommit(firstCommit, emptyList()))
+        .isEqualTo(storedObjResult(firstCommit, true));
     ObjId firstCommitId = firstCommit.id();
 
     // callback for a remove + update
@@ -502,7 +504,8 @@ public class TestCommitConflicts {
         .containsEntry(fooKey, null)
         .containsEntry(barKey, barUpdateId);
 
-    soft.assertThat(commitLogic.storeCommit(secondCommit, emptyList())).isEqualTo(secondCommit);
+    soft.assertThat(commitLogic.storeCommit(secondCommit, emptyList()))
+        .isEqualTo(storedObjResult(secondCommit, true));
     ObjId secondCommitId = secondCommit.id();
     CommitObj secondCommitLoaded = requireNonNull(commitLogic.fetchCommit(secondCommitId));
     commitLogic.updateCommit(secondCommitLoaded);

--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/objtypes/TestGenericObj.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/objtypes/TestGenericObj.java
@@ -16,7 +16,7 @@
 package org.projectnessie.versioned.storage.common.objtypes;
 
 import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static org.projectnessie.versioned.storage.common.json.ObjIdHelper.readerWithObjIdAndVersionToken;
+import static org.projectnessie.versioned.storage.common.json.ObjIdHelper.contextualReader;
 import static org.projectnessie.versioned.storage.common.objtypes.GenericObj.VERSION_TOKEN_ATTRIBUTE;
 import static org.projectnessie.versioned.storage.common.objtypes.GenericObjTypeMapper.newGenericObjType;
 import static org.projectnessie.versioned.storage.common.persist.ObjId.randomObjId;
@@ -53,7 +53,7 @@ public class TestGenericObj {
     String json = mapper.writeValueAsString(realObj);
 
     Obj genericObj =
-        readerWithObjIdAndVersionToken(mapper, genericType, id, versionToken, realObj.referenced())
+        contextualReader(mapper, genericType, id, versionToken, realObj.referenced())
             .readValue(json, genericType.targetClass());
     soft.assertThat(genericObj)
         .isInstanceOf(GenericObj.class)
@@ -68,7 +68,7 @@ public class TestGenericObj {
 
     String jsonGeneric = mapper.writeValueAsString(genericObj);
     Obj deserRealObj =
-        readerWithObjIdAndVersionToken(mapper, realType, id, versionToken, realObj.referenced())
+        contextualReader(mapper, realType, id, versionToken, realObj.referenced())
             .readValue(jsonGeneric, realType.targetClass());
     soft.assertThat(deserRealObj).isEqualTo(realObj);
   }

--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/objtypes/TestGenericObj.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/objtypes/TestGenericObj.java
@@ -53,7 +53,7 @@ public class TestGenericObj {
     String json = mapper.writeValueAsString(realObj);
 
     Obj genericObj =
-        readerWithObjIdAndVersionToken(mapper, genericType, id, versionToken)
+        readerWithObjIdAndVersionToken(mapper, genericType, id, versionToken, realObj.referenced())
             .readValue(json, genericType.targetClass());
     soft.assertThat(genericObj)
         .isInstanceOf(GenericObj.class)
@@ -68,7 +68,7 @@ public class TestGenericObj {
 
     String jsonGeneric = mapper.writeValueAsString(genericObj);
     Obj deserRealObj =
-        readerWithObjIdAndVersionToken(mapper, realType, id, versionToken)
+        readerWithObjIdAndVersionToken(mapper, realType, id, versionToken, realObj.referenced())
             .readValue(jsonGeneric, realType.targetClass());
     soft.assertThat(deserRealObj).isEqualTo(realObj);
   }

--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/objtypes/TestStandardObjTypes.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/objtypes/TestStandardObjTypes.java
@@ -75,7 +75,7 @@ public class TestStandardObjTypes {
 
   static Stream<Arguments> standardObjTypes() {
     return Stream.of(
-        arguments(ref(randomObjId(), "hello", randomObjId(), 42L, randomObjId()), REF),
+        arguments(ref(randomObjId(), 420L, "hello", randomObjId(), 42L, randomObjId()), REF),
         arguments(
             CommitObj.commitBuilder()
                 .id(randomObjId())
@@ -89,24 +89,28 @@ public class TestStandardObjTypes {
         arguments(
             tag(
                 randomObjId(),
+                420L,
                 "tab-msg",
                 newCommitHeaders().add("Foo", "bar").build(),
                 ByteString.copyFrom(new byte[1])),
             TAG),
-        arguments(contentValue(randomObjId(), "cid", 0, ByteString.copyFrom(new byte[1])), VALUE),
+        arguments(
+            contentValue(randomObjId(), 420L, "cid", 0, ByteString.copyFrom(new byte[1])), VALUE),
         arguments(
             stringData(
                 randomObjId(),
+                420L,
                 "foo",
                 Compression.NONE,
                 "foo",
                 emptyList(),
                 ByteString.copyFrom(new byte[1])),
             STRING),
-        arguments(indexSegments(randomObjId(), emptyList()), INDEX_SEGMENTS),
+        arguments(indexSegments(randomObjId(), 420L, emptyList()), INDEX_SEGMENTS),
         arguments(
-            index(randomObjId(), emptyImmutableIndex(COMMIT_OP_SERIALIZER).serialize()), INDEX),
-        arguments(uniqueId(randomObjId(), "space", uuidToBytes(UUID.randomUUID())), UNIQUE));
+            index(randomObjId(), 420L, emptyImmutableIndex(COMMIT_OP_SERIALIZER).serialize()),
+            INDEX),
+        arguments(uniqueId(randomObjId(), 420L, "space", uuidToBytes(UUID.randomUUID())), UNIQUE));
   }
 
   @ParameterizedTest

--- a/versioned/storage/dynamodb/src/intTest/java/org/projectnessie/versioned/storage/dynamodb/ITDynamoDBPersist.java
+++ b/versioned/storage/dynamodb/src/intTest/java/org/projectnessie/versioned/storage/dynamodb/ITDynamoDBPersist.java
@@ -55,11 +55,13 @@ public class ITDynamoDBPersist extends AbstractPersistTests {
     @Test
     public void dynamoDbHardItemSizeLimit() throws Exception {
       persist.storeObj(
-          contentValue(ObjId.randomObjId(), "foo", 42, ByteString.copyFrom(new byte[350 * 1024])));
+          contentValue(
+              ObjId.randomObjId(), 4200L, "foo", 42, ByteString.copyFrom(new byte[350 * 1024])));
 
       persist.storeObjs(
           new Obj[] {
-            contentValue(ObjId.randomObjId(), "foo", 42, ByteString.copyFrom(new byte[350 * 1024]))
+            contentValue(
+                ObjId.randomObjId(), 4200L, "foo", 42, ByteString.copyFrom(new byte[350 * 1024]))
           });
 
       // DynamoDB's hard 400k limit
@@ -68,6 +70,7 @@ public class ITDynamoDBPersist extends AbstractPersistTests {
                   persist.storeObj(
                       contentValue(
                           ObjId.randomObjId(),
+                          4200L,
                           "foo",
                           42,
                           ByteString.copyFrom(new byte[400 * 1024]))))
@@ -78,6 +81,7 @@ public class ITDynamoDBPersist extends AbstractPersistTests {
                       new Obj[] {
                         contentValue(
                             ObjId.randomObjId(),
+                            4200L,
                             "foo",
                             42,
                             ByteString.copyFrom(new byte[400 * 1024]))

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBConstants.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBConstants.java
@@ -38,6 +38,7 @@ final class DynamoDBConstants {
 
   static final String COL_OBJ_TYPE = "y";
   static final String COL_OBJ_VERS = "V";
+  static final String COL_OBJ_REFERENCED = "z";
 
   static final String CONDITION_STORE_REF = "attribute_not_exists(" + COL_REFERENCES_POINTER + ")";
   static final String CONDITION_STORE_OBJ = "attribute_not_exists(" + COL_OBJ_TYPE + ")";

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBPersist.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBPersist.java
@@ -26,6 +26,7 @@ import static org.projectnessie.versioned.storage.common.persist.Reference.refer
 import static org.projectnessie.versioned.storage.dynamodb.DynamoDBBackend.condition;
 import static org.projectnessie.versioned.storage.dynamodb.DynamoDBBackend.keyPrefix;
 import static org.projectnessie.versioned.storage.dynamodb.DynamoDBConstants.BATCH_GET_LIMIT;
+import static org.projectnessie.versioned.storage.dynamodb.DynamoDBConstants.COL_OBJ_REFERENCED;
 import static org.projectnessie.versioned.storage.dynamodb.DynamoDBConstants.COL_OBJ_TYPE;
 import static org.projectnessie.versioned.storage.dynamodb.DynamoDBConstants.COL_OBJ_VERS;
 import static org.projectnessie.versioned.storage.dynamodb.DynamoDBConstants.COL_REFERENCES_CONDITION_COMMON;
@@ -438,18 +439,34 @@ public class DynamoDBPersist implements Persist {
     ObjId id = obj.id();
     checkArgument(id != null, "Obj to store must have a non-null ID");
 
-    Map<String, AttributeValue> item = objToItem(obj, id, ignoreSoftSizeRestrictions);
+    long referenced = config.currentTimeMicros();
+
+    Map<String, AttributeValue> item = objToItem(obj, referenced, id, ignoreSoftSizeRestrictions);
 
     try {
-      backend
-          .client()
-          .putItem(
-              b ->
-                  b.tableName(backend.tableObjs)
-                      .conditionExpression(CONDITION_STORE_OBJ)
-                      .item(item));
-    } catch (ConditionalCheckFailedException e) {
-      return false;
+      try {
+        backend
+            .client()
+            .putItem(
+                b ->
+                    b.tableName(backend.tableObjs)
+                        .conditionExpression(CONDITION_STORE_OBJ)
+                        .item(item));
+      } catch (ConditionalCheckFailedException e) {
+        backend
+            .client()
+            .updateItem(
+                b ->
+                    b.tableName(backend.tableObjs)
+                        .key(objKeyMap(id))
+                        .attributeUpdates(
+                            Map.of(
+                                COL_OBJ_REFERENCED,
+                                AttributeValueUpdate.builder()
+                                    .value(fromS(Long.toString(referenced)))
+                                    .build())));
+        return false;
+      }
     } catch (DynamoDbException e) {
       // Best effort to detect whether an object exceeded DynamoDB's hard item size limit of 400k.
       AwsErrorDetails errorDetails = e.awsErrorDetails();
@@ -487,7 +504,10 @@ public class DynamoDBPersist implements Persist {
     ObjId id = obj.id();
     checkArgument(id != null, "Obj to store must have a non-null ID");
 
-    Map<String, AttributeValue> item = objToItem(obj, id, false);
+    long referenced = config.currentTimeMicros();
+    obj = obj.withReferenced(referenced);
+
+    Map<String, AttributeValue> item = objToItem(obj, config.currentTimeMicros(), id, false);
 
     try {
       backend.client().putItem(b -> b.tableName(backend.tableObjs).item(item));
@@ -507,12 +527,15 @@ public class DynamoDBPersist implements Persist {
   public void upsertObjs(@Nonnull Obj[] objs) throws ObjTooLargeException {
     // DynamoDB does not support "PUT IF NOT EXISTS" in a BatchWriteItemRequest/PutItem
     try (BatchWrite batchWrite = new BatchWrite(backend, backend.tableObjs)) {
+      long referenced = config.currentTimeMicros();
       for (Obj obj : objs) {
         if (obj != null) {
           ObjId id = obj.id();
           checkArgument(id != null, "Obj to store must have a non-null ID");
 
-          Map<String, AttributeValue> item = objToItem(obj, id, false);
+          obj = obj.withReferenced(referenced);
+
+          Map<String, AttributeValue> item = objToItem(obj, config.currentTimeMicros(), id, false);
 
           batchWrite.addPut(item);
         }
@@ -552,8 +575,11 @@ public class DynamoDBPersist implements Persist {
 
     Map<String, ExpectedAttributeValue> expectedValues = conditionalUpdateExpectedValues(expected);
 
+    long referenced = config.currentTimeMicros();
     Map<String, AttributeValueUpdate> updates =
-        objToItem(newValue, id, false).entrySet().stream()
+        objToItem(newValue.withReferenced(referenced), config.currentTimeMicros(), id, false)
+            .entrySet()
+            .stream()
             .filter(e -> !COL_OBJ_TYPE.equals(e.getKey()) && !KEY_NAME.equals(e.getKey()))
             .collect(
                 Collectors.toMap(
@@ -614,14 +640,17 @@ public class DynamoDBPersist implements Persist {
     ObjSerializer<?> serializer = ObjSerializers.forType(type);
     Map<String, AttributeValue> inner = item.get(serializer.attributeName()).m();
     String versionToken = attributeToString(item, COL_OBJ_VERS);
+    String referencedString = attributeToString(item, COL_OBJ_REFERENCED);
+    long referenced = referencedString != null ? Long.parseLong(referencedString) : 0L;
     @SuppressWarnings("unchecked")
-    T typed = (T) serializer.fromMap(id, type, inner, versionToken);
+    T typed = (T) serializer.fromMap(id, type, referenced, inner, versionToken);
     return typed;
   }
 
   @Nonnull
   private Map<String, AttributeValue> objToItem(
-      @Nonnull Obj obj, ObjId id, boolean ignoreSoftSizeRestrictions) throws ObjTooLargeException {
+      @Nonnull Obj obj, long referenced, ObjId id, boolean ignoreSoftSizeRestrictions)
+      throws ObjTooLargeException {
     ObjType type = obj.type();
     ObjSerializer<Obj> serializer = ObjSerializers.forType(type);
 
@@ -629,6 +658,7 @@ public class DynamoDBPersist implements Persist {
     Map<String, AttributeValue> inner = new HashMap<>();
     item.put(KEY_NAME, objKey(id));
     item.put(COL_OBJ_TYPE, fromS(type.shortName()));
+    item.put(COL_OBJ_REFERENCED, fromS(Long.toString(referenced)));
     UpdateableObj.extractVersionToken(obj).ifPresent(token -> item.put(COL_OBJ_VERS, fromS(token)));
     int incrementalIndexSizeLimit =
         ignoreSoftSizeRestrictions ? Integer.MAX_VALUE : effectiveIncrementalIndexSizeLimit();

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/CommitObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/CommitObjSerializer.java
@@ -114,10 +114,11 @@ public class CommitObjSerializer implements ObjSerializer<CommitObj> {
 
   @Override
   public CommitObj fromMap(
-      ObjId id, ObjType type, Map<String, AttributeValue> i, String versionToken) {
+      ObjId id, ObjType type, long referenced, Map<String, AttributeValue> i, String versionToken) {
     CommitObj.Builder b =
         commitBuilder()
             .id(id)
+            .referenced(referenced)
             .seq(Long.parseLong(requireNonNull(attributeToString(i, COL_COMMIT_SEQ))))
             .created(Long.parseLong(requireNonNull(attributeToString(i, COL_COMMIT_CREATED))))
             .message(attributeToString(i, COL_COMMIT_MESSAGE))

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/ContentValueObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/ContentValueObjSerializer.java
@@ -58,9 +58,10 @@ public class ContentValueObjSerializer implements ObjSerializer<ContentValueObj>
 
   @Override
   public ContentValueObj fromMap(
-      ObjId id, ObjType type, Map<String, AttributeValue> i, String versionToken) {
+      ObjId id, ObjType type, long referenced, Map<String, AttributeValue> i, String versionToken) {
     return contentValue(
         id,
+        referenced,
         attributeToString(i, COL_VALUE_CONTENT_ID),
         Integer.parseInt(requireNonNull(attributeToString(i, COL_VALUE_PAYLOAD))),
         attributeToBytes(i, COL_VALUE_DATA));

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/CustomObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/CustomObjSerializer.java
@@ -62,9 +62,10 @@ public class CustomObjSerializer implements ObjSerializer<Obj> {
   }
 
   @Override
-  public Obj fromMap(ObjId id, ObjType type, Map<String, AttributeValue> i, String versionToken) {
+  public Obj fromMap(
+      ObjId id, ObjType type, long referenced, Map<String, AttributeValue> i, String versionToken) {
     ByteBuffer buffer = requireNonNull(attributeToBytes(i, COL_CUSTOM_DATA)).asReadOnlyByteBuffer();
     return SmileSerialization.deserializeObj(
-        id, versionToken, buffer, type, attributeToString(i, COL_CUSTOM_COMPRESSION));
+        id, versionToken, buffer, type, referenced, attributeToString(i, COL_CUSTOM_COMPRESSION));
   }
 }

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/IndexObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/IndexObjSerializer.java
@@ -58,7 +58,7 @@ public class IndexObjSerializer implements ObjSerializer<IndexObj> {
 
   @Override
   public IndexObj fromMap(
-      ObjId id, ObjType type, Map<String, AttributeValue> i, String versionToken) {
-    return index(id, requireNonNull(attributeToBytes(i, COL_INDEX_INDEX)));
+      ObjId id, ObjType type, long referenced, Map<String, AttributeValue> i, String versionToken) {
+    return index(id, referenced, requireNonNull(attributeToBytes(i, COL_INDEX_INDEX)));
   }
 }

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/IndexSegmentsObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/IndexSegmentsObjSerializer.java
@@ -53,9 +53,9 @@ public class IndexSegmentsObjSerializer implements ObjSerializer<IndexSegmentsOb
 
   @Override
   public IndexSegmentsObj fromMap(
-      ObjId id, ObjType type, Map<String, AttributeValue> i, String versionToken) {
+      ObjId id, ObjType type, long referenced, Map<String, AttributeValue> i, String versionToken) {
     List<IndexStripe> stripes = new ArrayList<>();
     fromStripesAttrList(i.get(COL_SEGMENTS_STRIPES), stripes::add);
-    return indexSegments(id, stripes);
+    return indexSegments(id, referenced, stripes);
   }
 }

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/ObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/ObjSerializer.java
@@ -35,5 +35,6 @@ public interface ObjSerializer<O extends Obj> {
       O obj, Map<String, AttributeValue> i, int incrementalIndexSize, int maxSerializedIndexSize)
       throws ObjTooLargeException;
 
-  O fromMap(ObjId id, ObjType type, Map<String, AttributeValue> i, String versionToken);
+  O fromMap(
+      ObjId id, ObjType type, long referenced, Map<String, AttributeValue> i, String versionToken);
 }

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/RefObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/RefObjSerializer.java
@@ -62,11 +62,12 @@ public class RefObjSerializer implements ObjSerializer<RefObj> {
 
   @Override
   public RefObj fromMap(
-      ObjId id, ObjType type, Map<String, AttributeValue> i, String versionToken) {
+      ObjId id, ObjType type, long referenced, Map<String, AttributeValue> i, String versionToken) {
     String createdAtStr = attributeToString(i, COL_REF_CREATED_AT);
     long createdAt = createdAtStr != null ? Long.parseLong(createdAtStr) : 0L;
     return ref(
         id,
+        referenced,
         attributeToString(i, COL_REF_NAME),
         attributeToObjId(i, COL_REF_INITIAL_POINTER),
         createdAt,

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/StringObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/StringObjSerializer.java
@@ -72,11 +72,12 @@ public class StringObjSerializer implements ObjSerializer<StringObj> {
 
   @Override
   public StringObj fromMap(
-      ObjId id, ObjType type, Map<String, AttributeValue> i, String versionToken) {
+      ObjId id, ObjType type, long referenced, Map<String, AttributeValue> i, String versionToken) {
     List<ObjId> predecessors = new ArrayList<>();
     attributeToObjIds(i, COL_STRING_PREDECESSORS, predecessors::add);
     return stringData(
         id,
+        referenced,
         attributeToString(i, COL_STRING_CONTENT_TYPE),
         Compression.valueOf(attributeToString(i, COL_STRING_COMPRESSION)),
         attributeToString(i, COL_STRING_FILENAME),

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/TagObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/TagObjSerializer.java
@@ -86,7 +86,7 @@ public class TagObjSerializer implements ObjSerializer<TagObj> {
 
   @Override
   public TagObj fromMap(
-      ObjId id, ObjType type, Map<String, AttributeValue> i, String versionToken) {
+      ObjId id, ObjType type, long referenced, Map<String, AttributeValue> i, String versionToken) {
     CommitHeaders tagHeaders = null;
     AttributeValue headerMap = i.get(COL_TAG_HEADERS);
     if (headerMap != null) {
@@ -97,6 +97,7 @@ public class TagObjSerializer implements ObjSerializer<TagObj> {
 
     return tag(
         id,
+        referenced,
         attributeToString(i, COL_TAG_MESSAGE),
         tagHeaders,
         attributeToBytes(i, COL_TAG_SIGNATURE));

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/UniqueIdObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/UniqueIdObjSerializer.java
@@ -55,8 +55,11 @@ public class UniqueIdObjSerializer implements ObjSerializer<UniqueIdObj> {
 
   @Override
   public UniqueIdObj fromMap(
-      ObjId id, ObjType type, Map<String, AttributeValue> i, String versionToken) {
+      ObjId id, ObjType type, long referenced, Map<String, AttributeValue> i, String versionToken) {
     return uniqueId(
-        id, attributeToString(i, COL_UNIQUE_SPACE), attributeToBytes(i, COL_UNIQUE_VALUE));
+        id,
+        referenced,
+        attributeToString(i, COL_UNIQUE_SPACE),
+        attributeToBytes(i, COL_UNIQUE_VALUE));
   }
 }

--- a/versioned/storage/dynamodb2/src/intTest/java/org/projectnessie/versioned/storage/dynamodb2/ITDynamoDB2Persist.java
+++ b/versioned/storage/dynamodb2/src/intTest/java/org/projectnessie/versioned/storage/dynamodb2/ITDynamoDB2Persist.java
@@ -55,11 +55,13 @@ public class ITDynamoDB2Persist extends AbstractPersistTests {
     @Test
     public void dynamoDbHardItemSizeLimit() throws Exception {
       persist.storeObj(
-          contentValue(ObjId.randomObjId(), "foo", 42, ByteString.copyFrom(new byte[350 * 1024])));
+          contentValue(
+              ObjId.randomObjId(), 4200L, "foo", 42, ByteString.copyFrom(new byte[350 * 1024])));
 
       persist.storeObjs(
           new Obj[] {
-            contentValue(ObjId.randomObjId(), "foo", 42, ByteString.copyFrom(new byte[350 * 1024]))
+            contentValue(
+                ObjId.randomObjId(), 4200L, "foo", 42, ByteString.copyFrom(new byte[350 * 1024]))
           });
 
       // DynamoDB's hard 400k limit
@@ -68,6 +70,7 @@ public class ITDynamoDB2Persist extends AbstractPersistTests {
                   persist.storeObj(
                       contentValue(
                           ObjId.randomObjId(),
+                          4200L,
                           "foo",
                           42,
                           ByteString.copyFrom(new byte[400 * 1024]))))
@@ -78,6 +81,7 @@ public class ITDynamoDB2Persist extends AbstractPersistTests {
                       new Obj[] {
                         contentValue(
                             ObjId.randomObjId(),
+                            4200L,
                             "foo",
                             42,
                             ByteString.copyFrom(new byte[400 * 1024]))

--- a/versioned/storage/dynamodb2/src/main/java/org/projectnessie/versioned/storage/dynamodb2/DynamoDB2Constants.java
+++ b/versioned/storage/dynamodb2/src/main/java/org/projectnessie/versioned/storage/dynamodb2/DynamoDB2Constants.java
@@ -39,6 +39,7 @@ final class DynamoDB2Constants {
   static final String COL_OBJ_TYPE = "y";
   static final String COL_OBJ_VERS = "V";
   static final String COL_OBJ_VALUE = "v";
+  static final String COL_OBJ_REFERENCED = "z";
 
   static final String CONDITION_STORE_REF = "attribute_not_exists(" + COL_REFERENCES_POINTER + ")";
   static final String CONDITION_STORE_OBJ = "attribute_not_exists(" + COL_OBJ_TYPE + ")";

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/SqlConstants.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/SqlConstants.java
@@ -33,6 +33,7 @@ final class SqlConstants {
   static final String COL_OBJ_TYPE = "obj_type";
   static final String COL_OBJ_ID = "obj_id";
   static final String COL_OBJ_VERS = "obj_vers";
+  static final String COL_OBJ_REFERENCED = "obj_ref";
 
   static final String ERASE_OBJS =
       "DELETE FROM " + TABLE_OBJS + " WHERE " + COL_REPO_ID + " IN (?)";
@@ -51,6 +52,16 @@ final class SqlConstants {
           + COL_OBJ_TYPE
           + "=? AND "
           + COL_OBJ_VERS
+          + "=?";
+  static final String UPDATE_OBJS_REFERENCED =
+      "UPDATE "
+          + TABLE_OBJS
+          + " SET "
+          + COL_OBJ_REFERENCED
+          + "=? WHERE "
+          + COL_REPO_ID
+          + "=? AND "
+          + COL_OBJ_ID
           + "=?";
 
   static final String COL_REFS_NAME = "ref_name";
@@ -162,7 +173,8 @@ final class SqlConstants {
               Stream.of(
                   entry(COL_OBJ_ID, JdbcColumnType.OBJ_ID),
                   entry(COL_OBJ_TYPE, JdbcColumnType.NAME),
-                  entry(COL_OBJ_VERS, JdbcColumnType.VARCHAR)),
+                  entry(COL_OBJ_VERS, JdbcColumnType.VARCHAR),
+                  entry(COL_OBJ_REFERENCED, JdbcColumnType.BIGINT)),
               ObjSerializers.ALL_SERIALIZERS.stream()
                   .flatMap(serializer -> serializer.columns().entrySet().stream())
                   .sorted(Map.Entry.comparingByKey()))

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/CommitObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/CommitObjSerializer.java
@@ -140,11 +140,13 @@ public class CommitObjSerializer implements ObjSerializer<CommitObj> {
   }
 
   @Override
-  public CommitObj deserialize(ResultSet rs, ObjType type, ObjId id, String versionToken)
+  public CommitObj deserialize(
+      ResultSet rs, ObjType type, ObjId id, long referenced, String versionToken)
       throws SQLException {
     CommitObj.Builder b =
         CommitObj.commitBuilder()
             .id(id)
+            .referenced(referenced)
             .created(rs.getLong(COL_COMMIT_CREATED))
             .seq(rs.getLong(COL_COMMIT_SEQ))
             .message(rs.getString(COL_COMMIT_MESSAGE))

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/ContentValueObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/ContentValueObjSerializer.java
@@ -68,10 +68,12 @@ public class ContentValueObjSerializer implements ObjSerializer<ContentValueObj>
   }
 
   @Override
-  public ContentValueObj deserialize(ResultSet rs, ObjType type, ObjId id, String versionToken)
+  public ContentValueObj deserialize(
+      ResultSet rs, ObjType type, ObjId id, long referenced, String versionToken)
       throws SQLException {
     return contentValue(
         id,
+        referenced,
         rs.getString(COL_VALUE_CONTENT_ID),
         rs.getInt(COL_VALUE_PAYLOAD),
         requireNonNull(deserializeBytes(rs, COL_VALUE_DATA)));

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/CustomObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/CustomObjSerializer.java
@@ -77,9 +77,14 @@ public class CustomObjSerializer implements ObjSerializer<Obj> {
   }
 
   @Override
-  public Obj deserialize(ResultSet rs, ObjType type, ObjId id, String versionToken)
+  public Obj deserialize(ResultSet rs, ObjType type, ObjId id, long referenced, String versionToken)
       throws SQLException {
     return SmileSerialization.deserializeObj(
-        id, versionToken, rs.getBytes(COL_CUSTOM_DATA), type, rs.getString(COL_CUSTOM_COMPRESSION));
+        id,
+        versionToken,
+        rs.getBytes(COL_CUSTOM_DATA),
+        type,
+        referenced,
+        rs.getString(COL_CUSTOM_COMPRESSION));
   }
 }

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/IndexObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/IndexObjSerializer.java
@@ -66,11 +66,12 @@ public class IndexObjSerializer implements ObjSerializer<IndexObj> {
   }
 
   @Override
-  public IndexObj deserialize(ResultSet rs, ObjType type, ObjId id, String versionToken)
+  public IndexObj deserialize(
+      ResultSet rs, ObjType type, ObjId id, long referenced, String versionToken)
       throws SQLException {
     ByteString index = deserializeBytes(rs, COL_INDEX_INDEX);
     if (index != null) {
-      return index(id, index);
+      return index(id, referenced, index);
     }
     throw new IllegalStateException("Index column for object ID " + id + " is null");
   }

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/IndexSegmentsObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/IndexSegmentsObjSerializer.java
@@ -78,7 +78,8 @@ public class IndexSegmentsObjSerializer implements ObjSerializer<IndexSegmentsOb
   }
 
   @Override
-  public IndexSegmentsObj deserialize(ResultSet rs, ObjType type, ObjId id, String versionToken)
+  public IndexSegmentsObj deserialize(
+      ResultSet rs, ObjType type, ObjId id, long referenced, String versionToken)
       throws SQLException {
     try {
       Stripes stripes = Stripes.parseFrom(rs.getBytes(COL_SEGMENTS_STRIPES));
@@ -91,7 +92,7 @@ public class IndexSegmentsObjSerializer implements ObjSerializer<IndexSegmentsOb
                           keyFromString(s.getLastKey()),
                           objIdFromByteBuffer(s.getSegment().asReadOnlyByteBuffer())))
               .collect(Collectors.toList());
-      return indexSegments(id, stripeList);
+      return indexSegments(id, referenced, stripeList);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/ObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/ObjSerializer.java
@@ -41,7 +41,8 @@ public interface ObjSerializer<O extends Obj> {
       DatabaseSpecific databaseSpecific)
       throws SQLException, ObjTooLargeException;
 
-  O deserialize(ResultSet rs, ObjType type, ObjId id, String versionToken) throws SQLException;
+  O deserialize(ResultSet rs, ObjType type, ObjId id, long referenced, String versionToken)
+      throws SQLException;
 
   default void setNull(
       PreparedStatement ps, Function<String, Integer> nameToIdx, DatabaseSpecific databaseSpecific)

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/RefObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/RefObjSerializer.java
@@ -72,10 +72,12 @@ public class RefObjSerializer implements ObjSerializer<RefObj> {
   }
 
   @Override
-  public RefObj deserialize(ResultSet rs, ObjType type, ObjId id, String versionToken)
+  public RefObj deserialize(
+      ResultSet rs, ObjType type, ObjId id, long referenced, String versionToken)
       throws SQLException {
     return ref(
         id,
+        referenced,
         rs.getString(COL_REF_NAME),
         deserializeObjId(rs, COL_REF_INITIAL_POINTER),
         rs.getLong(COL_REF_CREATED_AT),

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/StringObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/StringObjSerializer.java
@@ -77,10 +77,12 @@ public class StringObjSerializer implements ObjSerializer<StringObj> {
   }
 
   @Override
-  public StringObj deserialize(ResultSet rs, ObjType type, ObjId id, String versionToken)
+  public StringObj deserialize(
+      ResultSet rs, ObjType type, ObjId id, long referenced, String versionToken)
       throws SQLException {
     return stringData(
         id,
+        referenced,
         rs.getString(COL_STRING_CONTENT_TYPE),
         Compression.valueOf(rs.getString(COL_STRING_COMPRESSION)),
         rs.getString(COL_STRING_FILENAME),

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/TagObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/TagObjSerializer.java
@@ -78,7 +78,8 @@ public class TagObjSerializer implements ObjSerializer<TagObj> {
   }
 
   @Override
-  public TagObj deserialize(ResultSet rs, ObjType type, ObjId id, String versionToken)
+  public TagObj deserialize(
+      ResultSet rs, ObjType type, ObjId id, long referenced, String versionToken)
       throws SQLException {
     CommitHeaders tagHeaders = null;
     try {
@@ -97,6 +98,10 @@ public class TagObjSerializer implements ObjSerializer<TagObj> {
     }
 
     return tag(
-        id, rs.getString(COL_TAG_MESSAGE), tagHeaders, deserializeBytes(rs, COL_TAG_SIGNATURE));
+        id,
+        referenced,
+        rs.getString(COL_TAG_MESSAGE),
+        tagHeaders,
+        deserializeBytes(rs, COL_TAG_SIGNATURE));
   }
 }

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/UniqueIdObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/UniqueIdObjSerializer.java
@@ -64,8 +64,10 @@ public class UniqueIdObjSerializer implements ObjSerializer<UniqueIdObj> {
   }
 
   @Override
-  public UniqueIdObj deserialize(ResultSet rs, ObjType type, ObjId id, String versionToken)
+  public UniqueIdObj deserialize(
+      ResultSet rs, ObjType type, ObjId id, long referenced, String versionToken)
       throws SQLException {
-    return uniqueId(id, rs.getString(COL_UNIQUE_SPACE), deserializeBytes(rs, COL_UNIQUE_VALUE));
+    return uniqueId(
+        id, referenced, rs.getString(COL_UNIQUE_SPACE), deserializeBytes(rs, COL_UNIQUE_VALUE));
   }
 }

--- a/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/Jdbc2Backend.java
+++ b/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/Jdbc2Backend.java
@@ -25,6 +25,7 @@ import static org.projectnessie.versioned.storage.jdbc2.Jdbc2ColumnType.OBJ_ID;
 import static org.projectnessie.versioned.storage.jdbc2.Jdbc2ColumnType.VARBINARY;
 import static org.projectnessie.versioned.storage.jdbc2.Jdbc2ColumnType.VARCHAR;
 import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.COL_OBJ_ID;
+import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.COL_OBJ_REFERENCED;
 import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.COL_OBJ_TYPE;
 import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.COL_OBJ_VALUE;
 import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.COL_OBJ_VERS;
@@ -151,6 +152,10 @@ public final class Jdbc2Backend implements Backend {
         + COL_OBJ_VALUE
         + " "
         + columnTypes.get(VARBINARY)
+        + ",\n    "
+        + COL_OBJ_REFERENCED
+        + " "
+        + columnTypes.get(BIGINT)
         + ",\n    PRIMARY KEY ("
         + COL_REPO_ID
         + ", "

--- a/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/SqlConstants.java
+++ b/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/SqlConstants.java
@@ -27,6 +27,7 @@ final class SqlConstants {
   static final String COL_OBJ_ID = "obj_id";
   static final String COL_OBJ_VERS = "obj_vers";
   static final String COL_OBJ_VALUE = "obj_value";
+  static final String COL_OBJ_REFERENCED = "obj_ref";
 
   static final String ERASE_OBJS =
       "DELETE FROM " + TABLE_OBJS + " WHERE " + COL_REPO_ID + " IN (?)";
@@ -45,6 +46,16 @@ final class SqlConstants {
           + COL_OBJ_TYPE
           + "=? AND "
           + COL_OBJ_VERS
+          + "=?";
+  static final String UPDATE_OBJS_REFERENCED =
+      "UPDATE "
+          + TABLE_OBJS
+          + " SET "
+          + COL_OBJ_REFERENCED
+          + "=? WHERE "
+          + COL_REPO_ID
+          + "=? AND "
+          + COL_OBJ_ID
           + "=?";
 
   static final String COL_REFS_NAME = "ref_name";
@@ -152,7 +163,15 @@ final class SqlConstants {
           + " IN (?)";
 
   static final String COLS_OBJS_ALL_NAMES =
-      COL_OBJ_ID + ", " + COL_OBJ_TYPE + ", " + COL_OBJ_VERS + ", " + COL_OBJ_VALUE;
+      COL_OBJ_ID
+          + ", "
+          + COL_OBJ_TYPE
+          + ", "
+          + COL_OBJ_VERS
+          + ", "
+          + COL_OBJ_VALUE
+          + ", "
+          + COL_OBJ_REFERENCED;
 
   static final String FETCH_OBJ_TYPE =
       "SELECT "
@@ -183,7 +202,7 @@ final class SqlConstants {
           + COL_REPO_ID
           + ", "
           + COLS_OBJS_ALL_NAMES
-          + ") VALUES (?, ?, ?, ?, ?)";
+          + ") VALUES (?, ?, ?, ?, ?, ?)";
 
   static final String FIND_OBJS_TYPED = FIND_OBJS + " AND " + COL_OBJ_TYPE + "=?";
 

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBConstants.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBConstants.java
@@ -33,6 +33,7 @@ final class MongoDBConstants {
   static final String COL_REPO = "r";
   static final String COL_OBJ_TYPE = "y";
   static final String COL_OBJ_VERS = "V";
+  static final String COL_OBJ_REFERENCED = "z";
 
   static final String ID_REPO_PATH = ID_PROPERTY_NAME + "." + COL_REPO;
   static final String ID_OBJ_ID_PATH = ID_PROPERTY_NAME + "." + COL_OBJ_ID;

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
@@ -643,12 +643,9 @@ public class MongoDBPersist implements Persist {
     for (Obj obj : objs) {
       if (obj != null) {
         ObjId id = obj.id();
-        obj = obj.withReferenced(referenced);
         docs.add(
             new ReplaceOneModel<>(
-                eq(ID_PROPERTY_NAME, idObjDoc(id)),
-                objToDoc(obj, config.currentTimeMicros(), false),
-                options));
+                eq(ID_PROPERTY_NAME, idObjDoc(id)), objToDoc(obj, referenced, false), options));
       }
     }
 

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
@@ -29,6 +29,7 @@ import static java.util.stream.Collectors.toList;
 import static org.projectnessie.versioned.storage.common.persist.ObjTypes.objTypeByName;
 import static org.projectnessie.versioned.storage.common.persist.Reference.reference;
 import static org.projectnessie.versioned.storage.mongodb.MongoDBConstants.COL_OBJ_ID;
+import static org.projectnessie.versioned.storage.mongodb.MongoDBConstants.COL_OBJ_REFERENCED;
 import static org.projectnessie.versioned.storage.mongodb.MongoDBConstants.COL_OBJ_TYPE;
 import static org.projectnessie.versioned.storage.mongodb.MongoDBConstants.COL_OBJ_VERS;
 import static org.projectnessie.versioned.storage.mongodb.MongoDBConstants.COL_REFERENCES_CREATED_AT;
@@ -58,11 +59,13 @@ import com.mongodb.WriteError;
 import com.mongodb.bulk.BulkWriteError;
 import com.mongodb.bulk.BulkWriteInsert;
 import com.mongodb.bulk.BulkWriteResult;
+import com.mongodb.bulk.BulkWriteUpsert;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.model.InsertOneModel;
 import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.Updates;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.result.DeleteResult;
@@ -436,11 +439,17 @@ public class MongoDBPersist implements Persist {
   @Override
   public boolean storeObj(@Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)
       throws ObjTooLargeException {
-    Document doc = objToDoc(obj, ignoreSoftSizeRestrictions);
+    long referenced = config.currentTimeMicros();
+    Document doc = objToDoc(obj, referenced, ignoreSoftSizeRestrictions);
     try {
       backend.objs().insertOne(doc);
     } catch (MongoWriteException e) {
       if (e.getError().getCategory() == DUPLICATE_KEY) {
+        backend
+            .objs()
+            .updateOne(
+                eq(ID_PROPERTY_NAME, idObjDoc(obj.id())),
+                Updates.set(COL_OBJ_REFERENCED, referenced));
         return false;
       }
       throw handleMongoWriteException(e);
@@ -454,22 +463,79 @@ public class MongoDBPersist implements Persist {
   @Nonnull
   @Override
   public boolean[] storeObjs(@Nonnull Obj[] objs) throws ObjTooLargeException {
-    List<WriteModel<Document>> docs = new ArrayList<>(objs.length);
-    for (Obj obj : objs) {
-      if (obj != null) {
-        docs.add(new InsertOneModel<>(objToDoc(obj, false)));
+    boolean[] r = new boolean[objs.length];
+
+    storeObjsWrite(objs, r);
+
+    List<ObjId> updateReferenced = new ArrayList<>();
+    for (int i = 0; i < r.length; i++) {
+      if (!r[i]) {
+        Obj obj = objs[i];
+        if (obj != null) {
+          updateReferenced.add(obj.id());
+        }
       }
     }
 
-    boolean[] r = new boolean[objs.length];
+    if (!updateReferenced.isEmpty()) {
+      storeObjsUpdateReferenced(objs, updateReferenced);
+    }
 
+    return r;
+  }
+
+  private void storeObjsUpdateReferenced(Obj[] objs, List<ObjId> updateReferenced) {
+    long referenced = config.currentTimeMicros();
+    List<UpdateOneModel<Document>> docs =
+        updateReferenced.stream()
+            .map(
+                id ->
+                    new UpdateOneModel<Document>(
+                        eq(ID_PROPERTY_NAME, idObjDoc(id)),
+                        Updates.set(COL_OBJ_REFERENCED, referenced)))
+            .collect(toList());
+    List<WriteModel<Document>> updates = new ArrayList<>(docs);
+    while (!updates.isEmpty()) {
+      try {
+        backend.objs().bulkWrite(updates);
+        break;
+      } catch (MongoBulkWriteException e) {
+        // Handle "insert of already existing objects".
+        //
+        // MongoDB returns a BulkWriteResult of what _would_ have succeeded. Use that information
+        // to retry the bulk write to make progress.
+        List<BulkWriteError> errs = e.getWriteErrors();
+        for (BulkWriteError err : errs) {
+          throw handleMongoWriteError(e, err);
+        }
+        BulkWriteResult res = e.getWriteResult();
+        updates.clear();
+        res.getUpserts().stream()
+            .map(MongoDBPersist::objIdFromBulkWriteUpsert)
+            .mapToInt(id -> objIdIndex(objs, id))
+            .mapToObj(docs::get)
+            .forEach(updates::add);
+      } catch (RuntimeException e) {
+        throw unhandledException(e);
+      }
+    }
+  }
+
+  private void storeObjsWrite(Obj[] objs, boolean[] r) throws ObjTooLargeException {
+    List<WriteModel<Document>> docs = new ArrayList<>(objs.length);
+    long referenced = config.currentTimeMicros();
+    for (Obj obj : objs) {
+      if (obj != null) {
+        docs.add(new InsertOneModel<>(objToDoc(obj, referenced, false)));
+      }
+    }
     List<WriteModel<Document>> inserts = new ArrayList<>(docs);
     while (!inserts.isEmpty()) {
       try {
         BulkWriteResult res = backend.objs().bulkWrite(inserts);
         for (BulkWriteInsert insert : res.getInserts()) {
           ObjId id = objIdFromBulkWriteInsert(insert);
-          r[objIdIndex(objs, id)] = id != null;
+          r[objIdIndex(objs, id)] = true;
         }
         break;
       } catch (MongoBulkWriteException e) {
@@ -494,7 +560,6 @@ public class MongoDBPersist implements Persist {
         throw unhandledException(e);
       }
     }
-    return r;
   }
 
   private static ObjId objIdFromDoc(Document doc) {
@@ -512,6 +577,10 @@ public class MongoDBPersist implements Persist {
 
   private static ObjId objIdFromBulkWriteInsert(BulkWriteInsert insert) {
     return ObjId.objIdFromByteArray(insert.getId().asDocument().getBinary(COL_OBJ_ID).getData());
+  }
+
+  private static ObjId objIdFromBulkWriteUpsert(BulkWriteUpsert upsert) {
+    return ObjId.objIdFromByteArray(upsert.getId().asDocument().getBinary(COL_OBJ_ID).getData());
   }
 
   @Override
@@ -544,7 +613,8 @@ public class MongoDBPersist implements Persist {
 
     ReplaceOptions options = upsertOptions();
 
-    Document doc = objToDoc(obj, false);
+    long referenced = config.currentTimeMicros();
+    Document doc = objToDoc(obj, referenced, false);
     UpdateResult result;
     try {
       result = backend.objs().replaceOne(eq(ID_PROPERTY_NAME, idObjDoc(id)), doc, options);
@@ -568,13 +638,17 @@ public class MongoDBPersist implements Persist {
   public void upsertObjs(@Nonnull Obj[] objs) throws ObjTooLargeException {
     ReplaceOptions options = upsertOptions();
 
+    long referenced = config.currentTimeMicros();
     List<WriteModel<Document>> docs = new ArrayList<>(objs.length);
     for (Obj obj : objs) {
       if (obj != null) {
         ObjId id = obj.id();
+        obj = obj.withReferenced(referenced);
         docs.add(
             new ReplaceOneModel<>(
-                eq(ID_PROPERTY_NAME, idObjDoc(id)), objToDoc(obj, false), options));
+                eq(ID_PROPERTY_NAME, idObjDoc(id)),
+                objToDoc(obj, config.currentTimeMicros(), false),
+                options));
       }
     }
 
@@ -622,7 +696,8 @@ public class MongoDBPersist implements Persist {
     checkArgument(expected.type().equals(newValue.type()));
     checkArgument(!expected.versionToken().equals(newValue.versionToken()));
 
-    Document doc = objToDoc(newValue, false);
+    long referenced = config.currentTimeMicros();
+    Document doc = objToDoc(newValue, referenced, false);
 
     List<Bson> updates =
         doc.entrySet().stream()
@@ -676,10 +751,11 @@ public class MongoDBPersist implements Persist {
     ObjSerializer<T> serializer = (ObjSerializer<T>) ObjSerializers.forType(type);
     Document inner = doc.get(serializer.fieldName(), Document.class);
     String versionToken = doc.getString(COL_OBJ_VERS);
-    return serializer.docToObj(id, type, inner, versionToken);
+    Long referenced = doc.getLong(COL_OBJ_REFERENCED);
+    return serializer.docToObj(id, type, referenced != null ? referenced : 0L, inner, versionToken);
   }
 
-  private Document objToDoc(@Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)
+  private Document objToDoc(@Nonnull Obj obj, long referenced, boolean ignoreSoftSizeRestrictions)
       throws ObjTooLargeException {
     ObjId id = obj.id();
     checkArgument(id != null, "Obj to store must have a non-null ID");
@@ -691,6 +767,7 @@ public class MongoDBPersist implements Persist {
     Document inner = new Document();
     doc.put(ID_PROPERTY_NAME, idObjDoc(id));
     doc.put(COL_OBJ_TYPE, type.shortName());
+    doc.put(COL_OBJ_REFERENCED, referenced);
     UpdateableObj.extractVersionToken(obj).ifPresent(token -> doc.put(COL_OBJ_VERS, token));
     int incrementalIndexSizeLimit =
         ignoreSoftSizeRestrictions ? Integer.MAX_VALUE : effectiveIncrementalIndexSizeLimit();

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/CommitObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/CommitObjSerializer.java
@@ -102,10 +102,12 @@ public class CommitObjSerializer implements ObjSerializer<CommitObj> {
   }
 
   @Override
-  public CommitObj docToObj(ObjId id, ObjType type, Document doc, String versionToken) {
+  public CommitObj docToObj(
+      ObjId id, ObjType type, long referenced, Document doc, String versionToken) {
     CommitObj.Builder b =
         commitBuilder()
             .id(id)
+            .referenced(referenced)
             .seq(doc.getLong(COL_COMMIT_SEQ))
             .created(doc.getLong(COL_COMMIT_CREATED))
             .message(doc.getString(COL_COMMIT_MESSAGE))

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/ContentValueObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/ContentValueObjSerializer.java
@@ -51,9 +51,11 @@ public class ContentValueObjSerializer implements ObjSerializer<ContentValueObj>
   }
 
   @Override
-  public ContentValueObj docToObj(ObjId id, ObjType type, Document doc, String versionToken) {
+  public ContentValueObj docToObj(
+      ObjId id, ObjType type, long referenced, Document doc, String versionToken) {
     return contentValue(
         id,
+        referenced,
         doc.getString(COL_VALUE_CONTENT_ID),
         doc.getInteger(COL_VALUE_PAYLOAD),
         binaryToBytes(doc.get(COL_VALUE_DATA, Binary.class)));

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/CustomObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/CustomObjSerializer.java
@@ -49,9 +49,9 @@ public class CustomObjSerializer implements ObjSerializer<Obj> {
   }
 
   @Override
-  public Obj docToObj(ObjId id, ObjType type, Document doc, String versionToken) {
+  public Obj docToObj(ObjId id, ObjType type, long referenced, Document doc, String versionToken) {
     byte[] data = doc.get(COL_CUSTOM_DATA, Binary.class).getData();
     return SmileSerialization.deserializeObj(
-        id, versionToken, data, type, doc.getString(COL_CUSTOM_COMPRESSION));
+        id, versionToken, data, type, referenced, doc.getString(COL_CUSTOM_COMPRESSION));
   }
 }

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/IndexObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/IndexObjSerializer.java
@@ -53,7 +53,8 @@ public class IndexObjSerializer implements ObjSerializer<IndexObj> {
   }
 
   @Override
-  public IndexObj docToObj(ObjId id, ObjType type, Document doc, String versionToken) {
-    return index(id, binaryToBytes(doc.get(COL_INDEX_INDEX, Binary.class)));
+  public IndexObj docToObj(
+      ObjId id, ObjType type, long referenced, Document doc, String versionToken) {
+    return index(id, referenced, binaryToBytes(doc.get(COL_INDEX_INDEX, Binary.class)));
   }
 }

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/IndexSegmentsObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/IndexSegmentsObjSerializer.java
@@ -48,9 +48,10 @@ public class IndexSegmentsObjSerializer implements ObjSerializer<IndexSegmentsOb
   }
 
   @Override
-  public IndexSegmentsObj docToObj(ObjId id, ObjType type, Document doc, String versionToken) {
+  public IndexSegmentsObj docToObj(
+      ObjId id, ObjType type, long referenced, Document doc, String versionToken) {
     List<IndexStripe> stripes = new ArrayList<>();
     fromStripesDocList(doc, COL_SEGMENTS_STRIPES, stripes::add);
-    return indexSegments(id, stripes);
+    return indexSegments(id, referenced, stripes);
   }
 }

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/ObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/ObjSerializer.java
@@ -32,5 +32,5 @@ public interface ObjSerializer<O extends Obj> {
   void objToDoc(O obj, Document doc, int incrementalIndexLimit, int maxSerializedIndexSize)
       throws ObjTooLargeException;
 
-  O docToObj(ObjId id, ObjType type, Document doc, String versionToken);
+  O docToObj(ObjId id, ObjType type, long referenced, Document doc, String versionToken);
 }

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/RefObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/RefObjSerializer.java
@@ -56,9 +56,11 @@ public class RefObjSerializer implements ObjSerializer<RefObj> {
   }
 
   @Override
-  public RefObj docToObj(ObjId id, ObjType type, Document doc, String versionToken) {
+  public RefObj docToObj(
+      ObjId id, ObjType type, long referenced, Document doc, String versionToken) {
     return ref(
         id,
+        referenced,
         doc.getString(COL_REF_NAME),
         binaryToObjId(doc.get(COL_REF_INITIAL_POINTER, Binary.class)),
         doc.getLong(COL_REF_CREATED_AT),

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/StringObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/StringObjSerializer.java
@@ -64,9 +64,11 @@ public class StringObjSerializer implements ObjSerializer<StringObj> {
   }
 
   @Override
-  public StringObj docToObj(ObjId id, ObjType type, Document doc, String versionToken) {
+  public StringObj docToObj(
+      ObjId id, ObjType type, long referenced, Document doc, String versionToken) {
     return stringData(
         id,
+        referenced,
         doc.getString(COL_STRING_CONTENT_TYPE),
         Compression.valueOf(doc.getString(COL_STRING_COMPRESSION)),
         doc.getString(COL_STRING_FILENAME),

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/TagObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/TagObjSerializer.java
@@ -72,7 +72,8 @@ public class TagObjSerializer implements ObjSerializer<TagObj> {
   }
 
   @Override
-  public TagObj docToObj(ObjId id, ObjType type, Document doc, String versionToken) {
+  public TagObj docToObj(
+      ObjId id, ObjType type, long referenced, Document doc, String versionToken) {
     CommitHeaders tagHeaders = null;
     Document headerDoc = doc.get(COL_TAG_HEADERS, Document.class);
     if (headerDoc != null) {
@@ -88,6 +89,7 @@ public class TagObjSerializer implements ObjSerializer<TagObj> {
 
     return tag(
         id,
+        referenced,
         doc.getString(COL_TAG_MESSAGE),
         tagHeaders,
         binaryToBytes(doc.get(COL_TAG_SIGNATURE, Binary.class)));

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/UniqueIdObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/UniqueIdObjSerializer.java
@@ -49,9 +49,11 @@ public class UniqueIdObjSerializer implements ObjSerializer<UniqueIdObj> {
   }
 
   @Override
-  public UniqueIdObj docToObj(ObjId id, ObjType type, Document doc, String versionToken) {
+  public UniqueIdObj docToObj(
+      ObjId id, ObjType type, long referenced, Document doc, String versionToken) {
     return uniqueId(
         id,
+        referenced,
         doc.getString(COL_UNIQUE_SPACE),
         binaryToBytes(doc.get(COL_UNIQUE_VALUE, Binary.class)));
   }

--- a/versioned/storage/rocksdb/src/main/java/org/projectnessie/versioned/storage/rocksdb/RocksDBPersist.java
+++ b/versioned/storage/rocksdb/src/main/java/org/projectnessie/versioned/storage/rocksdb/RocksDBPersist.java
@@ -345,10 +345,11 @@ class RocksDBPersist implements Persist {
 
       byte[] existing = db.get(cf, key);
       if (existing != null) {
-        obj = deserializeObj(obj.id(), 0L, existing, null).withReferenced(referenced);
+        obj = deserializeObj(obj.id(), referenced, existing, null);
         ignoreSoftSizeRestrictions = true;
         r = false;
       } else {
+        obj = obj.withReferenced(referenced);
         r = true;
       }
 
@@ -356,9 +357,7 @@ class RocksDBPersist implements Persist {
           ignoreSoftSizeRestrictions ? Integer.MAX_VALUE : effectiveIncrementalIndexSizeLimit();
       int indexSizeLimit =
           ignoreSoftSizeRestrictions ? Integer.MAX_VALUE : effectiveIndexSegmentSizeLimit();
-      byte[] serialized =
-          serializeObj(
-              obj.withReferenced(referenced), incrementalIndexSizeLimit, indexSizeLimit, true);
+      byte[] serialized = serializeObj(obj, incrementalIndexSizeLimit, indexSizeLimit, true);
 
       db.put(cf, key, serialized);
       return r;

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseMergeTransplantSquash.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseMergeTransplantSquash.java
@@ -58,6 +58,7 @@ import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 import org.projectnessie.versioned.storage.common.persist.Persist;
 import org.projectnessie.versioned.storage.common.persist.Reference;
+import org.projectnessie.versioned.storage.common.persist.StoredObjResult;
 
 class BaseMergeTransplantSquash extends BaseCommitHelper {
 
@@ -119,9 +120,9 @@ class BaseMergeTransplantSquash extends BaseCommitHelper {
     } else {
       CommitLogic commitLogic = commitLogic(persist);
       newHead = mergeCommit.id();
-      CommitObj committed = commitLogic.storeCommit(mergeCommit, objsToStore);
-      if (committed != null) {
-        mergeCommit = committed;
+      StoredObjResult<CommitObj> committed = commitLogic.storeCommit(mergeCommit, objsToStore);
+      if (committed.stored()) {
+        mergeCommit = committed.obj().orElseThrow();
         mergeResult.addCreatedCommits(commitObjToCommit(mergeCommit));
       }
     }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/CommitImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/CommitImpl.java
@@ -209,7 +209,7 @@ class CommitImpl extends BaseCommitHelper {
       // example).
       StoredObjResult<CommitObj> stored = commitLogic.storeCommit(newHead, objectsToStore);
       if (stored.obj().isPresent()) {
-        newHead = stored.obj().orElseThrow();
+        newHead = stored.obj().get();
         commitRetryState.commitPersisted = newHead.id();
         commitRetryState.storedContents.addAll(toStore);
       }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TransplantIndividualImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TransplantIndividualImpl.java
@@ -61,6 +61,7 @@ import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 import org.projectnessie.versioned.storage.common.persist.Persist;
 import org.projectnessie.versioned.storage.common.persist.Reference;
+import org.projectnessie.versioned.storage.common.persist.StoredObjResult;
 
 final class TransplantIndividualImpl extends BaseCommitHelper implements Transplant {
 
@@ -115,13 +116,13 @@ final class TransplantIndividualImpl extends BaseCommitHelper implements Transpl
       empty = false;
       if (!transplantOp.dryRun()) {
         newHead = newCommit.id();
-        CommitObj committed = commitLogic.storeCommit(newCommit, objsToStore);
+        StoredObjResult<CommitObj> committed = commitLogic.storeCommit(newCommit, objsToStore);
         // Here we have to know whether "our" 'newCommit' object has been persisted or not.
         // If not equal, we have to assume that the commit already existed - aka a "fast-forward
         // transplant". This is only to maintain compatibility with (pre-)existing behavior.
         // (This .equals has been introduced with https://github.com/projectnessie/nessie/pull/8533)
-        if (newCommit.equals(committed)) {
-          newCommit = committed;
+        if (committed.stored()) {
+          newCommit = committed.obj().orElseThrow();
           mergeResult.addCreatedCommits(commitObjToCommit(newCommit));
         }
       }

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ImportPersistV23.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ImportPersistV23.java
@@ -160,7 +160,7 @@ final class ImportPersistV23 extends ImportPersistCommon {
 
     Obj obj;
     if (type.equals(StandardObjType.UNIQUE)) {
-      obj = UniqueIdObj.uniqueId(id, genericObj.getSpace(), genericObj.getData());
+      obj = UniqueIdObj.uniqueId(id, 0L, genericObj.getSpace(), genericObj.getData());
     } else {
       ByteBuffer data = genericObj.getData().asReadOnlyByteBuffer();
       String versionToken = genericObj.hasVersionToken() ? genericObj.getVersionToken() : null;
@@ -172,7 +172,7 @@ final class ImportPersistV23 extends ImportPersistCommon {
 
       obj =
           SmileSerialization.deserializeObj(
-              id, versionToken, data, type, Compression.fromValue(genericObj.getCompression()));
+              id, versionToken, data, type, 0L, Compression.fromValue(genericObj.getCompression()));
     }
 
     persist.storeObj(obj);


### PR DESCRIPTION
This is a prerequisite to eventually be able to delete any stale objects in the backing database.

The `referenced` attribute contains the timestamp when the object was last "referenced" (aka: attempted to be written). It is ...
* set when an object is first persisted via a `storeObj()`
* updated in the database, when an object was not persisted via `storeObj()`
* set/updated via `upsertObj()`
* updated via `updateConditional()`

Let's assume that there is a mechanism to identify the IDs of all referenced objects (it would be very similar to what the export functionality does). The algorithm to purge unreferenced objects must never delete an object that is referenced at any point of time, and must consider the case that an object that was unreferenced when a purge-unreferenced-objects routine started, but became referenced while it is running.

An approach could work as follows:

1. Memoize the current timestamp (minus some wall-clock drift adjustment).
2. Identify the IDs of all referenced objects. We could leverage a bloom filter, if the set of IDs is big.
3. Then scan all objects in the repository. Objects can be purged, if ...
    * the ID is not in the set (or bloom filter) generated in step 2 ...
    * _AND_ have a `referenced` timestamp less than the memoized timestamp.

Any deletion in the backing database would follow the meaning of this pseudo SQL: `DELETE FROM objs WHERE obj_id = :objId AND referenced < :memoizedTimestamp`.

Noting, that the `referenced` attribute is rather incorrect when retrieved from the objects cache (aka: during normal operations), which is not a problem, because that `referenced` attribute is irrelevant for production accesses.

There are two edge cases / race conditions:
* (for some backends): A `storeObj()` operation detected that the object already exists - then the purge routine deletes that object - and then the `storeObj()` tries to upddate the `referenced` attribute. The result is the loss of that object. This race condition can only occur, if the object existed but was not referenced.
* While the referenced objects are being identified, create a new named reference (branch / tag) pointing to commit(s) that would be identified as unreferenced and being later purged.
