### PR TITLE
[Bug]: Helm Chart does not render in version 0.96 because of secretToEnv

### DIFF
--- a/helm/nessie/templates/_helpers.tpl
+++ b/helm/nessie/templates/_helpers.tpl
@@ -358,3 +358,27 @@ config types know about that symbolic name and resolve it via a SecretsProvider,
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Define an env var from secret key.
+*/}}
+{{- define "nessie.secretKeyToEnv" -}}
+{{- $secret := index . 0 -}}
+{{- $key := index . 1 -}}
+{{- $envVarName := index . 2 -}}
+{{- $global := index . 3 -}}
+{{- if $secret -}}
+{{- $secretName := get $secret "name" -}}
+{{- $secretKey := get $secret $key -}}
+{{- with $global -}}
+{{- if (and $secretName $secretKey) -}}
+- name: {{ $envVarName | quote }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ (tpl $secretName . ) | quote }}
+      key: {{ (tpl $secretKey . ) | quote }}
+{{ end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm/nessie/templates/_helpers.tpl
+++ b/helm/nessie/templates/_helpers.tpl
@@ -291,32 +291,32 @@ Define environkent variables for catalog storage options.
 */}}
 {{- define "nessie.catalogStorageEnv" -}}
 {{ $global := .}}
-{{- include "nessie.secretToEnv" (list .Values.catalog.storage.s3.defaultOptions.accessKeySecret "awsAccessKeyId" "s3.default-options.access-key" "name" true . ) }}
-{{- include "nessie.secretToEnv" (list .Values.catalog.storage.s3.defaultOptions.accessKeySecret "awsSecretAccessKey" "s3.default-options.access-key" "secret" false . ) }}
+{{- include "nessie.catalogSecretToEnv" (list .Values.catalog.storage.s3.defaultOptions.accessKeySecret "awsAccessKeyId" "s3.default-options.access-key" "name" true . ) }}
+{{- include "nessie.catalogSecretToEnv" (list .Values.catalog.storage.s3.defaultOptions.accessKeySecret "awsSecretAccessKey" "s3.default-options.access-key" "secret" false . ) }}
 {{- range $i, $bucket := .Values.catalog.storage.s3.buckets -}}
 {{- with $global }}
-{{- include "nessie.secretToEnv" (list $bucket.accessKeySecret "awsAccessKeyId" (printf "s3.buckets.bucket%d.access-key" (add $i 1)) "name" true . ) }}
-{{- include "nessie.secretToEnv" (list $bucket.accessKeySecret "awsSecretAccessKey" (printf "s3.buckets.bucket%d.access-key" (add $i 1)) "secret" false . ) }}
+{{- include "nessie.catalogSecretToEnv" (list $bucket.accessKeySecret "awsAccessKeyId" (printf "s3.buckets.bucket%d.access-key" (add $i 1)) "name" true . ) }}
+{{- include "nessie.catalogSecretToEnv" (list $bucket.accessKeySecret "awsSecretAccessKey" (printf "s3.buckets.bucket%d.access-key" (add $i 1)) "secret" false . ) }}
 {{- end -}}
 {{- end -}}
-{{- include "nessie.secretToEnv" (list .Values.catalog.storage.gcs.defaultOptions.authCredentialsJsonSecret "key" "gcs.default-options.auth-credentials-json" "key" true . ) }}
-{{- include "nessie.secretToEnv" (list .Values.catalog.storage.gcs.defaultOptions.oauth2TokenSecret "token" "gcs.default-options.oauth-token" "token" true . ) }}
-{{- include "nessie.secretToEnv" (list .Values.catalog.storage.gcs.defaultOptions.oauth2TokenSecret "expiresAt" "gcs.default-options.oauth-token" "expiresAt" false . ) }}
+{{- include "nessie.catalogSecretToEnv" (list .Values.catalog.storage.gcs.defaultOptions.authCredentialsJsonSecret "key" "gcs.default-options.auth-credentials-json" "key" true . ) }}
+{{- include "nessie.catalogSecretToEnv" (list .Values.catalog.storage.gcs.defaultOptions.oauth2TokenSecret "token" "gcs.default-options.oauth-token" "token" true . ) }}
+{{- include "nessie.catalogSecretToEnv" (list .Values.catalog.storage.gcs.defaultOptions.oauth2TokenSecret "expiresAt" "gcs.default-options.oauth-token" "expiresAt" false . ) }}
 {{- range $i, $bucket := .Values.catalog.storage.gcs.buckets -}}
 {{- with $global }}
