### PR TITLE
Switch to new s3-sign endpoint using an opaque path parameter

### DIFF
--- a/catalog/service/rest/build.gradle.kts
+++ b/catalog/service/rest/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
   implementation(platform(libs.jackson.bom))
   implementation("com.fasterxml.jackson.core:jackson-databind")
   implementation("com.fasterxml.jackson.core:jackson-annotations")
+  implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-smile")
 
   implementation(libs.slf4j.api)
   implementation(libs.guava)

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/ExternalBaseUri.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/ExternalBaseUri.java
@@ -99,31 +99,9 @@ public interface ExternalBaseUri {
    * deal with this.
    *
    * @param prefix the prefix of the request (warehouse and reference)
-   * @param contentKeyPathString the content key to sign the request for
    * @param signerParam the signer params path parameter (URL safe representation)
    */
   default String icebergS3SignerPathWithPath(String prefix, String signerParam) {
-    return format("v1/%s/s3-sign2/%s", encode(prefix, UTF_8), signerParam);
-  }
-
-  /**
-   * The path, without a leading slash, of the URI to sign a request to S3 for a specific content
-   * key.
-   *
-   * <p>Must use both {@code s3.signer.uri} and {@code s3.signer.endpoint}, because Iceberg before
-   * 1.5.0 does not handle full URIs passed via {@code s3.signer.endpoint}. This was changed via <a
-   * href="https://github.com/apache/iceberg/pull/8976/files#diff-1f7498b6989fffc169f7791292ed2ccb35b305f6a547fd832f6724057c8aca8bR213-R216">this
-   * Iceberg PR</a> first released in Iceberg 1.5.0. It's unclear how other language implementations
-   * deal with this.
-   *
-   * @param prefix the prefix of the request (warehouse and reference)
-   * @param contentKeyPathString the content key to sign the request for
-   * @param uriQuery the query string for the URL
-   */
-  default String icebergS3SignerPathWithQuery(
-      String prefix, String contentKeyPathString, String uriQuery) {
-    return format(
-        "v1/%s/s3-sign/%s?%s",
-        encode(prefix, UTF_8), encode(contentKeyPathString, UTF_8), uriQuery);
+    return format("v1/%s/s3sign/%s", encode(prefix, UTF_8), signerParam);
   }
 }

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/ExternalBaseUri.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/ExternalBaseUri.java
@@ -100,9 +100,28 @@ public interface ExternalBaseUri {
    *
    * @param prefix the prefix of the request (warehouse and reference)
    * @param contentKeyPathString the content key to sign the request for
+   * @param signerParam the signer params path parameter (URL safe representation)
+   */
+  default String icebergS3SignerPathWithPath(String prefix, String signerParam) {
+    return format("v1/%s/s3-sign2/%s", encode(prefix, UTF_8), signerParam);
+  }
+
+  /**
+   * The path, without a leading slash, of the URI to sign a request to S3 for a specific content
+   * key.
+   *
+   * <p>Must use both {@code s3.signer.uri} and {@code s3.signer.endpoint}, because Iceberg before
+   * 1.5.0 does not handle full URIs passed via {@code s3.signer.endpoint}. This was changed via <a
+   * href="https://github.com/apache/iceberg/pull/8976/files#diff-1f7498b6989fffc169f7791292ed2ccb35b305f6a547fd832f6724057c8aca8bR213-R216">this
+   * Iceberg PR</a> first released in Iceberg 1.5.0. It's unclear how other language implementations
+   * deal with this.
+   *
+   * @param prefix the prefix of the request (warehouse and reference)
+   * @param contentKeyPathString the content key to sign the request for
    * @param uriQuery the query string for the URL
    */
-  default String icebergS3SignerPath(String prefix, String contentKeyPathString, String uriQuery) {
+  default String icebergS3SignerPathWithQuery(
+      String prefix, String contentKeyPathString, String uriQuery) {
     return format(
         "v1/%s/s3-sign/%s?%s",
         encode(prefix, UTF_8), encode(contentKeyPathString, UTF_8), uriQuery);

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1S3SignResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1S3SignResource.java
@@ -70,7 +70,7 @@ public class IcebergApiV1S3SignResource extends IcebergApiV1ResourceBase {
 
   @Operation(operationId = "iceberg.v1.s3sign.blob")
   @POST
-  @Path("/v1/{prefix}/s3-sign2/{signedParams}")
+  @Path("/v1/{prefix}/s3sign/{signedParams}")
   @Blocking
   public Uni<IcebergS3SignResponse> s3signWIthOpaqueParams(
       IcebergS3SignRequest request,

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1S3SignResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1S3SignResource.java
@@ -68,6 +68,40 @@ public class IcebergApiV1S3SignResource extends IcebergApiV1ResourceBase {
     return errorMapper.toResponse(ex, IcebergEntityKind.UNKNOWN);
   }
 
+  @Operation(operationId = "iceberg.v1.s3sign.blob")
+  @POST
+  @Path("/v1/{prefix}/s3-sign2/{signedParams}")
+  @Blocking
+  public Uni<IcebergS3SignResponse> s3signWIthOpaqueParams(
+      IcebergS3SignRequest request,
+      @PathParam("prefix") String prefix,
+      @PathParam("signedParams") String signedParams) {
+
+    SignerParams signerParams = SignerParams.fromPathParam(signedParams);
+    SignerKey signerKey = signerKeysService.getSignerKey(signerParams.keyName());
+
+    SignerSignature signerSignature = signerParams.signerSignature();
+    Optional<String> verifyError =
+        signerSignature.verify(signerKey, signerParams.signature(), clock.instant());
+
+    if (verifyError.isPresent()) {
+      LOGGER.warn("{} for request {}", verifyError.get(), uriInfo.getRequestUri());
+      throw new IllegalArgumentException("Invalid signature");
+    }
+
+    return ImmutableIcebergS3SignParams.builder()
+        .request(request)
+        .ref(decodePrefix(prefix).parsedReference())
+        .key(ContentKey.fromPathString(signerSignature.identifier()))
+        .warehouseLocation(signerSignature.warehouseLocation())
+        .writeLocations(signerSignature.writeLocations())
+        .readLocations(signerSignature.readLocations())
+        .catalogService(catalogService)
+        .signer(signer)
+        .build()
+        .verifyAndSign();
+  }
+
   @Operation(operationId = "iceberg.v1.s3sign")
   @POST
   @Path("/v1/{prefix}/s3-sign/{identifier}")

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergConfigurer.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergConfigurer.java
@@ -321,7 +321,7 @@ public class IcebergConfigurer {
     long expirationTimestamp = systemUTC().instant().plus(3, ChronoUnit.HOURS).getEpochSecond();
 
     String contentKeyPathString = contentKey.toPathStringEscaped();
-    String uriQuery =
+    String pathParam =
         SignerSignature.builder()
             .expirationTimestamp(expirationTimestamp)
             .prefix(prefix)
@@ -330,10 +330,9 @@ public class IcebergConfigurer {
             .writeLocations(normalizedWriteLocations)
             .readLocations(normalizedReadLocations)
             .build()
-            .uriQuery(signerKey);
+            .toPathParam(signerKey);
 
-    config.accept(
-        S3_SIGNER_ENDPOINT, uriInfo.icebergS3SignerPath(prefix, contentKeyPathString, uriQuery));
+    config.accept(S3_SIGNER_ENDPOINT, uriInfo.icebergS3SignerPathWithPath(prefix, pathParam));
 
     return true;
   }

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/SignerParams.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/SignerParams.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.service.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Base64;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import org.projectnessie.nessie.immutables.NessieImmutable;
+
+@NessieImmutable
+@JsonSerialize(as = ImmutableSignerParams.class)
+@JsonDeserialize(as = ImmutableSignerParams.class)
+public abstract class SignerParams {
+
+  private static final ObjectMapper SMILE_MAPPER = new SmileMapper().findAndRegisterModules();
+
+  public abstract String keyName();
+
+  public abstract String signature();
+
+  public abstract SignerSignature signerSignature();
+
+  public static SignerParams fromPathParam(String pathParam) {
+    try {
+      byte[] bin = Base64.getUrlDecoder().decode(pathParam);
+      try (InputStream is = new GZIPInputStream(new ByteArrayInputStream(bin))) {
+        return SMILE_MAPPER.readValue(is, SignerParams.class);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public String toPathParam() {
+    try {
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      try (OutputStream gzip = new GZIPOutputStream(out)) {
+        SMILE_MAPPER.writeValue(gzip, this);
+      }
+      byte[] bin = out.toByteArray();
+      return Base64.getUrlEncoder().withoutPadding().encodeToString(bin);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static ImmutableSignerParams.Builder builder() {
+    return ImmutableSignerParams.builder();
+  }
+}

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/SignerSignature.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/SignerSignature.java
@@ -19,6 +19,8 @@ import static com.google.common.hash.Hashing.hmacSha256;
 import static java.net.URLEncoder.encode;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.hash.Hasher;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
@@ -28,6 +30,8 @@ import org.projectnessie.catalog.service.objtypes.SignerKey;
 import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
+@JsonSerialize(as = ImmutableSignerSignature.class)
+@JsonDeserialize(as = ImmutableSignerSignature.class)
 public abstract class SignerSignature {
 
   public abstract String prefix();
@@ -56,6 +60,16 @@ public abstract class SignerSignature {
       hasher.putString("r=" + readLocation, UTF_8);
     }
     return hasher.hash().toString();
+  }
+
+  public String toPathParam(SignerKey signerKey) {
+    String signature = sign(signerKey);
+    return SignerParams.builder()
+        .keyName(signerKey.name())
+        .signature(signature)
+        .signerSignature(this)
+        .build()
+        .toPathParam();
   }
 
   public String uriQuery(SignerKey signerKey) {

--- a/catalog/service/rest/src/test/java/org/projectnessie/catalog/service/rest/TestSignerSignature.java
+++ b/catalog/service/rest/src/test/java/org/projectnessie/catalog/service/rest/TestSignerSignature.java
@@ -63,6 +63,12 @@ public class TestSignerSignature {
     String signature = signerSignature.sign(key);
     soft.assertThat(signerSignature.verify(key, signature, now)).isEmpty();
 
+    String pathParam = signerSignature.toPathParam(key);
+    SignerParams signerParams = SignerParams.fromPathParam(pathParam);
+    soft.assertThat(signerParams)
+        .extracting(SignerParams::keyName, SignerParams::signature, SignerParams::signerSignature)
+        .containsExactly(key.name(), signature, signerSignature);
+
     soft.assertThat(signerSignature.verify(null, signature, now))
         .contains("Could not find signingKey");
     soft.assertThat(signerSignature.verify(key, "tampered-signature", now))


### PR DESCRIPTION
This adds a little bit more obscurity, but also makes S3 signing compatible to some query engines that do not support query parameters for the s3-signing endpoint.

Fixes #9444