### PR TITLE
Quarkus: fail on unknown config properties

### DIFF
--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -306,6 +306,10 @@ quarkus.log.category."io.quarkus.http.access-log".level=${HTTP_ACCESS_LOG_LEVEL:
 # Prevent the annoying Netty version mismatch (there's nothing we can do about it!)
 quarkus.log.category."com.azure.core.http.netty.implementation.Utility".level=ERROR
 
+# Verify that there are no properties that cannot be mapped to any @ConfigMapping.
+# This does not necessarily catch every property, only those that are in the "namespace" of any @ConfigMapping.
+quarkus.config.mapping.validate-unknown=true
+
 ## Quarkus http related settings
 quarkus.http.port=19120
 quarkus.http.test-port=0


### PR DESCRIPTION
This change is meant to add a layer of protecting against configuration mistakes by checking for configuration properties that cannot be mapped to any `@ConfigMapping`, but are within the "namespaces" of those.