-{{- include "nessie.secretToEnv" (list $bucket.authCredentialsJsonSecret "key" (printf "gcs.buckets.bucket%d.auth-credentials-json" (add $i 1)) "key" true . ) }}
-{{- include "nessie.secretToEnv" (list $bucket.oauth2TokenSecret "token" (printf "gcs.buckets.bucket%d.oauth-token" (add $i 1)) "token" true . ) }}
-{{- include "nessie.secretToEnv" (list $bucket.oauth2TokenSecret "expiresAt" (printf "gcs.buckets.bucket%d.oauth-token" (add $i 1)) "expiresAt" false . ) }}
+{{- include "nessie.catalogSecretToEnv" (list $bucket.authCredentialsJsonSecret "key" (printf "gcs.buckets.bucket%d.auth-credentials-json" (add $i 1)) "key" true . ) }}
+{{- include "nessie.catalogSecretToEnv" (list $bucket.oauth2TokenSecret "token" (printf "gcs.buckets.bucket%d.oauth-token" (add $i 1)) "token" true . ) }}
+{{- include "nessie.catalogSecretToEnv" (list $bucket.oauth2TokenSecret "expiresAt" (printf "gcs.buckets.bucket%d.oauth-token" (add $i 1)) "expiresAt" false . ) }}
 {{- end -}}
 {{- end -}}
-{{ include "nessie.secretToEnv" (list .Values.catalog.storage.adls.defaultOptions.accountSecret "accountName" "adls.default-options.account" "name" true . ) }}
-{{- include "nessie.secretToEnv" (list .Values.catalog.storage.adls.defaultOptions.accountSecret "accountKey" "adls.default-options.account" "secret" false . ) }}
-{{- include "nessie.secretToEnv" (list .Values.catalog.storage.adls.defaultOptions.sasTokenSecret "sasToken" "adls.default-options.sas-token" "token" true . ) }}
+{{ include "nessie.catalogSecretToEnv" (list .Values.catalog.storage.adls.defaultOptions.accountSecret "accountName" "adls.default-options.account" "name" true . ) }}
+{{- include "nessie.catalogSecretToEnv" (list .Values.catalog.storage.adls.defaultOptions.accountSecret "accountKey" "adls.default-options.account" "secret" false . ) }}
+{{- include "nessie.catalogSecretToEnv" (list .Values.catalog.storage.adls.defaultOptions.sasTokenSecret "sasToken" "adls.default-options.sas-token" "token" true . ) }}
 {{- range $i, $filesystem := .Values.catalog.storage.adls.filesystems -}}
 {{- with $global }}
-{{- include "nessie.secretToEnv" (list $filesystem.accountSecret "accountName" (printf "adls.file-systems.filesystem%d.account" (add $i 1)) "name" true . ) }}
-{{- include "nessie.secretToEnv" (list $filesystem.accountSecret "accountKey" (printf "adls.file-systems.filesystem%d.account" (add $i 1)) "secret" false . ) }}
-{{- include "nessie.secretToEnv" (list $filesystem.sasTokenSecret "sasToken" (printf "adls.file-systems.filesystem%d.sas-token" (add $i 1)) "token" true . ) }}
+{{- include "nessie.catalogSecretToEnv" (list $filesystem.accountSecret "accountName" (printf "adls.file-systems.filesystem%d.account" (add $i 1)) "name" true . ) }}
+{{- include "nessie.catalogSecretToEnv" (list $filesystem.accountSecret "accountKey" (printf "adls.file-systems.filesystem%d.account" (add $i 1)) "secret" false . ) }}
+{{- include "nessie.catalogSecretToEnv" (list $filesystem.sasTokenSecret "sasToken" (printf "adls.file-systems.filesystem%d.sas-token" (add $i 1)) "token" true . ) }}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -330,7 +330,7 @@ via a symbolic name, which is something like 'nessie-catalog-secrets.s3.default-
 config types know about that symbolic name and resolve it via a SecretsProvider, which resolves via Quarkus' config.
 
 */}}
