### PR TITLE
Postgres tests: use alpine-based Docker images

### DIFF
--- a/gc/gc-repository-jdbc/src/intTest/resources/org/projectnessie/gc/contents/jdbc/Dockerfile-postgres-version
+++ b/gc/gc-repository-jdbc/src/intTest/resources/org/projectnessie/gc/contents/jdbc/Dockerfile-postgres-version
@@ -1,3 +1,3 @@
 # Dockerfile to provide the image name and tag to a test.
 # Version is managed by Renovate - do not edit.
-FROM postgres:16.4
+FROM postgres:16.4-alpine

--- a/versioned/storage/jdbc-tests/src/main/resources/org/projectnessie/versioned/storage/jdbctests/Dockerfile-postgres-version
+++ b/versioned/storage/jdbc-tests/src/main/resources/org/projectnessie/versioned/storage/jdbctests/Dockerfile-postgres-version
@@ -1,3 +1,3 @@
 # Dockerfile to provide the image name and tag to a test.
 # Version is managed by Renovate - do not edit.
-FROM postgres:16.4
+FROM postgres:16.4-alpine

--- a/versioned/storage/jdbc2-tests/src/main/resources/org/projectnessie/versioned/storage/jdbc2tests/Dockerfile-postgres-version
+++ b/versioned/storage/jdbc2-tests/src/main/resources/org/projectnessie/versioned/storage/jdbc2tests/Dockerfile-postgres-version
@@ -1,3 +1,3 @@
 # Dockerfile to provide the image name and tag to a test.
 # Version is managed by Renovate - do not edit.
-FROM postgres:16.4
+FROM postgres:16.4-alpine


### PR DESCRIPTION
The images are roughly half the size.