### PR TITLE
OAuth client: avoid recomputing HTTP headers for static secrets

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ImpersonationConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ImpersonationConfig.java
@@ -87,24 +87,21 @@ public interface ImpersonationConfig {
   Optional<String> getClientId();
 
   /**
-   * An alternate client secret to use for impersonations only. Required if the alternate client
-   * obtained from {@link #getClientId()} is confidential.
-   *
-   * @deprecated Use {@link #getClientSecretSupplier()} instead.
-   */
-  @SuppressWarnings("DeprecatedIsStillUsed")
-  @Deprecated
-  @Value.Derived
-  default Optional<Secret> getClientSecret() {
-    return getClientSecretSupplier().map(Supplier::get).map(Secret::new);
-  }
-
-  /**
-   * An alternate client secret to use for impersonations only. Required if the alternate client
-   * obtained from {@link #getClientId()} is confidential.
+   * An alternate, static client secret to use for impersonations only. If the alternate client
+   * obtained from {@link #getClientId()} is confidential, either this attribute or {@link
+   * #getClientSecretSupplier()} must be set.
    *
    * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_IMPERSONATION_CLIENT_SECRET
    */
+  @Value.Redacted
+  Optional<Secret> getClientSecret();
+
+  /**
+   * An alternate client secret supplier to use for impersonations only. If the alternate client
+   * obtained from {@link #getClientId()} is confidential, either this attribute or {@link
+   * #getClientSecret()} must be set.
+   */
+  @Value.Redacted
   Optional<Supplier<String>> getClientSecretSupplier();
 
   /**
@@ -160,18 +157,15 @@ public interface ImpersonationConfig {
     Builder clientId(String clientId);
 
     @CanIgnoreReturnValue
-    Builder clientSecretSupplier(Supplier<String> clientSecret);
-
-    @CanIgnoreReturnValue
-    @SuppressWarnings("deprecation")
-    default Builder clientSecret(Secret clientSecret) {
-      return clientSecretSupplier(clientSecret::getString);
-    }
+    Builder clientSecret(Secret clientSecret);
 
     @CanIgnoreReturnValue
     default Builder clientSecret(String clientSecret) {
-      return clientSecretSupplier(() -> clientSecret);
+      return clientSecret(new Secret(clientSecret));
     }
+
+    @CanIgnoreReturnValue
+    Builder clientSecretSupplier(Supplier<String> clientSecret);
 
     @CanIgnoreReturnValue
     Builder issuerUrl(URI issuerUrl);

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ImpersonationFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ImpersonationFlow.java
@@ -48,34 +48,23 @@ class ImpersonationFlow extends TokenExchangeFlow {
 
   @Override
   URI getResolvedTokenEndpoint() {
-    if (impersonationConfig.getIssuerUrl().isPresent()
-        || impersonationConfig.getTokenEndpoint().isPresent()) {
-      return config.getResolvedImpersonationTokenEndpoint();
-    }
-    return super.getResolvedTokenEndpoint();
+    return config
+        .getResolvedImpersonationTokenEndpoint()
+        .orElseGet(super::getResolvedTokenEndpoint);
   }
 
   @Override
   String getClientId() {
-    if (impersonationConfig.getClientId().isPresent()) {
-      return impersonationConfig.getClientId().get();
-    }
-    return super.getClientId();
+    return impersonationConfig.getClientId().orElseGet(super::getClientId);
   }
 
   @Override
   boolean isPublicClient() {
-    if (impersonationConfig.getClientId().isPresent()) {
-      return !impersonationConfig.getClientSecret().isPresent();
-    }
-    return super.isPublicClient();
+    return config.isImpersonationPublicClient().orElseGet(super::isPublicClient);
   }
 
   @Override
   Optional<HttpAuthentication> getBasicAuthentication() {
-    if (impersonationConfig.getClientId().isPresent()) {
-      return config.getImpersonationBasicAuthentication();
-    }
-    return super.getBasicAuthentication();
+    return config.getImpersonationBasicAuthentication().or(super::getBasicAuthentication);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2AuthenticatorConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2AuthenticatorConfig.java
@@ -201,22 +201,19 @@ public interface OAuth2AuthenticatorConfig {
   String getClientId();
 
   /**
-   * The OAuth2 client secret. Must be set, if required by the IdP.
-   *
-   * @deprecated Use {@link #getClientSecretSupplier()} instead.
-   */
-  @SuppressWarnings("DeprecatedIsStillUsed")
-  @Deprecated
-  @Value.Derived
-  default Optional<Secret> getClientSecret() {
-    return getClientSecretSupplier().map(Supplier::get).map(Secret::new);
-  }
-
-  /**
-   * The OAuth2 client secret supplier. Must be set, if required by the IdP.
+   * The OAuth2 static client secret. Either this attribute or {@link #getClientSecretSupplier()}
+   * must be set, if a client secret is required by the IdP.
    *
    * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_CLIENT_SECRET
    */
+  @Value.Redacted
+  Optional<Secret> getClientSecret();
+
+  /**
+   * The OAuth2 client secret supplier. Either this attribute or {@link #getClientSecret()} must be
+   * set, if a client secret is required by the IdP.
+   */
+  @Value.Redacted
   Optional<Supplier<String>> getClientSecretSupplier();
 
   /**
@@ -227,22 +224,19 @@ public interface OAuth2AuthenticatorConfig {
   Optional<String> getUsername();
 
   /**
-   * The OAuth2 password. Only relevant for {@link GrantType#PASSWORD} grant type.
-   *
-   * @deprecated Use {@link #getPasswordSupplier()} instead.
-   */
-  @SuppressWarnings("DeprecatedIsStillUsed")
-  @Deprecated
-  @Value.Derived
-  default Optional<Secret> getPassword() {
-    return getPasswordSupplier().map(Supplier::get).map(Secret::new);
-  }
-
-  /**
-   * The OAuth2 password supplier. Only relevant for {@link GrantType#PASSWORD} grant type.
+   * The OAuth2 static password. Only relevant for {@link GrantType#PASSWORD} grant type. Either
+   * this attribute or {@link #getPasswordSupplier()} must be set if a password is required.
    *
    * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_PASSWORD
    */
+  @Value.Redacted
+  Optional<Secret> getPassword();
+
+  /**
+   * The OAuth2 password supplier. Only relevant for {@link GrantType#PASSWORD} grant type. Either
+   * this attribute or {@link #getPassword()} must be set if a password is required.
+   */
+  @Value.Redacted
   Optional<Supplier<String>> getPasswordSupplier();
 
   @Value.Derived
@@ -436,37 +430,29 @@ public interface OAuth2AuthenticatorConfig {
     Builder clientId(String clientId);
 
     @CanIgnoreReturnValue
-    Builder clientSecretSupplier(Supplier<String> clientSecret);
-
-    @CanIgnoreReturnValue
-    @Deprecated
-    default Builder clientSecret(Secret clientSecret) {
-      return clientSecretSupplier(clientSecret::getString);
-    }
+    Builder clientSecret(Secret clientSecret);
 
     @CanIgnoreReturnValue
     default Builder clientSecret(String clientSecret) {
-      char[] chars = clientSecret.toCharArray();
-      return clientSecretSupplier(() -> new String(chars));
+      return clientSecret(new Secret(clientSecret));
     }
+
+    @CanIgnoreReturnValue
+    Builder clientSecretSupplier(Supplier<String> clientSecret);
 
     @CanIgnoreReturnValue
     Builder username(String username);
 
     @CanIgnoreReturnValue
-    Builder passwordSupplier(Supplier<String> password);
-
-    @CanIgnoreReturnValue
-    @Deprecated
-    default Builder password(Secret password) {
-      return passwordSupplier(password::getString);
-    }
+    Builder password(Secret password);
 
     @CanIgnoreReturnValue
     default Builder password(String password) {
-      char[] chars = password.toCharArray();
-      return passwordSupplier(() -> new String(chars));
+      return password(new Secret(password));
     }
+
+    @CanIgnoreReturnValue
+    Builder passwordSupplier(Supplier<String> password);
 
     @CanIgnoreReturnValue
     @Deprecated

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/Secret.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/Secret.java
@@ -15,12 +15,7 @@
  */
 package org.projectnessie.client.auth.oauth2;
 
-/**
- * A secret value.
- *
- * @deprecated will be removed in a future release.
- */
-@Deprecated
+/** A secret value. */
 public final class Secret {
 
   private final char[] value;

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
@@ -494,4 +494,31 @@ class TestOAuth2ClientConfig {
                 RefreshToken.of("dynamic-refresh", null));
     assertThat(actorToken).isNull();
   }
+
+  @Test
+  void testSecretSuppliers() {
+    OAuth2ClientConfig config =
+        OAuth2ClientConfig.builder()
+            .grantType(GrantType.PASSWORD)
+            .issuerUrl(URI.create("https://example.com/"))
+            .clientId("Client")
+            .username("Alice")
+            .clientSecretSupplier(() -> "w00t")
+            .passwordSupplier(() -> "s3cr3t")
+            .impersonationConfig(
+                ImpersonationConfig.builder()
+                    .clientId("Client2")
+                    .clientSecretSupplier(() -> "w00t2")
+                    .build())
+            .build();
+    assertThat(config.getClientSecretSupplier()).isPresent();
+    assertThat(config.getClientSecretSupplier().get().get()).isEqualTo("w00t");
+    assertThat(config.getBasicAuthentication()).isPresent();
+    assertThat(config.getPasswordSupplier()).isPresent();
+    assertThat(config.getPasswordSupplier().get().get()).isEqualTo("s3cr3t");
+    assertThat(config.getImpersonationConfig().getClientSecretSupplier()).isPresent();
+    assertThat(config.getImpersonationConfig().getClientSecretSupplier().get().get())
+        .isEqualTo("w00t2");
+    assertThat(config.getImpersonationBasicAuthentication()).isPresent();
+  }
 }


### PR DESCRIPTION
This PR also un-deprecates a few methods that were recently deprecated.