-{{- define "nessie.secretToEnv" -}}
+{{- define "nessie.catalogSecretToEnv" -}}
 {{- $secret := index . 0 -}}
 {{- $key := index . 1 -}}
 {{- $midfix := index . 2 -}}
@@ -363,7 +363,7 @@ config types know about that symbolic name and resolve it via a SecretsProvider,
 {{/*
 Define an env var from secret key.
 */}}
-{{- define "nessie.secretKeyToEnv" -}}
+{{- define "nessie.secretToEnv" -}}
 {{- $secret := index . 0 -}}
 {{- $key := index . 1 -}}
 {{- $envVarName := index . 2 -}}

--- a/helm/nessie/templates/deployment.yaml
+++ b/helm/nessie/templates/deployment.yaml
@@ -80,16 +80,16 @@ spec:
           {{- end }}
           env:
             {{- if or (eq .Values.versionStoreType "DYNAMODB") (eq .Values.versionStoreType "DYNAMO") -}}
-            {{- include "nessie.secretToEnv" (list .Values.dynamodb.secret "awsAccessKeyId" "AWS_ACCESS_KEY_ID" . ) | trim | nindent 12 -}}
-            {{- include "nessie.secretToEnv" (list .Values.dynamodb.secret "awsSecretAccessKey" "AWS_SECRET_ACCESS_KEY" . ) | trim | nindent 12 -}}
+            {{- include "nessie.secretKeyToEnv" (list .Values.dynamodb.secret "awsAccessKeyId" "AWS_ACCESS_KEY_ID" . ) | trim | nindent 12 -}}
+            {{- include "nessie.secretKeyToEnv" (list .Values.dynamodb.secret "awsSecretAccessKey" "AWS_SECRET_ACCESS_KEY" . ) | trim | nindent 12 -}}
             {{- end -}}
             {{- if or (eq .Values.versionStoreType "MONGODB") (eq .Values.versionStoreType "MONGO") }}
-            {{- include "nessie.secretToEnv" (list .Values.mongodb.secret "username" "quarkus.mongodb.credentials.username" . ) | trim | nindent 12 -}}
-            {{- include "nessie.secretToEnv" (list .Values.mongodb.secret "password" "quarkus.mongodb.credentials.password" . ) | trim | nindent 12 -}}
+            {{- include "nessie.secretKeyToEnv" (list .Values.mongodb.secret "username" "quarkus.mongodb.credentials.username" . ) | trim | nindent 12 -}}
+            {{- include "nessie.secretKeyToEnv" (list .Values.mongodb.secret "password" "quarkus.mongodb.credentials.password" . ) | trim | nindent 12 -}}
             {{- end -}}
             {{- if eq .Values.versionStoreType "CASSANDRA" }}
-            {{- include "nessie.secretToEnv" (list .Values.cassandra.secret "username" "quarkus.cassandra.auth.username" . ) | trim | nindent 12 -}}
-            {{- include "nessie.secretToEnv" (list .Values.cassandra.secret "password" "quarkus.cassandra.auth.password" . ) | trim | nindent 12 -}}
+            {{- include "nessie.secretKeyToEnv" (list .Values.cassandra.secret "username" "quarkus.cassandra.auth.username" . ) | trim | nindent 12 -}}
+            {{- include "nessie.secretKeyToEnv" (list .Values.cassandra.secret "password" "quarkus.cassandra.auth.password" . ) | trim | nindent 12 -}}
             {{- end -}}
             {{- if or (eq .Values.versionStoreType "JDBC") (eq .Values.versionStoreType "TRANSACTIONAL") }}
             {{- $oldConfig := .Values.postgres | default dict }}
@@ -97,8 +97,8 @@ spec:
             {{- $jdbcUrl := coalesce $oldConfig.jdbcUrl $newConfig.jdbcUrl }}
             {{- $secret := coalesce $oldConfig.secret $newConfig.secret }}
             {{- $dbKind := include "nessie.dbKind" $jdbcUrl }}
