### PR TITLE
Helm chart: strengthen default security context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ as necessary. Empty sections will not end in the release notes.
   (root). If you have any custom configurations, especially Kubernetes manifests containing security
   contexts, that rely on the previous user `default` (UID 185 and GID 0), you will need to adjust
   them to reference the new user `nessie` (UID 10000 and GID 10001) from now on.
+- Helm chart: the chart now comes with sane defaults for both pod and container security contexts.
+  If you have customized these settings, you don't need to do anything. If you have not customized these
+  settings, you may need to check if the new defaults are compatible with your environment.
 
 ### Breaking changes
 

--- a/helm/nessie/ci/rocksdb-values.yaml
+++ b/helm/nessie/ci/rocksdb-values.yaml
@@ -1,2 +1,8 @@
 ---
 versionStoreType: ROCKSDB
+extraVolumes:
+  - name: temp2
+    emptyDir: {}
+extraVolumeMounts:
+  - name: temp2
+    mountPath: /tmp2

--- a/helm/nessie/templates/NOTES.txt
+++ b/helm/nessie/templates/NOTES.txt
@@ -33,6 +33,6 @@ To connect to Nessie, please execute the following commands:
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "nessie.fullname" . }} -o jsonpath="{ .status.loadBalancer.ingress[0].ip }")
   echo http://$SERVICE_IP:{{ index .Values.service.ports "nessie-server" }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  nohup kubectl --namespace {{ .Release.Namespace }} port-forward svc/nessie 19120:{{ index .Values.service.ports "nessie-server" }} &
+  nohup kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "nessie.fullname" . }} 19120:{{ index .Values.service.ports "nessie-server" }} &
   echo "Visit http://127.0.0.1:19120 to use your application"
 {{- end }}

--- a/helm/nessie/templates/deployment.yaml
+++ b/helm/nessie/templates/deployment.yaml
@@ -62,13 +62,21 @@ spec:
             - name: nessie-config
               mountPath: {{ trimSuffix "/" .Values.image.configDir }}/application.properties
               subPath: application.properties
+              readOnly: true
+            - name: temp-dir
+              mountPath: /tmp
           {{- if or (eq .Values.versionStoreType "ROCKSDB") (eq .Values.versionStoreType "ROCKS") }}
             - name: rocks-storage
               mountPath: /rocks-nessie
+              readOnly: false
           {{- end }}
           {{- if and (eq .Values.versionStoreType "BIGTABLE") (.Values.bigtable.secret) }}
             - name: bigtable-creds
               mountPath: /bigtable-nessie
+              readOnly: true
+          {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          {{- tpl (toYaml .Values.extraVolumeMounts) . | nindent 12 }}
           {{- end }}
           env:
             {{- if or (eq .Values.versionStoreType "DYNAMODB") (eq .Values.versionStoreType "DYNAMO") -}}
@@ -142,6 +150,8 @@ spec:
         - name: nessie-config
           configMap:
             name: {{ include "nessie.fullname" . }}
+        - name: temp-dir
+          emptyDir: {}
       {{- if or (eq .Values.versionStoreType "ROCKSDB") (eq .Values.versionStoreType "ROCKS") }}
         - name: rocks-storage
           persistentVolumeClaim:
@@ -154,6 +164,9 @@ spec:
             items:
               - key: {{ .Values.bigtable.secret.key }}
                 path: sa_credentials.json
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+      {{- tpl (toYaml .Values.extraVolumes) . | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -649,18 +649,25 @@ configMapLabels: {}
 
 # -- Security context for the nessie pod. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/.
 podSecurityContext:
-  {}
-  # fsGroup: 2000
+  # GID 10001 is compatible with Nessie OSS default images starting with 0.95.1; change this if you
+  # are using a different image.
+  fsGroup: 10001
+  seccompProfile:
+    type: RuntimeDefault
 
 # -- Security context for the nessie container. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/.
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  # UID 10000 and GID 10001 are compatible with Nessie OSS default images starting with 0.95.1;
+  # change this if you are using a different image.
+  runAsUser: 10000
+  runAsGroup: 10001
+  runAsNonRoot: true
+  privileged: false
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 
 # Nessie service settings.
 service:
@@ -795,3 +802,13 @@ readinessProbe:
   failureThreshold: 3
   # -- Number of seconds after which the probe times out. Minimum value is 1.
   timeoutSeconds: 10
+
+# -- Extra volumes to add to the nessie pod. See https://kubernetes.io/docs/concepts/storage/volumes/.
+extraVolumes: []
+    # - name: extra-volume
+    #   emptyDir: {}
+
+# -- Extra volume mounts to add to the nessie container. See https://kubernetes.io/docs/concepts/storage/volumes/.
+extraVolumeMounts: []
+    # - name: extra-volume
+    #   mountPath: /usr/share/extra-volume


### PR DESCRIPTION
This PR adds sane defaults for pod and container security contexts.

Since the default filesystem is now read-only, it also adds a new mount point for /tmp with read-write access.

It also adds two more options: `extraVolumes` and `extraVolumeMounts`. These can serve as escape hatches in case users need more locations with read-write access.