### PR TITLE
Switch Nessie Docker images to use UID 10000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ as necessary. Empty sections will not end in the release notes.
 
 - Support for Java 8 has been removed, even for Nessie clients. Minimum runtime requirement for clients
   is Java 11.
+- Nessie Docker images now all execute as user `nessie` (UID 10000 and GID 10001). They would
+  previously execute as user `default` (UID 185 and GID 0). This is a security improvement, as the
+  Nessie images no longer run with a UID within the privileged range, and the GID is no longer 0
+  (root). If you have any custom configurations, especially Kubernetes manifests containing security
+  contexts, that rely on the previous user `default` (UID 185 and GID 0), you will need to adjust
+  them to reference the new user `nessie` (UID 10000 and GID 10001) from now on.
 
 ### Breaking changes
 

--- a/tools/dockerbuild/docker/Dockerfile-admintool
+++ b/tools/dockerbuild/docker/Dockerfile-admintool
@@ -7,21 +7,21 @@ LABEL org.opencontainers.image.licenses=Apache-2.0
 ENV LANGUAGE='en_US:en'
 
 USER root
-RUN groupadd --gid 1001 nessie \
-      && useradd --uid 1001 --gid nessie nessie \
+RUN groupadd --gid 10001 nessie \
+      && useradd --uid 10000 --gid nessie nessie \
       && chown -R nessie:nessie /opt/jboss/container \
       && chown -R nessie:nessie /deployments
 
-USER 1001
+USER nessie
 WORKDIR /home/nessie
 ENV USER=nessie
