### PR TITLE
Use `Tree`/`ContentService` in Catalog

### DIFF
--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/api/CatalogService.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/api/CatalogService.java
@@ -20,12 +20,14 @@ import java.net.URI;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.projectnessie.api.v2.params.ParsedReference;
 import org.projectnessie.catalog.model.snapshot.NessieEntitySnapshot;
 import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.Reference;
@@ -58,7 +60,10 @@ public interface CatalogService {
       throws NessieNotFoundException;
 
   CompletionStage<Stream<SnapshotResponse>> commit(
-      ParsedReference reference, CatalogCommit commit, SnapshotReqParams reqParams)
+      ParsedReference reference,
+      CatalogCommit commit,
+      SnapshotReqParams reqParams,
+      Function<String, CommitMeta> commitMetaBuilder)
       throws BaseNessieClientServerException;
 
   interface CatalogUriResolver {

--- a/catalog/service/impl/build.gradle.kts
+++ b/catalog/service/impl/build.gradle.kts
@@ -24,8 +24,9 @@ dependencies {
   implementation(project(":nessie-catalog-model"))
   implementation(project(":nessie-catalog-service-common"))
   implementation(project(":nessie-versioned-storage-common"))
-  implementation(project(":nessie-client"))
   implementation(project(":nessie-model"))
+  implementation(project(":nessie-services"))
+  implementation(project(":nessie-versioned-spi"))
   implementation(project(":nessie-tasks-api"))
   implementation(project(":nessie-tasks-service-async"))
 

--- a/catalog/service/impl/src/test/java/org/projectnessie/catalog/service/impl/TestCatalogServiceImpl.java
+++ b/catalog/service/impl/src/test/java/org/projectnessie/catalog/service/impl/TestCatalogServiceImpl.java
@@ -51,6 +51,7 @@ import org.projectnessie.catalog.service.api.SnapshotReqParams;
 import org.projectnessie.catalog.service.api.SnapshotResponse;
 import org.projectnessie.error.NessieReferenceConflictException;
 import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IcebergTable;
@@ -165,7 +166,7 @@ public class TestCatalogServiceImpl extends AbstractCatalogService {
         parsedReference(main.getName(), main.getHash(), Reference.ReferenceType.BRANCH);
     CatalogCommit commit = CatalogCommit.builder().build();
 
-    catalogService.commit(ref, commit).toCompletableFuture().get();
+    catalogService.commit(ref, commit, CommitMeta::fromMessage).toCompletableFuture().get();
 
     Reference afterCommit = api.getReference().refName("main").get();
     soft.assertThat(afterCommit).isEqualTo(main);

--- a/catalog/service/rest/build.gradle.kts
+++ b/catalog/service/rest/build.gradle.kts
@@ -30,8 +30,9 @@ dependencies {
   implementation(project(":nessie-catalog-files-api"))
   implementation(project(":nessie-catalog-secrets-api"))
   implementation(project(":nessie-model"))
-  implementation(project(":nessie-client"))
   implementation(project(":nessie-services-config"))
+  implementation(project(":nessie-services"))
+  implementation(project(":nessie-versioned-spi"))
   compileOnly(libs.smallrye.config.core)
 
   compileOnly(project(":nessie-immutables"))

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/AbstractCatalogResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/AbstractCatalogResource.java
@@ -20,6 +20,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.net.URLEncoder;
@@ -30,14 +31,18 @@ import org.projectnessie.catalog.service.api.CatalogService;
 import org.projectnessie.catalog.service.api.SnapshotReqParams;
 import org.projectnessie.catalog.service.api.SnapshotResponse;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.Reference;
+import org.projectnessie.services.rest.common.RestCommon;
 
 abstract class AbstractCatalogResource {
   @SuppressWarnings("CdiInjectionPointsInspection")
   @Inject
   CatalogService catalogService;
+
+  @Inject HttpHeaders httpHeaders;
 
   @Inject ObjectIO objectIO;
 
@@ -81,5 +86,9 @@ abstract class AbstractCatalogResource {
 
   static void nessieResponseHeaders(Reference reference, BiConsumer<String, String> header) {
     header.accept("Nessie-Reference", URLEncoder.encode(reference.toPathString(), UTF_8));
+  }
+
+  CommitMeta updateCommitMeta(String message) {
+    return RestCommon.updateCommitMeta(CommitMeta.builder().message(message), httpHeaders).build();
   }
 }

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1GenericResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1GenericResource.java
@@ -140,7 +140,8 @@ public class IcebergApiV1GenericResource extends IcebergApiV1ResourceBase {
     // Although we don't return anything, need to make sure that the commit operation starts and all
     // results are consumed.
     return Uni.createFrom()
-        .completionStage(catalogService.commit(ref, commit.build(), reqParams))
+        .completionStage(
+            catalogService.commit(ref, commit.build(), reqParams, this::updateCommitMeta))
         .map(stream -> stream.reduce(null, (ident, snap) -> ident, (i1, i2) -> i1));
   }
 }

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ViewResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ViewResource.java
@@ -25,7 +25,6 @@ import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpda
 import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.SetCurrentViewVersion.setCurrentViewVersion;
 import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.SetProperties.setProperties;
 import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.UpgradeFormatVersion.upgradeFormatVersion;
-import static org.projectnessie.model.CommitMeta.fromMessage;
 import static org.projectnessie.model.Content.Type.ICEBERG_VIEW;
 
 import io.smallrye.common.annotation.Blocking;
@@ -68,7 +67,9 @@ import org.projectnessie.model.Branch;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.ContentResponse;
 import org.projectnessie.model.IcebergView;
+import org.projectnessie.model.ImmutableOperations;
 import org.projectnessie.model.Operation.Delete;
+import org.projectnessie.model.Operations;
 
 /** Handles Iceberg REST API v1 endpoints that are associated with views. */
 @RequestScoped
@@ -154,12 +155,13 @@ public class IcebergApiV1ViewResource extends IcebergApiV1ResourceBase {
     ContentResponse resp = fetchIcebergView(tableRef, false);
     Branch ref = checkBranch(resp.getEffectiveReference());
 
-    nessieApi
-        .commitMultipleOperations()
-        .branch(ref)
-        .commitMeta(fromMessage(format("Drop ICEBERG_VIEW %s", tableRef.contentKey())))
-        .operation(Delete.of(tableRef.contentKey()))
-        .commitWithResponse();
+    Operations ops =
+        ImmutableOperations.builder()
+            .addOperations(Delete.of(tableRef.contentKey()))
+            .commitMeta(updateCommitMeta(format("Drop ICEBERG_VIEW %s", tableRef.contentKey())))
+            .build();
+
+    treeService.commitMultipleOperations(ref.getName(), ref.getHash(), ops);
   }
 
   private ContentResponse fetchIcebergView(TableRef tableRef, boolean forWrite)

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/NessieCatalogResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/NessieCatalogResource.java
@@ -124,7 +124,8 @@ public class NessieCatalogResource extends AbstractCatalogResource {
     SnapshotReqParams reqParams = forSnapshotHttpReq(reference, format, specVersion);
 
     return Uni.createFrom()
-        .completionStage(catalogService.commit(reference, commit, reqParams))
+        .completionStage(
+            catalogService.commit(reference, commit, reqParams, this::updateCommitMeta))
         .map(v -> Response.ok().build());
   }
 }

--- a/servers/quarkus-catalog/build.gradle.kts
+++ b/servers/quarkus-catalog/build.gradle.kts
@@ -19,7 +19,6 @@ plugins { id("nessie-conventions-quarkus") }
 publishingHelper { mavenName = "Nessie - Quarkus Catalog" }
 
 dependencies {
-  implementation(project(":nessie-combined-cs"))
   implementation(project(":nessie-rest-services"))
   implementation(project(":nessie-quarkus-config"))
   implementation(project(":nessie-catalog-files-api"))

--- a/servers/quarkus-catalog/src/main/java/org/projectnessie/server/catalog/CatalogProducers.java
+++ b/servers/quarkus-catalog/src/main/java/org/projectnessie/server/catalog/CatalogProducers.java
@@ -24,7 +24,6 @@ import io.quarkus.runtime.StartupEvent;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.context.SmallRyeManagedExecutor;
 import io.smallrye.context.SmallRyeThreadContext;
-import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Disposes;
@@ -72,16 +71,12 @@ import org.projectnessie.catalog.service.impl.IcebergExceptionMapper;
 import org.projectnessie.catalog.service.impl.IllegalArgumentExceptionMapper;
 import org.projectnessie.catalog.service.impl.NessieExceptionMapper;
 import org.projectnessie.catalog.service.impl.PreviousTaskExceptionMapper;
-import org.projectnessie.client.api.NessieApiV2;
-import org.projectnessie.nessie.combined.CombinedClientBuilder;
 import org.projectnessie.nessie.tasks.async.TasksAsync;
 import org.projectnessie.nessie.tasks.async.pool.JavaPoolTasksAsync;
 import org.projectnessie.nessie.tasks.async.wrapping.ThreadContextTasksAsync;
 import org.projectnessie.nessie.tasks.service.TasksServiceConfig;
 import org.projectnessie.nessie.tasks.service.impl.TasksServiceExecutor;
 import org.projectnessie.quarkus.config.CatalogServiceConfig;
-import org.projectnessie.services.rest.RestV2ConfigResource;
-import org.projectnessie.services.rest.RestV2TreeResource;
 import org.projectnessie.versioned.storage.common.config.StoreConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -328,15 +323,5 @@ public class CatalogProducers {
         (SmallRyeThreadContext) threadContext,
         executor,
         "import-jobs");
-  }
-
-  @Produces
-  @RequestScoped
-  public NessieApiV2 nessieApiV2(
-      RestV2ConfigResource configResource, RestV2TreeResource treeResource) {
-    return new CombinedClientBuilder()
-        .withConfigResource(configResource)
-        .withTreeResource(treeResource)
-        .build(NessieApiV2.class);
   }
 }

--- a/servers/rest-common/src/main/java/org/projectnessie/services/rest/common/RestCommon.java
+++ b/servers/rest-common/src/main/java/org/projectnessie/services/rest/common/RestCommon.java
@@ -16,12 +16,17 @@
 package org.projectnessie.services.rest.common;
 
 import com.google.common.base.Throwables;
+import jakarta.ws.rs.core.HttpHeaders;
+import java.util.Arrays;
+import java.util.Locale;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.projectnessie.error.ErrorCode;
 import org.projectnessie.error.ErrorCodeAware;
 import org.projectnessie.error.ImmutableNessieError;
 import org.projectnessie.error.NessieError;
 import org.projectnessie.error.NessieErrorDetails;
+import org.projectnessie.model.CommitMeta;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,5 +87,53 @@ public final class RestCommon {
     } catch (IllegalArgumentException e) {
       return false;
     }
+  }
+
+  public static CommitMeta.Builder updateCommitMeta(
+      CommitMeta.Builder commitMeta, HttpHeaders httpHeaders) {
+    httpHeaders
+        .getRequestHeaders()
+        .forEach(
+            (k, v) -> {
+              if (!v.isEmpty()) {
+                String lower = k.toLowerCase(Locale.ROOT);
+                switch (lower) {
+                  case "nessie-commit-message":
+                    v.stream()
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .findFirst()
+                        .ifPresent(commitMeta::message);
+                    break;
+                  case "nessie-commit-authors":
+                    v.stream()
+                        .flatMap(s -> Arrays.stream(s.split(",")))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .forEach(commitMeta::addAllAuthors);
+                    break;
+                  case "nessie-commit-signedoffby":
+                    v.stream()
+                        .flatMap(s -> Arrays.stream(s.split(",")))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .forEach(commitMeta::addAllSignedOffBy);
+                    break;
+                  default:
+                    if (lower.startsWith("nessie-commit-property-")) {
+                      String prop = lower.substring("nessie-commit-property-".length()).trim();
+                      commitMeta.putAllProperties(
+                          prop,
+                          v.stream()
+                              .map(String::trim)
+                              .filter(s -> !s.isEmpty())
+                              .collect(Collectors.toList()));
+                    }
+                    break;
+                }
+              }
+            });
+
+    return commitMeta;
   }
 }


### PR DESCRIPTION
This is a preparation to eventually have finer grained access checks from Nessie Catalog and an ability prevent "generic" commits via the core Nessie API.

With this change it becomes possible to call `Tree`/`ContentService` directly and add more information about the actual request being made, which can be used to pass that information down to `BatchAccessChecker`. This change plus #9546 eventually allow having access checks that can respect attributes like `SCHEMA_CHANGE` or `APPEND_FILES` or the like, and to distinguish such from requests via Nessie's own API, but that is something for a follow-up PR.