-            {{- include "nessie.secretToEnv" (list $secret "username" (printf "quarkus.datasource.%s.username" $dbKind) . ) | trim | nindent 12 }}
-            {{- include "nessie.secretToEnv" (list $secret "password" (printf "quarkus.datasource.%s.password" $dbKind) . ) | trim | nindent 12 }}
+            {{- include "nessie.secretKeyToEnv" (list $secret "username" (printf "quarkus.datasource.%s.username" $dbKind) . ) | trim | nindent 12 }}
+            {{- include "nessie.secretKeyToEnv" (list $secret "password" (printf "quarkus.datasource.%s.password" $dbKind) . ) | trim | nindent 12 }}
             {{- end -}}
             {{- if eq .Values.versionStoreType "BIGTABLE" }}
             {{- if .Values.bigtable.secret }}
@@ -107,8 +107,8 @@ spec:
             {{- end }}
             {{- end -}}
             {{- if .Values.authentication.enabled -}}
-            {{- include "nessie.secretToEnv" (list .Values.authentication.oidcClientSecret "key" "quarkus.oidc.credentials.secret" . ) | trim | nindent 12 -}}
-            {{- include "nessie.secretToEnv" (list .Values.authentication.oidcClientSecret "key" "quarkus.oidc.ui-app.credentials.secret" . ) | trim | nindent 12 -}}
+            {{- include "nessie.secretKeyToEnv" (list .Values.authentication.oidcClientSecret "key" "quarkus.oidc.credentials.secret" . ) | trim | nindent 12 -}}
+            {{- include "nessie.secretKeyToEnv" (list .Values.authentication.oidcClientSecret "key" "quarkus.oidc.ui-app.credentials.secret" . ) | trim | nindent 12 -}}
             {{- end -}}
             {{- if .Values.catalog.enabled -}}
             {{- include "nessie.catalogStorageEnv" . | trim | nindent 12 -}}

--- a/helm/nessie/templates/deployment.yaml
+++ b/helm/nessie/templates/deployment.yaml
@@ -80,16 +80,16 @@ spec:
           {{- end }}
           env:
             {{- if or (eq .Values.versionStoreType "DYNAMODB") (eq .Values.versionStoreType "DYNAMO") -}}
-            {{- include "nessie.secretKeyToEnv" (list .Values.dynamodb.secret "awsAccessKeyId" "AWS_ACCESS_KEY_ID" . ) | trim | nindent 12 -}}
-            {{- include "nessie.secretKeyToEnv" (list .Values.dynamodb.secret "awsSecretAccessKey" "AWS_SECRET_ACCESS_KEY" . ) | trim | nindent 12 -}}
+            {{- include "nessie.secretToEnv" (list .Values.dynamodb.secret "awsAccessKeyId" "AWS_ACCESS_KEY_ID" . ) | trim | nindent 12 -}}
+            {{- include "nessie.secretToEnv" (list .Values.dynamodb.secret "awsSecretAccessKey" "AWS_SECRET_ACCESS_KEY" . ) | trim | nindent 12 -}}
             {{- end -}}
             {{- if or (eq .Values.versionStoreType "MONGODB") (eq .Values.versionStoreType "MONGO") }}
-            {{- include "nessie.secretKeyToEnv" (list .Values.mongodb.secret "username" "quarkus.mongodb.credentials.username" . ) | trim | nindent 12 -}}
-            {{- include "nessie.secretKeyToEnv" (list .Values.mongodb.secret "password" "quarkus.mongodb.credentials.password" . ) | trim | nindent 12 -}}
+            {{- include "nessie.secretToEnv" (list .Values.mongodb.secret "username" "quarkus.mongodb.credentials.username" . ) | trim | nindent 12 -}}
+            {{- include "nessie.secretToEnv" (list .Values.mongodb.secret "password" "quarkus.mongodb.credentials.password" . ) | trim | nindent 12 -}}
             {{- end -}}
             {{- if eq .Values.versionStoreType "CASSANDRA" }}
