### PR TITLE
Minor cleanups in JDBC(2)

### DIFF
--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcBackend.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcBackend.java
@@ -73,7 +73,6 @@ public final class JdbcBackend implements Backend {
   private final String createTableRefsSql;
   private final String createTableObjsSql;
 
-  @SuppressWarnings("removal")
   public JdbcBackend(
       @Nonnull JdbcBackendConfig config,
       @Nonnull DatabaseSpecific databaseSpecific,

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcPersist.java
@@ -44,11 +44,6 @@ class JdbcPersist extends AbstractJdbcPersist {
   }
 
   @FunctionalInterface
-  interface SQLRunnable<R> {
-    R run(Connection conn) throws SQLException;
-  }
-
-  @FunctionalInterface
   interface SQLRunnableException<R, E extends Exception> {
     R run(Connection conn) throws E;
   }
@@ -64,34 +59,12 @@ class JdbcPersist extends AbstractJdbcPersist {
   }
 
   private void withConnectionVoid(SQLRunnableVoid runnable) {
-    withConnection(
+    withConnectionException(
         false,
         conn -> {
           runnable.run(conn);
           return null;
         });
-  }
-
-  private <R> R withConnection(boolean readOnly, SQLRunnable<R> runnable) {
-    try (Connection conn = backend.borrowConnection()) {
-      boolean ok = false;
-      R r;
-      try {
-        r = runnable.run(conn);
-        ok = true;
-      } finally {
-        if (!readOnly) {
-          if (ok) {
-            conn.commit();
-          } else {
-            conn.rollback();
-          }
-        }
-      }
-      return r;
-    } catch (SQLException e) {
-      throw unhandledSQLException(e);
-    }
   }
 
   private <R, E extends Exception> R withConnectionException(
@@ -140,13 +113,13 @@ class JdbcPersist extends AbstractJdbcPersist {
 
   @Override
   public Reference fetchReference(@Nonnull String name) {
-    return withConnection(true, conn -> super.findReference(conn, name));
+    return withConnectionException(true, conn -> super.findReference(conn, name));
   }
 
   @Override
   @Nonnull
   public Reference[] fetchReferences(@Nonnull String[] names) {
-    return withConnection(true, conn -> super.findReferences(conn, names));
+    return withConnectionException(true, conn -> super.findReferences(conn, names));
   }
 
   @Override

--- a/versioned/storage/jdbc/src/testFixtures/java/org/projectnessie/versioned/storage/jdbc/AbstractTestJdbcBackendFactory.java
+++ b/versioned/storage/jdbc/src/testFixtures/java/org/projectnessie/versioned/storage/jdbc/AbstractTestJdbcBackendFactory.java
@@ -118,8 +118,8 @@ public abstract class AbstractTestJdbcBackendFactory {
               .jdbcPass(testFactory.jdbcPass())
               .build()
               .createNewDataSource();
-      try (Connection keepAliveForH2 = dataSource.getConnection()) {
-
+      try (@SuppressWarnings("unused")
+          Connection keepAliveForH2 = dataSource.getConnection()) {
         RepositoryDescription repoDesc;
 
         try (Backend backend = testFactory.createNewBackend()) {

--- a/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/Jdbc2Backend.java
+++ b/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/Jdbc2Backend.java
@@ -75,7 +75,6 @@ public final class Jdbc2Backend implements Backend {
   private final String createTableRefsSql;
   private final String createTableObjsSql;
 
-  @SuppressWarnings("removal")
   public Jdbc2Backend(
       @Nonnull Jdbc2BackendConfig config,
       @Nonnull DatabaseSpecific databaseSpecific,

--- a/versioned/storage/jdbc2/src/testFixtures/java/org/projectnessie/versioned/storage/jdbc2/AbstractTestJdbc2BackendFactory.java
+++ b/versioned/storage/jdbc2/src/testFixtures/java/org/projectnessie/versioned/storage/jdbc2/AbstractTestJdbc2BackendFactory.java
@@ -118,8 +118,8 @@ public abstract class AbstractTestJdbc2BackendFactory {
               .jdbcPass(testFactory.jdbcPass())
               .build()
               .createNewDataSource();
-      try (Connection keepAliveForH2 = dataSource.getConnection()) {
-
+      try (@SuppressWarnings("unused")
+          Connection keepAliveForH2 = dataSource.getConnection()) {
         RepositoryDescription repoDesc;
 
         try (Backend backend = testFactory.createNewBackend()) {


### PR DESCRIPTION
* remove superfluous `@SuppressWarnings("removal")`
* unify duplicated code
* add a `@SuppressWarnings("unused")`