### PR TITLE
public test methods in `BaseTestNessieApi`

### DIFF
--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
@@ -1861,7 +1861,7 @@ public abstract class BaseTestNessieApi {
 
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  void createAndUpdateRepositoryConfig() throws Exception {
+  public void createAndUpdateRepositoryConfig() throws Exception {
     @SuppressWarnings("resource")
     NessieApiV2 api = apiV2();
 
@@ -1909,7 +1909,7 @@ public abstract class BaseTestNessieApi {
 
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  void genericRepositoryConfigForbidden() {
+  public void genericRepositoryConfigForbidden() {
     @SuppressWarnings("resource")
     NessieApiV2 api = apiV2();
 
@@ -1940,7 +1940,7 @@ public abstract class BaseTestNessieApi {
 
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  void invalidCreateRepositoryConfig() {
+  public void invalidCreateRepositoryConfig() {
     @SuppressWarnings("resource")
     NessieApiV2 api = apiV2();
 
@@ -1961,7 +1961,7 @@ public abstract class BaseTestNessieApi {
   }
 
   @Test
-  void invalidParameters() {
+  public void invalidParameters() {
     soft.assertThatThrownBy(() -> api().getEntries().refName("..invalid..").get())
         .isInstanceOf(NessieBadRequestException.class)
         .hasMessageContaining(Validation.REF_NAME_MESSAGE);
@@ -1969,7 +1969,7 @@ public abstract class BaseTestNessieApi {
 
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  void renameTwice() throws Exception {
+  public void renameTwice() throws Exception {
     Branch main = api().getDefaultBranch();
     soft.assertThat(api().getAllReferences().get().getReferences()).containsExactly(main);
 


### PR DESCRIPTION
in a downstream project we are sub-classing `BaseTestNessieRest` in order to override and disable some methods related to the `/config` endpoint (which is unavailable there).

because of this we are unable to upgrade to the junit 5.11.0 version because method visibility has been changed: https://junit.org/junit5/docs/5.11.0/release-notes/#release-notes-5.11.0-junit-platform-deprecations-and-breaking-changes

note that all other test methods in the file seem `public` already so this makes things more consistent as well.