-            {{- include "nessie.secretKeyToEnv" (list .Values.cassandra.secret "username" "quarkus.cassandra.auth.username" . ) | trim | nindent 12 -}}
-            {{- include "nessie.secretKeyToEnv" (list .Values.cassandra.secret "password" "quarkus.cassandra.auth.password" . ) | trim | nindent 12 -}}
+            {{- include "nessie.secretToEnv" (list .Values.cassandra.secret "username" "quarkus.cassandra.auth.username" . ) | trim | nindent 12 -}}
+            {{- include "nessie.secretToEnv" (list .Values.cassandra.secret "password" "quarkus.cassandra.auth.password" . ) | trim | nindent 12 -}}
             {{- end -}}
             {{- if or (eq .Values.versionStoreType "JDBC") (eq .Values.versionStoreType "TRANSACTIONAL") }}
             {{- $oldConfig := .Values.postgres | default dict }}
@@ -97,8 +97,8 @@ spec:
             {{- $jdbcUrl := coalesce $oldConfig.jdbcUrl $newConfig.jdbcUrl }}
             {{- $secret := coalesce $oldConfig.secret $newConfig.secret }}
             {{- $dbKind := include "nessie.dbKind" $jdbcUrl }}
-            {{- include "nessie.secretKeyToEnv" (list $secret "username" (printf "quarkus.datasource.%s.username" $dbKind) . ) | trim | nindent 12 }}
-            {{- include "nessie.secretKeyToEnv" (list $secret "password" (printf "quarkus.datasource.%s.password" $dbKind) . ) | trim | nindent 12 }}
+            {{- include "nessie.secretToEnv" (list $secret "username" (printf "quarkus.datasource.%s.username" $dbKind) . ) | trim | nindent 12 }}
+            {{- include "nessie.secretToEnv" (list $secret "password" (printf "quarkus.datasource.%s.password" $dbKind) . ) | trim | nindent 12 }}
             {{- end -}}
             {{- if eq .Values.versionStoreType "BIGTABLE" }}
             {{- if .Values.bigtable.secret }}
@@ -107,8 +107,8 @@ spec:
             {{- end }}
             {{- end -}}
             {{- if .Values.authentication.enabled -}}
-            {{- include "nessie.secretKeyToEnv" (list .Values.authentication.oidcClientSecret "key" "quarkus.oidc.credentials.secret" . ) | trim | nindent 12 -}}
-            {{- include "nessie.secretKeyToEnv" (list .Values.authentication.oidcClientSecret "key" "quarkus.oidc.ui-app.credentials.secret" . ) | trim | nindent 12 -}}
+            {{- include "nessie.secretToEnv" (list .Values.authentication.oidcClientSecret "key" "quarkus.oidc.credentials.secret" . ) | trim | nindent 12 -}}
+            {{- include "nessie.secretToEnv" (list .Values.authentication.oidcClientSecret "key" "quarkus.oidc.ui-app.credentials.secret" . ) | trim | nindent 12 -}}
             {{- end -}}
             {{- if .Values.catalog.enabled -}}
             {{- include "nessie.catalogStorageEnv" . | trim | nindent 12 -}}


### PR DESCRIPTION
Hello, thanks for working on this project!

We found today that after release `0.96.0` the helm chart does not deploy with the following error:

```
error deploying nessie: unable to deploy helm chart: 
error executing 'helm upgrade nessie --values /tmp/3296770843 --install /nessie/chart --kube-context pod-context': 
Error: UPGRADE FAILED: 
template: nessie/charts/nessie/templates/deployment.yaml:100:16: executing "nessie/charts/nessie/templates/deployment.yaml" at <include "nessie.secretToEnv" (list $secret "username" (printf "quarkus.datasource.%s.username" $dbKind) false .)>:
error calling include: template: nessie/charts/nessie/templates/_helpers.tpl:339:15: executing "nessie.secretToEnv" at <index . 5>: error calling index: reflect: slice index out of range
```

I think the update to `secretToEnv` missed also updating those secrets that are not related to the catalog, specifically those `quarkus.datasource` environment variables in the deployment. I have fixed it as in this PR, by restoring the previous behavior of `secretToEnv` by adding a new template `secretKeyToEnv`, and using it in `deployment.yaml`.

I don't know if this is the best approach to fix this, but it solves the most immediate issue.

Could you please take a look if possible?

Thanks a lot!