### PR TITLE
CLI: make tool runnable without history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Fixes
 
+- CLI: fixed a bug that was preventing the tool from running properly when history is disabled.
+
 ### Commits
 
 ## [0.95.0] Release (2024-08-07)

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/cli/NessieCliImpl.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/cli/NessieCliImpl.java
@@ -192,6 +192,14 @@ public class NessieCliImpl extends BaseNessieCli implements Callable<Integer> {
         writer.printf("v%s%n%n", NessieVersion.NESSIE_VERSION);
         writer.print(readResource("welcome.txt"));
 
+        if (history) {
+          writer.println(
+              String.format(
+                  "History file in %s will record all statements.\n"
+                      + "Tip: lines that start with a space (' ') are not recorded in the history.\n\n",
+                  historyFile));
+        }
+
         checkVersion();
 
         RuntimeMXBean rb = ManagementFactory.getRuntimeMXBean();
@@ -563,6 +571,8 @@ public class NessieCliImpl extends BaseNessieCli implements Callable<Integer> {
 
         readerBuilder.variable(LineReader.HISTORY_FILE, f);
       }
+    } else {
+      readerBuilder.variable(LineReader.DISABLE_HISTORY, true);
     }
 
     LineReader reader = readerBuilder.build();

--- a/cli/cli/src/main/resources/org/projectnessie/nessie/cli/cli/welcome.txt
+++ b/cli/cli/src/main/resources/org/projectnessie/nessie/cli/cli/welcome.txt
@@ -4,8 +4,5 @@ Welcome to the Nessie CLI REPL!
 Use HELP to get information about available commands.
 Commands can be autocompleted by pressing TAB.
 
-History file in $HOME/.nessie/nessie-cli.history will record all statements.
-Tip: lines that start with a space (' ') are not recorded in the history.
-
 Tip: Ctrl-C cannot be used to exit the REPL or paged output. Use Ctrl-D instead.
 


### PR DESCRIPTION
Setting `--history=false` wasn't working correctly.