-ENV UID=1001
+ENV UID=10000
 ENV HOME=/home/nessie
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
-COPY --chown=1001:1001 build/quarkus-app/lib/ /deployments/lib/
-COPY --chown=1001:1001 build/quarkus-app/*.jar /deployments/
-COPY --chown=1001:1001 build/quarkus-app/app/ /deployments/app/
-COPY --chown=1001:1001 build/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --chown=nessie:nessie build/quarkus-app/lib/ /deployments/lib/
+COPY --chown=nessie:nessie build/quarkus-app/*.jar /deployments/
+COPY --chown=nessie:nessie build/quarkus-app/app/ /deployments/app/
+COPY --chown=nessie:nessie build/quarkus-app/quarkus/ /deployments/quarkus/
 
 ENTRYPOINT [ "java", "-jar", "/deployments/quarkus-run.jar" ]

--- a/tools/dockerbuild/docker/Dockerfile-admintool
+++ b/tools/dockerbuild/docker/Dockerfile-admintool
@@ -6,11 +6,22 @@ LABEL org.opencontainers.image.licenses=Apache-2.0
 
 ENV LANGUAGE='en_US:en'
 
-# We make four distinct layers so if there are application changes the library layers can be re-used
-COPY --chown=185 build/quarkus-app/lib/ /deployments/lib/
-COPY --chown=185 build/quarkus-app/*.jar /deployments/
-COPY --chown=185 build/quarkus-app/app/ /deployments/app/
-COPY --chown=185 build/quarkus-app/quarkus/ /deployments/quarkus/
+USER root
+RUN groupadd --gid 1001 nessie \
+      && useradd --uid 1001 --gid nessie nessie \
+      && chown -R nessie:nessie /opt/jboss/container \
+      && chown -R nessie:nessie /deployments
 
-USER 185
+USER 1001
+WORKDIR /home/nessie
+ENV USER=nessie
+ENV UID=1001
+ENV HOME=/home/nessie
+
+# We make four distinct layers so if there are application changes the library layers can be re-used
+COPY --chown=1001:1001 build/quarkus-app/lib/ /deployments/lib/
+COPY --chown=1001:1001 build/quarkus-app/*.jar /deployments/
+COPY --chown=1001:1001 build/quarkus-app/app/ /deployments/app/
+COPY --chown=1001:1001 build/quarkus-app/quarkus/ /deployments/quarkus/
+
 ENTRYPOINT [ "java", "-jar", "/deployments/quarkus-run.jar" ]

--- a/tools/dockerbuild/docker/Dockerfile-cli
+++ b/tools/dockerbuild/docker/Dockerfile-cli
@@ -8,8 +8,18 @@ ARG VERSION
 
 ENV LANGUAGE='en_US:en'
 
-COPY --chown=185 build/libs/nessie-cli-$VERSION.jar /nessie-cli.jar
+USER root
+RUN groupadd --gid 1001 nessie \
+      && useradd --uid 1001 --gid nessie nessie \
+      && chown -R nessie:nessie /opt/jboss/container \
+      && chown -R nessie:nessie /deployments
 
-USER 185
+USER 1001
+WORKDIR /home/nessie
+ENV USER=nessie
+ENV UID=1001
+ENV HOME=/home/nessie
+
+COPY --chown=1001:1001 build/libs/nessie-cli-$VERSION.jar /nessie-cli.jar
 
 ENTRYPOINT [ "java", "-jar", "/nessie-cli.jar" ]

--- a/tools/dockerbuild/docker/Dockerfile-cli
+++ b/tools/dockerbuild/docker/Dockerfile-cli
@@ -9,17 +9,17 @@ ARG VERSION
 ENV LANGUAGE='en_US:en'
 
 USER root
-RUN groupadd --gid 1001 nessie \
-      && useradd --uid 1001 --gid nessie nessie \
+RUN groupadd --gid 10001 nessie \
+      && useradd --uid 10000 --gid nessie nessie \
       && chown -R nessie:nessie /opt/jboss/container \
       && chown -R nessie:nessie /deployments
 
-USER 1001
+USER nessie
 WORKDIR /home/nessie
 ENV USER=nessie
-ENV UID=1001
+ENV UID=10000
 ENV HOME=/home/nessie
 
-COPY --chown=1001:1001 build/libs/nessie-cli-$VERSION.jar /nessie-cli.jar
+COPY --chown=nessie:nessie build/libs/nessie-cli-$VERSION.jar /nessie-cli.jar
 
 ENTRYPOINT [ "java", "-jar", "/nessie-cli.jar" ]

--- a/tools/dockerbuild/docker/Dockerfile-gctool
+++ b/tools/dockerbuild/docker/Dockerfile-gctool
@@ -7,17 +7,17 @@ LABEL org.opencontainers.image.licenses=Apache-2.0
 ENV LANGUAGE='en_US:en'
 
 USER root
-RUN groupadd --gid 1001 nessie \
-      && useradd --uid 1001 --gid nessie nessie \
+RUN groupadd --gid 10001 nessie \
+      && useradd --uid 10000 --gid nessie nessie \
       && chown -R nessie:nessie /opt/jboss/container \
       && chown -R nessie:nessie /deployments
 
-USER 1001
+USER nessie
 WORKDIR /home/nessie
 ENV USER=nessie
-ENV UID=1001
+ENV UID=10000
 ENV HOME=/home/nessie
 
-COPY --chown=1001:1001 build/executable/nessie-gc.jar /
+COPY --chown=nessie:nessie build/executable/nessie-gc.jar /
 
 ENTRYPOINT [ "java", "-jar", "/nessie-gc.jar" ]

--- a/tools/dockerbuild/docker/Dockerfile-gctool
+++ b/tools/dockerbuild/docker/Dockerfile-gctool
@@ -6,8 +6,18 @@ LABEL org.opencontainers.image.licenses=Apache-2.0
 
 ENV LANGUAGE='en_US:en'
 
-COPY --chown=185 build/executable/nessie-gc.jar /
+USER root
+RUN groupadd --gid 1001 nessie \
+      && useradd --uid 1001 --gid nessie nessie \
+      && chown -R nessie:nessie /opt/jboss/container \
+      && chown -R nessie:nessie /deployments
 
-USER 185
+USER 1001
+WORKDIR /home/nessie
+ENV USER=nessie
+ENV UID=1001
+ENV HOME=/home/nessie
+
+COPY --chown=1001:1001 build/executable/nessie-gc.jar /
 
 ENTRYPOINT [ "java", "-jar", "/nessie-gc.jar" ]

--- a/tools/dockerbuild/docker/Dockerfile-server
+++ b/tools/dockerbuild/docker/Dockerfile-server
@@ -6,12 +6,8 @@
 # which is the default packaging type. For example:
 #    ./gradlew :nessie-quarkus:quarkusBuild
 #
-#
 # FOLLOWING DESCRIPTION AND CONTENT "BORROWED" FROM QUARKUS SOURCE.
 # source file: https://github.com/quarkusio/quarkus/blob/main/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.jvm
-#
-#
-#
 #
 # This image uses the `run-java.sh` script to run the application.
 # This scripts computes the command line to execute your Java application, and
@@ -19,7 +15,12 @@
 #
 # (See site/docs/try/configuration.md)
 #
+# Useful links to base images and respective Dockerfiles:
+# https://catalog.redhat.com/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f?architecture=amd64&image=66c2c0999bba0b8440407e86&container-tabs=dockerfile
+# https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?container-tabs=dockerfile
+#
 ###
+
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.20-2.1721752928
 
 LABEL org.opencontainers.image.source=https://github.com/projectnessie/nessie
@@ -28,13 +29,25 @@ LABEL org.opencontainers.image.licenses=Apache-2.0
 
 ENV LANGUAGE='en_US:en'
 
+USER root
+RUN groupadd --gid 1001 nessie \
+      && useradd --uid 1001 --gid nessie nessie \
+      && chown -R nessie:nessie /opt/jboss/container \
+      && chown -R nessie:nessie /deployments
+
+USER 1001
+WORKDIR /home/nessie
+ENV USER=nessie
+ENV UID=1001
+ENV HOME=/home/nessie
+
 # We make four distinct layers so if there are application changes the library layers can be re-used
-COPY --chown=185 build/quarkus-app/lib/ /deployments/lib/
-COPY --chown=185 build/quarkus-app/*.jar /deployments/
-COPY --chown=185 build/quarkus-app/app/ /deployments/app/
-COPY --chown=185 build/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --chown=1001:1001 build/quarkus-app/lib/ /deployments/lib/
+COPY --chown=1001:1001 build/quarkus-app/*.jar /deployments/
+COPY --chown=1001:1001 build/quarkus-app/app/ /deployments/app/
+COPY --chown=1001:1001 build/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 19120
-USER 185
+
 ENV AB_JOLOKIA_OFF=""
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/tools/dockerbuild/docker/Dockerfile-server
+++ b/tools/dockerbuild/docker/Dockerfile-server
@@ -30,22 +30,22 @@ LABEL org.opencontainers.image.licenses=Apache-2.0
 ENV LANGUAGE='en_US:en'
 
 USER root
-RUN groupadd --gid 1001 nessie \
-      && useradd --uid 1001 --gid nessie nessie \
+RUN groupadd --gid 10001 nessie \
+      && useradd --uid 10000 --gid nessie nessie \
       && chown -R nessie:nessie /opt/jboss/container \
       && chown -R nessie:nessie /deployments
 
-USER 1001
+USER nessie
 WORKDIR /home/nessie
 ENV USER=nessie
-ENV UID=1001
+ENV UID=10000
 ENV HOME=/home/nessie
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
-COPY --chown=1001:1001 build/quarkus-app/lib/ /deployments/lib/
-COPY --chown=1001:1001 build/quarkus-app/*.jar /deployments/
-COPY --chown=1001:1001 build/quarkus-app/app/ /deployments/app/
-COPY --chown=1001:1001 build/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --chown=nessie:nessie build/quarkus-app/lib/ /deployments/lib/
+COPY --chown=nessie:nessie build/quarkus-app/*.jar /deployments/
+COPY --chown=nessie:nessie build/quarkus-app/app/ /deployments/app/
+COPY --chown=nessie:nessie build/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 19120
 


### PR DESCRIPTION
Many companies have strict requirements on container security and a common convention is that containers should be run by non-root, non-system users with UID >= 1000.