### PR TITLE
Richer access checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ as necessary. Empty sections will not end in the release notes.
 
 ### New Features
 
+- Access check SPI has been enhanced to provide richer information in the `Check` type about the receiving
+  API (Nessie REST or Iceberg REST) and about the individual changes, especially during a commit operation.
+
 ### Changes
 
 ### Deprecations

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/CatalogOps.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/CatalogOps.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.formats.iceberg.nessie;
+
+/**
+ * Enum serving as a "constants pool" for the string values passed to Nessie access control checks.
+ */
+public enum CatalogOps {
+  // Iceberg metadata updates
+  META_ADD_VIEW_VERSION,
+  META_SET_CURRENT_VIEW_VERSION,
+  META_SET_STATISTICS,
+  META_REMOVE_STATISTICS,
+  META_SET_PARTITION_STATISTICS,
+  META_REMOVE_PARTITION_STATISTICS,
+  META_ASSIGN_UUID,
+  META_ADD_SCHEMA,
+  META_SET_CURRENT_SCHEMA,
+  META_ADD_PARTITION_SPEC,
+  META_SET_DEFAULT_PARTITION_SPEC,
+  META_ADD_SNAPSHOT,
+  META_ADD_SORT_ORDER,
+  META_SET_DEFAULT_SORT_ORDER,
+  META_SET_LOCATION,
+  META_SET_PROPERTIES,
+  META_REMOVE_PROPERTIES,
+  META_REMOVE_LOCATION_PROPERTY,
+  META_SET_SNAPSHOT_REF,
+  META_REMOVE_SNAPSHOT_REF,
+  META_UPGRADE_FORMAT_VERSION,
+
+  // Catalog operations
+  CATALOG_CREATE_ENTITY,
+  CATALOG_UPDATE_ENTITY,
+  CATALOG_DROP_ENTITY,
+  CATALOG_RENAME_ENTITY_FROM,
+  CATALOG_RENAME_ENTITY_TO,
+  CATALOG_REGISTER_ENTITY,
+  CATALOG_UPDATE_MULTIPLE,
+  CATALOG_S3_SIGN,
+
+  // From Iceberg's snapshot summary
+  SNAP_ADD_DATA_FILES,
+  SNAP_DELETE_DATA_FILES,
+  SNAP_ADD_DELETE_FILES,
+  SNAP_ADD_EQUALITY_DELETE_FILES,
+  SNAP_ADD_POSITION_DELETE_FILES,
+  SNAP_REMOVE_DELETE_FILES,
+  SNAP_REMOVE_EQUALITY_DELETE_FILES,
+  SNAP_REMOVE_POSITION_DELETE_FILES,
+  SNAP_ADDED_RECORDS,
+  SNAP_DELETED_RECORDS,
+  SNAP_ADDED_POSITION_DELETES,
+  SNAP_DELETED_POSITION_DELETES,
+  SNAP_ADDED_EQUALITY_DELETES,
+  SNAP_DELETED_EQUALITY_DELETES,
+  SNAP_REPLACE_PARTITIONS,
+  SNAP_OP_APPEND,
+  SNAP_OP_REPLACE,
+  SNAP_OP_OVERWRITE,
+  SNAP_OP_DELETE,
+}

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/IcebergTableMetadataUpdateState.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/IcebergTableMetadataUpdateState.java
@@ -20,6 +20,7 @@ import static java.util.Collections.emptyMap;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -59,6 +60,7 @@ public class IcebergTableMetadataUpdateState {
   private final Set<Integer> addedSchemaIds = new HashSet<>();
   private final Set<Integer> addedSpecIds = new HashSet<>();
   private final Set<Integer> addedOrderIds = new HashSet<>();
+  private final Set<CatalogOps> catalogOps = EnumSet.noneOf(CatalogOps.class);
 
   public IcebergTableMetadataUpdateState(
       NessieTableSnapshot snapshot, ContentKey key, boolean tableExists) {
@@ -70,6 +72,14 @@ public class IcebergTableMetadataUpdateState {
 
   public NessieTableSnapshot.Builder builder() {
     return builder;
+  }
+
+  public void addCatalogOp(CatalogOps op) {
+    catalogOps.add(op);
+  }
+
+  public Set<CatalogOps> catalogOps() {
+    return catalogOps;
   }
 
   public NessieTableSnapshot snapshot() {

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/IcebergViewMetadataUpdateState.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/IcebergViewMetadataUpdateState.java
@@ -19,6 +19,7 @@ import static java.time.Instant.now;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -50,6 +51,7 @@ public class IcebergViewMetadataUpdateState {
   private final List<IcebergSnapshot> addedSnapshots = new ArrayList<>();
   private final Set<Integer> addedSchemaIds = new HashSet<>();
   private final Set<Long> addedVersionIds = new HashSet<>();
+  private final Set<CatalogOps> catalogOps = EnumSet.noneOf(CatalogOps.class);
 
   public IcebergViewMetadataUpdateState(
       NessieViewSnapshot snapshot, ContentKey key, boolean viewExists) {
@@ -61,6 +63,14 @@ public class IcebergViewMetadataUpdateState {
 
   public NessieViewSnapshot.Builder builder() {
     return builder;
+  }
+
+  public void addCatalogOp(CatalogOps op) {
+    catalogOps.add(op);
+  }
+
+  public Set<CatalogOps> catalogOps() {
+    return catalogOps;
   }
 
   public NessieViewSnapshot snapshot() {

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergMetadataUpdate.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergMetadataUpdate.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -46,6 +47,7 @@ import org.projectnessie.catalog.formats.iceberg.meta.IcebergSortOrder;
 import org.projectnessie.catalog.formats.iceberg.meta.IcebergStatisticsFile;
 import org.projectnessie.catalog.formats.iceberg.meta.IcebergViewRepresentation;
 import org.projectnessie.catalog.formats.iceberg.meta.IcebergViewVersion;
+import org.projectnessie.catalog.formats.iceberg.nessie.CatalogOps;
 import org.projectnessie.catalog.formats.iceberg.nessie.IcebergTableMetadataUpdateState;
 import org.projectnessie.catalog.formats.iceberg.nessie.IcebergViewMetadataUpdateState;
 import org.projectnessie.catalog.formats.iceberg.nessie.NessieModelIceberg;
@@ -130,11 +132,13 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_UPGRADE_FORMAT_VERSION);
       NessieModelIceberg.upgradeFormatVersion(formatVersion(), state.snapshot(), state.builder());
     }
 
     @Override
     default void applyToView(IcebergViewMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_UPGRADE_FORMAT_VERSION);
       NessieModelIceberg.upgradeFormatVersion(formatVersion(), state.snapshot(), state.builder());
     }
   }
@@ -165,11 +169,19 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_REMOVE_PROPERTIES);
+      if (removals().contains("location")) {
+        state.addCatalogOp(CatalogOps.META_REMOVE_LOCATION_PROPERTY);
+      }
       NessieModelIceberg.removeProperties(this, state.snapshot(), state.builder());
     }
 
     @Override
     default void applyToView(IcebergViewMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_REMOVE_PROPERTIES);
+      if (removals().contains("location")) {
+        state.addCatalogOp(CatalogOps.META_REMOVE_LOCATION_PROPERTY);
+      }
       NessieModelIceberg.removeProperties(this, state.snapshot(), state.builder());
     }
   }
@@ -184,6 +196,7 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToView(IcebergViewMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_ADD_VIEW_VERSION);
       NessieModelIceberg.addViewVersion(this, state);
     }
 
@@ -214,6 +227,7 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToView(IcebergViewMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_SET_CURRENT_VIEW_VERSION);
       NessieModelIceberg.setCurrentViewVersion(this, state);
     }
 
@@ -234,6 +248,7 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_SET_STATISTICS);
       long snapshotId = Objects.requireNonNull(state.snapshot().icebergSnapshotId());
       if (snapshotId == snapshotId()) {
         state.builder().statisticsFiles(singleton(icebergStatisticsFileToNessie(statistics())));
@@ -251,6 +266,7 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_REMOVE_STATISTICS);
       long snapshotId = Objects.requireNonNull(state.snapshot().icebergSnapshotId());
       if (snapshotId == snapshotId()) {
         state.builder().statisticsFiles(emptyList());
@@ -268,6 +284,7 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_SET_PARTITION_STATISTICS);
       long snapshotId = Objects.requireNonNull(state.snapshot().icebergSnapshotId());
       if (snapshotId == partitionStatistics().snapshotId()) {
         state
@@ -289,6 +306,7 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_REMOVE_PARTITION_STATISTICS);
       long snapshotId = Objects.requireNonNull(state.snapshot().icebergSnapshotId());
       if (snapshotId == snapshotId()) {
         state.builder().partitionStatisticsFiles(emptyList());
@@ -305,11 +323,13 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_ASSIGN_UUID);
       NessieModelIceberg.assignUUID(this, state.snapshot());
     }
 
     @Override
     default void applyToView(IcebergViewMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_ASSIGN_UUID);
       NessieModelIceberg.assignUUID(this, state.snapshot());
     }
 
@@ -329,11 +349,13 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_ADD_SCHEMA);
       NessieModelIceberg.addSchema(this, state);
     }
 
     @Override
     default void applyToView(IcebergViewMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_ADD_SCHEMA);
       NessieModelIceberg.addSchema(this, state);
     }
 
@@ -352,12 +374,14 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_SET_CURRENT_SCHEMA);
       NessieModelIceberg.setCurrentSchema(
           this, state.lastAddedSchemaId(), state.snapshot(), state.builder());
     }
 
     @Override
     default void applyToView(IcebergViewMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_SET_CURRENT_SCHEMA);
       NessieModelIceberg.setCurrentSchema(
           this, state.lastAddedSchemaId(), state.snapshot(), state.builder());
     }
@@ -376,6 +400,7 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_ADD_PARTITION_SPEC);
       NessieModelIceberg.addPartitionSpec(this, state);
     }
 
@@ -403,6 +428,7 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_SET_DEFAULT_PARTITION_SPEC);
       NessieModelIceberg.setDefaultPartitionSpec(this, state);
     }
 
@@ -420,6 +446,89 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_ADD_SNAPSHOT);
+      Map<String, String> summary = snapshot().summary();
+
+      String v = summary.get("added-data-files");
+      if (v != null && Long.parseLong(v) > 0) {
+        state.addCatalogOp(CatalogOps.SNAP_ADD_DATA_FILES);
+      }
+      v = summary.get("deleted-data-files");
+      if (v != null && Long.parseLong(v) > 0) {
+        state.addCatalogOp(CatalogOps.SNAP_DELETE_DATA_FILES);
+      }
+      v = summary.get("added-delete-files");
+      if (v != null && Long.parseLong(v) > 0) {
+        state.addCatalogOp(CatalogOps.SNAP_ADD_DELETE_FILES);
+      }
+      v = summary.get("added-equality-delete-files");
+      if (v != null && Long.parseLong(v) > 0) {
+        state.addCatalogOp(CatalogOps.SNAP_ADD_EQUALITY_DELETE_FILES);
+      }
+      v = summary.get("added-position-delete-files");
+      if (v != null && Long.parseLong(v) > 0) {
+        state.addCatalogOp(CatalogOps.SNAP_ADD_POSITION_DELETE_FILES);
+      }
+      v = summary.get("removed-delete-files");
+      if (v != null && Long.parseLong(v) > 0) {
+        state.addCatalogOp(CatalogOps.SNAP_REMOVE_DELETE_FILES);
+      }
+      v = summary.get("removed-equality-delete-files");
+      if (v != null && Long.parseLong(v) > 0) {
+        state.addCatalogOp(CatalogOps.SNAP_REMOVE_EQUALITY_DELETE_FILES);
+      }
+      v = summary.get("removed-position-delete-files");
+      if (v != null && Long.parseLong(v) > 0) {
+        state.addCatalogOp(CatalogOps.SNAP_REMOVE_POSITION_DELETE_FILES);
+      }
+      v = summary.get("added-records");
+      if (v != null && Long.parseLong(v) > 0) {
+        state.addCatalogOp(CatalogOps.SNAP_ADDED_RECORDS);
+      }
+      v = summary.get("deleted-records");
+      if (v != null && Long.parseLong(v) > 0) {
+        state.addCatalogOp(CatalogOps.SNAP_DELETED_RECORDS);
+      }
+      v = summary.get("added-position-deletes");
+      if (v != null && Long.parseLong(v) > 0) {
+        state.addCatalogOp(CatalogOps.SNAP_ADDED_POSITION_DELETES);
+      }
+      v = summary.get("deleted-position-deletes");
+      if (v != null && Long.parseLong(v) > 0) {
+        state.addCatalogOp(CatalogOps.SNAP_DELETED_POSITION_DELETES);
+      }
+      v = summary.get("added-equality-deletes");
+      if (v != null && Long.parseLong(v) > 0) {
+        state.addCatalogOp(CatalogOps.SNAP_ADDED_EQUALITY_DELETES);
+      }
+      v = summary.get("deleted-equality-deletes");
+      if (v != null && Long.parseLong(v) > 0) {
+        state.addCatalogOp(CatalogOps.SNAP_DELETED_EQUALITY_DELETES);
+      }
+      v = summary.get("replace-partitions");
+      if (Boolean.parseBoolean(v)) {
+        state.addCatalogOp(CatalogOps.SNAP_REPLACE_PARTITIONS);
+      }
+      v = summary.get("operation");
+      if (v != null) {
+        switch (v.toLowerCase(Locale.ROOT)) {
+          case "append":
+            state.addCatalogOp(CatalogOps.SNAP_OP_APPEND);
+            break;
+          case "replace":
+            state.addCatalogOp(CatalogOps.SNAP_OP_REPLACE);
+            break;
+          case "overwrite":
+            state.addCatalogOp(CatalogOps.SNAP_OP_OVERWRITE);
+            break;
+          case "delete":
+            state.addCatalogOp(CatalogOps.SNAP_OP_DELETE);
+            break;
+          default:
+            break;
+        }
+      }
+
       NessieModelIceberg.addSnapshot(this, state);
     }
   }
@@ -433,6 +542,7 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_ADD_SORT_ORDER);
       NessieModelIceberg.addSortOrder(this, state);
     }
 
@@ -466,6 +576,7 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_SET_DEFAULT_SORT_ORDER);
       NessieModelIceberg.setDefaultSortOrder(this, state);
     }
 
@@ -489,6 +600,7 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_SET_LOCATION);
       if (trusted()) {
         NessieModelIceberg.setLocation(this, state.builder());
       }
@@ -496,6 +608,7 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToView(IcebergViewMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_SET_LOCATION);
       if (trusted()) {
         NessieModelIceberg.setLocation(this, state.builder());
       }
@@ -516,11 +629,19 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_SET_PROPERTIES);
+      if (updates().containsKey("location")) {
+        state.addCatalogOp(CatalogOps.META_SET_LOCATION);
+      }
       NessieModelIceberg.setProperties(this, state.snapshot(), state.builder());
     }
 
     @Override
     default void applyToView(IcebergViewMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_SET_PROPERTIES);
+      if (updates().containsKey("location")) {
+        state.addCatalogOp(CatalogOps.META_SET_LOCATION);
+      }
       NessieModelIceberg.setProperties(this, state.snapshot(), state.builder());
     }
 
@@ -554,6 +675,7 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_SET_SNAPSHOT_REF);
       // NOP - This class is used for JSON deserialization only.
       // Nessie has catalog-level branches and tags.
     }
@@ -569,6 +691,7 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      state.addCatalogOp(CatalogOps.META_REMOVE_SNAPSHOT_REF);
       // NOP - This class is used for JSON deserialization only.
       // Nessie has catalog-level branches and tags.
     }

--- a/catalog/service/common/build.gradle.kts
+++ b/catalog/service/common/build.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
   implementation(project(":nessie-model"))
   implementation(project(":nessie-catalog-files-api"))
   implementation(project(":nessie-catalog-model"))
+  implementation(project(":nessie-services"))
+  implementation(project(":nessie-versioned-spi"))
   implementation(project(":nessie-versioned-storage-common"))
   implementation(project(":nessie-tasks-api"))
   implementation(project(":nessie-catalog-service-transfer"))

--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/api/CatalogService.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/api/CatalogService.java
@@ -31,6 +31,8 @@ import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.Reference;
+import org.projectnessie.services.authz.ApiContext;
+import org.projectnessie.versioned.RequestMeta;
 
 public interface CatalogService {
 
@@ -41,7 +43,8 @@ public interface CatalogService {
    *     more.
    * @param key content key of the table or view
    * @param expectedType The expected content-type.
-   * @param forWrite indicates whether access checks shall be performed for a write/update request
+   * @param requestMeta additional information for access checks
+   * @param apiContext
    * @return The response is either a response object or callback to produce the result. The latter
    *     is useful to return results that are quite big, for example Iceberg manifest lists or
    *     manifest files.
@@ -50,20 +53,25 @@ public interface CatalogService {
       SnapshotReqParams reqParams,
       ContentKey key,
       @Nullable Content.Type expectedType,
-      boolean forWrite)
+      RequestMeta requestMeta,
+      ApiContext apiContext)
       throws NessieNotFoundException;
 
   Stream<Supplier<CompletionStage<SnapshotResponse>>> retrieveSnapshots(
       SnapshotReqParams reqParams,
       List<ContentKey> keys,
-      Consumer<Reference> effectiveReferenceConsumer)
+      Consumer<Reference> effectiveReferenceConsumer,
+      RequestMeta requestMeta,
+      ApiContext apiContext)
       throws NessieNotFoundException;
 
   CompletionStage<Stream<SnapshotResponse>> commit(
       ParsedReference reference,
       CatalogCommit commit,
       SnapshotReqParams reqParams,
-      Function<String, CommitMeta> commitMetaBuilder)
+      Function<String, CommitMeta> commitMetaBuilder,
+      String apiRequest,
+      ApiContext apiContext)
       throws BaseNessieClientServerException;
 
   interface CatalogUriResolver {

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/AbstractCatalogResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/AbstractCatalogResource.java
@@ -16,6 +16,7 @@
 package org.projectnessie.catalog.service.rest;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.projectnessie.versioned.RequestMeta.API_READ;
 
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
@@ -35,6 +36,7 @@ import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.Reference;
+import org.projectnessie.services.authz.ApiContext;
 import org.projectnessie.services.rest.common.RestCommon;
 
 abstract class AbstractCatalogResource {
@@ -49,18 +51,25 @@ abstract class AbstractCatalogResource {
   @Context ExternalBaseUri uriInfo;
 
   Uni<Response> snapshotBased(
-      ContentKey key, SnapshotReqParams snapshotReqParams, Content.Type expectedType)
+      ContentKey key,
+      SnapshotReqParams snapshotReqParams,
+      Content.Type expectedType,
+      ApiContext apiContext)
       throws NessieNotFoundException {
-    return snapshotResponse(key, snapshotReqParams, expectedType)
+    return snapshotResponse(key, snapshotReqParams, expectedType, apiContext)
         .map(AbstractCatalogResource::snapshotToResponse);
   }
 
   Uni<SnapshotResponse> snapshotResponse(
-      ContentKey key, SnapshotReqParams snapshotReqParams, Content.Type expectedType)
+      ContentKey key,
+      SnapshotReqParams snapshotReqParams,
+      Content.Type expectedType,
+      ApiContext apiContext)
       throws NessieNotFoundException {
     return Uni.createFrom()
         .completionStage(
-            catalogService.retrieveSnapshot(snapshotReqParams, key, expectedType, false));
+            catalogService.retrieveSnapshot(
+                snapshotReqParams, key, expectedType, API_READ, apiContext));
   }
 
   private static Response snapshotToResponse(SnapshotResponse snapshot) {

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1GenericResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1GenericResource.java
@@ -16,6 +16,7 @@
 package org.projectnessie.catalog.service.rest;
 
 import static java.util.Objects.requireNonNull;
+import static org.projectnessie.catalog.formats.iceberg.nessie.CatalogOps.CATALOG_UPDATE_MULTIPLE;
 import static org.projectnessie.model.Content.Type.ICEBERG_TABLE;
 
 import io.smallrye.common.annotation.Blocking;
@@ -160,7 +161,13 @@ public class IcebergApiV1GenericResource extends IcebergApiV1ResourceBase {
     // results are consumed.
     return Uni.createFrom()
         .completionStage(
-            catalogService.commit(ref, commit.build(), reqParams, this::updateCommitMeta))
+            catalogService.commit(
+                ref,
+                commit.build(),
+                reqParams,
+                this::updateCommitMeta,
+                CATALOG_UPDATE_MULTIPLE.name(),
+                ICEBERG_V1))
         .map(stream -> stream.reduce(null, (ident, snap) -> ident, (i1, i2) -> i1));
   }
 }

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ViewResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ViewResource.java
@@ -18,6 +18,9 @@ package org.projectnessie.catalog.service.rest;
 import static java.lang.String.format;
 import static java.util.UUID.randomUUID;
 import static org.projectnessie.catalog.formats.iceberg.meta.IcebergTableIdentifier.fromNessieContentKey;
+import static org.projectnessie.catalog.formats.iceberg.nessie.CatalogOps.CATALOG_CREATE_ENTITY;
+import static org.projectnessie.catalog.formats.iceberg.nessie.CatalogOps.CATALOG_DROP_ENTITY;
+import static org.projectnessie.catalog.formats.iceberg.nessie.CatalogOps.CATALOG_UPDATE_ENTITY;
 import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.AddSchema.addSchema;
 import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.AddViewVersion.addViewVersion;
 import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.AssignUUID.assignUUID;
@@ -26,6 +29,7 @@ import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpda
 import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.SetProperties.setProperties;
 import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.UpgradeFormatVersion.upgradeFormatVersion;
 import static org.projectnessie.model.Content.Type.ICEBERG_VIEW;
+import static org.projectnessie.versioned.RequestMeta.apiWrite;
 
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.mutiny.Uni;
@@ -74,6 +78,7 @@ import org.projectnessie.model.Operations;
 import org.projectnessie.services.authz.AccessContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
+import org.projectnessie.versioned.RequestMeta;
 import org.projectnessie.versioned.VersionStore;
 
 /** Handles Iceberg REST API v1 endpoints that are associated with views. */
@@ -138,7 +143,7 @@ public class IcebergApiV1ViewResource extends IcebergApiV1ResourceBase {
             .addRequirement(IcebergUpdateRequirement.AssertCreate.assertTableDoesNotExist())
             .build();
 
-    return createOrUpdateEntity(tableRef, updateTableReq, ICEBERG_VIEW)
+    return createOrUpdateEntity(tableRef, updateTableReq, ICEBERG_VIEW, CATALOG_CREATE_ENTITY)
         .map(snap -> loadViewResultFromSnapshotResponse(snap, IcebergLoadViewResponse.builder()));
   }
 
@@ -180,7 +185,9 @@ public class IcebergApiV1ViewResource extends IcebergApiV1ResourceBase {
             .commitMeta(updateCommitMeta(format("Drop ICEBERG_VIEW %s", tableRef.contentKey())))
             .build();
 
-    treeService.commitMultipleOperations(ref.getName(), ref.getHash(), ops);
+    RequestMeta.RequestMetaBuilder requestMeta =
+        apiWrite().addKeyAction(tableRef.contentKey(), CATALOG_DROP_ENTITY.name());
+    treeService.commitMultipleOperations(ref.getName(), ref.getHash(), ops, requestMeta.build());
   }
 
   private ContentResponse fetchIcebergView(TableRef tableRef, boolean forWrite)
@@ -230,7 +237,8 @@ public class IcebergApiV1ViewResource extends IcebergApiV1ResourceBase {
     return snapshotResponse(
             key,
             SnapshotReqParams.forSnapshotHttpReq(tableRef.reference(), "iceberg", null),
-            ICEBERG_VIEW)
+            ICEBERG_VIEW,
+            ICEBERG_V1)
         .map(snap -> loadViewResultFromSnapshotResponse(snap, IcebergLoadViewResponse.builder()));
   }
 
@@ -272,7 +280,7 @@ public class IcebergApiV1ViewResource extends IcebergApiV1ResourceBase {
       throws IOException {
     TableRef tableRef = decodeTableRef(prefix, namespace, view);
 
-    return createOrUpdateEntity(tableRef, commitViewRequest, ICEBERG_VIEW)
+    return createOrUpdateEntity(tableRef, commitViewRequest, ICEBERG_VIEW, CATALOG_UPDATE_ENTITY)
         .map(
             snap -> {
               IcebergViewMetadata viewMetadata =

--- a/compatibility/jersey/src/main/java/org/projectnessie/tools/compatibility/jersey/AuthorizerExtension.java
+++ b/compatibility/jersey/src/main/java/org/projectnessie/tools/compatibility/jersey/AuthorizerExtension.java
@@ -24,6 +24,7 @@ import jakarta.enterprise.inject.spi.Extension;
 import java.util.function.Function;
 import org.projectnessie.services.authz.AbstractBatchAccessChecker;
 import org.projectnessie.services.authz.AccessContext;
+import org.projectnessie.services.authz.ApiContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.authz.BatchAccessChecker;
 
@@ -33,7 +34,7 @@ public class AuthorizerExtension implements Extension {
   private final Authorizer authorizer =
       new Authorizer() {
         @Override
-        public BatchAccessChecker startAccessCheck(AccessContext context) {
+        public BatchAccessChecker startAccessCheck(AccessContext context, ApiContext apiContext) {
           if (accessCheckerSupplier == null) {
             return AbstractBatchAccessChecker.NOOP_ACCESS_CHECKER;
           }

--- a/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/AuthorizerExtension.java
+++ b/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/AuthorizerExtension.java
@@ -24,6 +24,7 @@ import jakarta.enterprise.inject.spi.Extension;
 import java.util.function.Function;
 import org.projectnessie.services.authz.AbstractBatchAccessChecker;
 import org.projectnessie.services.authz.AccessContext;
+import org.projectnessie.services.authz.ApiContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.authz.BatchAccessChecker;
 
@@ -33,7 +34,7 @@ public class AuthorizerExtension implements Extension {
   private final Authorizer authorizer =
       new Authorizer() {
         @Override
-        public BatchAccessChecker startAccessCheck(AccessContext context) {
+        public BatchAccessChecker startAccessCheck(AccessContext context, ApiContext apiContext) {
           if (accessCheckerSupplier == null) {
             return AbstractBatchAccessChecker.NOOP_ACCESS_CHECKER;
           }

--- a/servers/quarkus-auth/src/main/java/org/projectnessie/server/authz/CelAuthorizer.java
+++ b/servers/quarkus-auth/src/main/java/org/projectnessie/server/authz/CelAuthorizer.java
@@ -18,6 +18,7 @@ package org.projectnessie.server.authz;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import org.projectnessie.services.authz.AccessContext;
+import org.projectnessie.services.authz.ApiContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.authz.AuthorizerType;
 import org.projectnessie.services.authz.BatchAccessChecker;
@@ -33,7 +34,7 @@ public class CelAuthorizer implements Authorizer {
   }
 
   @Override
-  public BatchAccessChecker startAccessCheck(AccessContext context) {
-    return new CelBatchAccessChecker(compiledRules, context);
+  public BatchAccessChecker startAccessCheck(AccessContext context, ApiContext apiContext) {
+    return new CelBatchAccessChecker(compiledRules, context, apiContext);
   }
 }

--- a/servers/quarkus-auth/src/main/java/org/projectnessie/server/authz/CelBatchAccessChecker.java
+++ b/servers/quarkus-auth/src/main/java/org/projectnessie/server/authz/CelBatchAccessChecker.java
@@ -15,6 +15,15 @@
  */
 package org.projectnessie.server.authz;
 
+import static org.projectnessie.services.cel.CELUtil.VAR_ACTIONS;
+import static org.projectnessie.services.cel.CELUtil.VAR_API;
+import static org.projectnessie.services.cel.CELUtil.VAR_CONTENT_TYPE;
+import static org.projectnessie.services.cel.CELUtil.VAR_OP;
+import static org.projectnessie.services.cel.CELUtil.VAR_PATH;
+import static org.projectnessie.services.cel.CELUtil.VAR_REF;
+import static org.projectnessie.services.cel.CELUtil.VAR_ROLE;
+import static org.projectnessie.services.cel.CELUtil.VAR_ROLES;
+
 import java.security.Principal;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -27,6 +36,7 @@ import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.RepositoryConfig;
 import org.projectnessie.services.authz.AbstractBatchAccessChecker;
 import org.projectnessie.services.authz.AccessContext;
+import org.projectnessie.services.authz.ApiContext;
 import org.projectnessie.services.authz.BatchAccessChecker;
 import org.projectnessie.services.authz.Check;
 import org.projectnessie.versioned.NamedRef;
@@ -39,7 +49,9 @@ final class CelBatchAccessChecker extends AbstractBatchAccessChecker {
   private final CompiledAuthorizationRules compiledRules;
   private final AccessContext context;
 
-  CelBatchAccessChecker(CompiledAuthorizationRules compiledRules, AccessContext context) {
+  CelBatchAccessChecker(
+      CompiledAuthorizationRules compiledRules, AccessContext context, ApiContext apiContext) {
+    super(apiContext);
     this.compiledRules = compiledRules;
     this.context = context;
   }
@@ -81,17 +93,21 @@ final class CelBatchAccessChecker extends AbstractBatchAccessChecker {
     String roleName = roleName();
     Map<String, Object> arguments =
         Map.of(
-            "role",
+            VAR_ROLE,
             roleName,
-            "roles",
+            VAR_ROLES,
             roles(),
-            "op",
+            VAR_OP,
             check.type().name(),
-            "path",
+            VAR_ACTIONS,
+            check.actions(),
+            VAR_API,
+            getApiContext(),
+            VAR_PATH,
             "",
-            "ref",
+            VAR_REF,
             "",
-            "contentType",
+            VAR_CONTENT_TYPE,
             "");
 
     Supplier<String> errorMsgSupplier =

--- a/servers/quarkus-auth/src/main/java/org/projectnessie/server/authz/QuarkusAuthorizer.java
+++ b/servers/quarkus-auth/src/main/java/org/projectnessie/server/authz/QuarkusAuthorizer.java
@@ -23,6 +23,7 @@ import jakarta.inject.Inject;
 import org.projectnessie.server.config.QuarkusNessieAuthorizationConfig;
 import org.projectnessie.services.authz.AbstractBatchAccessChecker;
 import org.projectnessie.services.authz.AccessContext;
+import org.projectnessie.services.authz.ApiContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.authz.AuthorizerType;
 import org.projectnessie.services.authz.BatchAccessChecker;
@@ -53,12 +54,12 @@ public class QuarkusAuthorizer implements Authorizer {
 
       this.authorizer = authorizerInstance.get();
     } else {
-      this.authorizer = context -> AbstractBatchAccessChecker.NOOP_ACCESS_CHECKER;
+      this.authorizer = (context, apiContext) -> AbstractBatchAccessChecker.NOOP_ACCESS_CHECKER;
     }
   }
 
   @Override
-  public BatchAccessChecker startAccessCheck(AccessContext context) {
-    return this.authorizer.startAccessCheck(context);
+  public BatchAccessChecker startAccessCheck(AccessContext context, ApiContext apiContext) {
+    return this.authorizer.startAccessCheck(context, apiContext);
   }
 }

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -178,6 +178,8 @@ dependencies {
   testFixturesCompileOnly(libs.microprofile.openapi)
 
   testFixturesCompileOnly(project(":nessie-immutables"))
+  testCompileOnly(project(":nessie-immutables"))
+  testAnnotationProcessor(project(":nessie-immutables", configuration = "processor"))
   intTestCompileOnly(project(":nessie-immutables"))
   intTestAnnotationProcessor(project(":nessie-immutables", configuration = "processor"))
 

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/authz/MockedAuthorizer.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/authz/MockedAuthorizer.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.server.authz;
+
+import static org.projectnessie.server.authz.MockedAuthorizer.AuthzCheck.authzCheck;
+import static org.projectnessie.services.authz.Check.check;
+
+import jakarta.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import org.projectnessie.nessie.immutables.NessieImmutable;
+import org.projectnessie.services.authz.AbstractBatchAccessChecker;
+import org.projectnessie.services.authz.AccessContext;
+import org.projectnessie.services.authz.ApiContext;
+import org.projectnessie.services.authz.Authorizer;
+import org.projectnessie.services.authz.AuthorizerType;
+import org.projectnessie.services.authz.BatchAccessChecker;
+import org.projectnessie.services.authz.Check;
+
+@AuthorizerType("MOCKED")
+@Singleton
+public class MockedAuthorizer implements Authorizer {
+  private BiFunction<BatchAccessChecker, Collection<Check>, Map<Check, String>> responder =
+      (b, c) -> Map.of();
+  private final List<AuthzCheck> checks = new ArrayList<>();
+
+  @Override
+  public BatchAccessChecker startAccessCheck(AccessContext context, ApiContext apiContext) {
+    return new MockedBatchAccessChecker(context, apiContext);
+  }
+
+  public synchronized void setResponder(
+      BiFunction<BatchAccessChecker, Collection<Check>, Map<Check, String>> responder) {
+    this.responder = responder;
+  }
+
+  public synchronized void reset() {
+    checks.clear();
+    responder = (b, c) -> Map.of();
+  }
+
+  public synchronized List<AuthzCheck> checks() {
+    return List.copyOf(checks);
+  }
+
+  public List<AuthzCheck> checksWithoutIdentifiedKey() {
+    return checks().stream()
+        .map(
+            ac ->
+                authzCheck(
+                    ac.apiContext(),
+                    ac.checks().stream()
+                        .map(c -> check(c.type(), c.ref(), c.key(), c.actions()))
+                        .toList(),
+                    ac.response()))
+        .toList();
+  }
+
+  synchronized void addCheck(AuthzCheck authzCheck) {
+    checks.add(authzCheck);
+  }
+
+  public class MockedBatchAccessChecker extends AbstractBatchAccessChecker {
+    public final AccessContext context;
+
+    public MockedBatchAccessChecker(AccessContext context, ApiContext apiContext) {
+      super(apiContext);
+      this.context = context;
+    }
+
+    @Override
+    public Map<Check, String> check() {
+      var response = responder.apply(this, this.getChecks());
+      addCheck(authzCheck(getApiContext(), getChecks(), response));
+      return response;
+    }
+  }
+
+  @NessieImmutable
+  public interface AuthzCheck {
+    ApiContext apiContext();
+
+    Set<Check> checks();
+
+    Map<Check, String> response();
+
+    static AuthzCheck authzCheck(
+        ApiContext apiContext, Collection<Check> checks, Map<Check, String> response) {
+      return ImmutableAuthzCheck.of(apiContext, new LinkedHashSet<>(checks), response);
+    }
+  }
+}

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/authz/TestAuthzMeta.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/authz/TestAuthzMeta.java
@@ -1,0 +1,460 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.server.authz;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.projectnessie.server.authn.AuthenticationEnabledProfile.AUTH_CONFIG_OVERRIDES;
+import static org.projectnessie.server.authn.AuthenticationEnabledProfile.SECURITY_CONFIG;
+import static org.projectnessie.server.authz.MockedAuthorizer.AuthzCheck.authzCheck;
+import static org.projectnessie.server.catalog.IcebergCatalogTestCommon.WAREHOUSE_NAME;
+import static org.projectnessie.services.authz.ApiContext.apiContext;
+import static org.projectnessie.services.authz.Check.CheckType.CREATE_ENTITY;
+import static org.projectnessie.services.authz.Check.CheckType.DELETE_ENTITY;
+import static org.projectnessie.services.authz.Check.CheckType.READ_ENTITY_VALUE;
+import static org.projectnessie.services.authz.Check.CheckType.UPDATE_ENTITY;
+import static org.projectnessie.services.authz.Check.canCommitChangeAgainstReference;
+import static org.projectnessie.services.authz.Check.canReadContentKey;
+import static org.projectnessie.services.authz.Check.canReadEntries;
+import static org.projectnessie.services.authz.Check.canViewReference;
+import static org.projectnessie.services.authz.Check.check;
+
+import com.google.common.collect.ImmutableMap;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.types.Types;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.client.auth.BasicAuthenticationProvider;
+import org.projectnessie.error.NessieForbiddenException;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.Operation;
+import org.projectnessie.objectstoragemock.HeapStorageBucket;
+import org.projectnessie.quarkus.tests.profiles.BaseConfigProfile;
+import org.projectnessie.server.BaseClientAuthTest;
+import org.projectnessie.server.catalog.Catalogs;
+import org.projectnessie.server.catalog.S3UnitTestProfiles.S3UnitTestProfile;
+import org.projectnessie.services.authz.ApiContext;
+import org.projectnessie.services.authz.AuthorizerType;
+import org.projectnessie.services.authz.BatchAccessChecker;
+import org.projectnessie.services.authz.Check;
+import org.projectnessie.versioned.BranchName;
+
+@SuppressWarnings("resource") // api() returns an AutoCloseable
+@QuarkusTest
+@TestProfile(TestAuthzMeta.Profile.class)
+public class TestAuthzMeta extends BaseClientAuthTest {
+  @Inject
+  @AuthorizerType("MOCKED")
+  MockedAuthorizer mockedAuthorizer;
+
+  HeapStorageBucket heapStorageBucket;
+
+  private static final Catalogs CATALOGS = new Catalogs();
+
+  // Cannot use @ExtendWith(SoftAssertionsExtension.class) + @InjectSoftAssertions here, because
+  // of Quarkus class loading issues. See https://github.com/quarkusio/quarkus/issues/19814
+  protected final SoftAssertions soft = new SoftAssertions();
+
+  protected RESTCatalog catalog(Map<String, String> catalogOptions) {
+    return CATALOGS.getCatalog(catalogOptions);
+  }
+
+  @AfterAll
+  static void closeRestCatalog() throws Exception {
+    CATALOGS.close();
+  }
+
+  @AfterEach
+  void cleanup() {
+    // Cannot use @ExtendWith(SoftAssertionsExtension.class) + @InjectSoftAssertions here, because
+    // of Quarkus class loading issues. See https://github.com/quarkusio/quarkus/issues/19814
+    soft.assertAll();
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    mockedAuthorizer.reset();
+    heapStorageBucket.clear();
+  }
+
+  /**
+   * Verifies that the expected authz checks are issued with the right {@link ApiContext} and
+   * "actions".
+   */
+  @Test
+  public void icebergApiTable() {
+    var catalog =
+        catalog(
+            Map.of("http.header.Authorization", basicAuthorizationHeader("admin_user", "test123")));
+
+    var apiContext = apiContext("Iceberg", 1);
+    var branch = BranchName.of("main");
+
+    var myNamespaceIceberg = Namespace.of("iceberg_table");
+    var tableKey = ContentKey.of("iceberg_table", "table_foo");
+    var tableIdentifier = TableIdentifier.of(myNamespaceIceberg, "table_foo");
+
+    mockedAuthorizer.reset();
+    catalog.createNamespace(myNamespaceIceberg);
+    // no assertion, done in 'icebergApiNamespaces()'
+
+    var schema =
+        new Schema(
+            required(3, "id", Types.IntegerType.get()),
+            required(4, "data", Types.StringType.get()));
+    var spec = PartitionSpec.builderFor(schema).bucket("id", 16).build();
+
+    mockedAuthorizer.reset();
+    var props = new HashMap<String, String>();
+    catalog.createTable(tableIdentifier, schema, spec, "my://location", props);
+    soft.assertThat(mockedAuthorizer.checksWithoutIdentifiedKey())
+        .containsExactly(
+            // 'IcebergApiV1ResourceBase.createEntityVerifyNotExists'
+            authzCheck(
+                apiContext,
+                List.of(
+                    canViewReference(branch),
+                    canCommitChangeAgainstReference(branch),
+                    check(READ_ENTITY_VALUE, branch, tableKey),
+                    check(CREATE_ENTITY, branch, tableKey)),
+                Map.of()),
+            // 'CatalogServiceImpl.commit'
+            authzCheck(
+                apiContext,
+                List.of(
+                    canViewReference(branch),
+                    canCommitChangeAgainstReference(branch),
+                    check(READ_ENTITY_VALUE, branch, tableKey, Set.of("CATALOG_CREATE_ENTITY")),
+                    check(CREATE_ENTITY, branch, tableKey, Set.of("CATALOG_CREATE_ENTITY"))),
+                Map.of()),
+            // actual 'commit'
+            authzCheck(
+                apiContext,
+                List.of(
+                    canViewReference(branch),
+                    canCommitChangeAgainstReference(branch),
+                    check(
+                        CREATE_ENTITY,
+                        branch,
+                        tableKey,
+                        Set.of(
+                            "CATALOG_CREATE_ENTITY",
+                            "META_ADD_SORT_ORDER",
+                            "META_SET_DEFAULT_PARTITION_SPEC",
+                            "META_SET_CURRENT_SCHEMA",
+                            "META_UPGRADE_FORMAT_VERSION",
+                            "META_SET_PROPERTIES",
+                            "META_ASSIGN_UUID",
+                            "META_SET_LOCATION",
+                            "META_ADD_SCHEMA",
+                            "META_SET_DEFAULT_SORT_ORDER",
+                            "META_ADD_PARTITION_SPEC"))),
+                Map.of()));
+  }
+
+  /**
+   * Verifies that the expected authz checks are issued with the right {@link ApiContext} and
+   * "actions".
+   */
+  @Test
+  public void icebergApiNamespaces() {
+    var catalog =
+        catalog(
+            Map.of("http.header.Authorization", basicAuthorizationHeader("admin_user", "test123")));
+
+    var myNamespace = ContentKey.of("iceberg_namespaces");
+    var myNamespaceIceberg = Namespace.of("iceberg_namespaces");
+    var myNamespaceInner = ContentKey.of("iceberg_namespaces", "inner");
+    var myNamespaceIcebergInner = Namespace.of("iceberg_namespaces", "inner");
+
+    var apiContext = apiContext("Iceberg", 1);
+    var branch = BranchName.of("main");
+
+    mockedAuthorizer.reset();
+    soft.assertThat(catalog.dropNamespace(myNamespaceIceberg)).isFalse();
+    soft.assertThat(mockedAuthorizer.checksWithoutIdentifiedKey())
+        .containsExactly(
+            authzCheck( // 'getEntries' in 'IcebergApiV1NamespaceResource.dropNamespace'
+                apiContext, List.of(canReadEntries(branch)), Map.of()));
+
+    mockedAuthorizer.reset();
+    catalog.createNamespace(myNamespaceIceberg);
+    soft.assertThat(mockedAuthorizer.checksWithoutIdentifiedKey())
+        .containsExactly(
+            authzCheck(apiContext, List.of(canViewReference(branch)), Map.of()),
+            authzCheck( // 'commit'
+                apiContext,
+                List.of(
+                    canViewReference(branch),
+                    check(CREATE_ENTITY, branch, myNamespace, Set.of("CATALOG_CREATE_ENTITY")),
+                    canCommitChangeAgainstReference(branch)),
+                Map.of()));
+
+    var props = new HashMap<String, String>();
+    props.put("location", "my_location");
+    mockedAuthorizer.reset();
+    catalog.createNamespace(myNamespaceIcebergInner, props);
+    soft.assertThat(mockedAuthorizer.checksWithoutIdentifiedKey())
+        .containsExactly(
+            authzCheck(apiContext, List.of(canViewReference(branch)), Map.of()),
+            authzCheck( // 'commit'
+                apiContext,
+                List.of(
+                    canViewReference(branch),
+                    check(
+                        CREATE_ENTITY,
+                        branch,
+                        myNamespaceInner,
+                        Set.of(
+                            "META_SET_LOCATION", "CATALOG_CREATE_ENTITY", "META_SET_PROPERTIES")),
+                    canCommitChangeAgainstReference(branch)),
+                Map.of()));
+
+    var props2 = new HashMap<String, String>();
+    props2.put("a", "b");
+    mockedAuthorizer.reset();
+    catalog.setProperties(myNamespaceIceberg, props2);
+    soft.assertThat(mockedAuthorizer.checksWithoutIdentifiedKey())
+        .containsExactly(
+            authzCheck( // 'getMultipleContents' in 'IcebergApiV1NamespaceResource.updateProperties'
+                apiContext,
+                List.of(
+                    canViewReference(branch),
+                    check(UPDATE_ENTITY, branch, myNamespace),
+                    check(READ_ENTITY_VALUE, branch, myNamespace),
+                    canCommitChangeAgainstReference(branch)),
+                Map.of()),
+            authzCheck( // 'commit'
+                apiContext,
+                List.of(
+                    canViewReference(branch),
+                    canCommitChangeAgainstReference(branch),
+                    check(
+                        UPDATE_ENTITY,
+                        branch,
+                        myNamespace,
+                        Set.of("META_SET_PROPERTIES", "CATALOG_UPDATE_ENTITY"))),
+                Map.of()));
+
+    // not empty
+    mockedAuthorizer.reset();
+    soft.assertThatThrownBy(() -> catalog.dropNamespace(myNamespaceIceberg))
+        .isInstanceOf(AlreadyExistsException.class);
+    soft.assertThat(mockedAuthorizer.checksWithoutIdentifiedKey())
+        .containsExactly(
+            authzCheck( // 'getEntries' in 'IcebergApiV1NamespaceResource.dropNamespace'
+                apiContext,
+                List.of(
+                    canReadEntries(branch),
+                    canReadContentKey(branch, myNamespace),
+                    canReadContentKey(branch, myNamespaceInner)),
+                Map.of()));
+
+    mockedAuthorizer.reset();
+    catalog.dropNamespace(myNamespaceIcebergInner);
+    soft.assertThat(mockedAuthorizer.checksWithoutIdentifiedKey())
+        .containsExactly(
+            authzCheck( // 'getEntries' in 'IcebergApiV1NamespaceResource.dropNamespace'
+                apiContext,
+                List.of(canReadEntries(branch), canReadContentKey(branch, myNamespaceInner)),
+                Map.of()),
+            authzCheck( // 'commit'
+                apiContext,
+                List.of(
+                    canViewReference(branch),
+                    canCommitChangeAgainstReference(branch),
+                    check(DELETE_ENTITY, branch, myNamespaceInner, Set.of("CATALOG_DROP_ENTITY"))),
+                Map.of()));
+
+    mockedAuthorizer.reset();
+    catalog.dropNamespace(myNamespaceIceberg);
+    soft.assertThat(mockedAuthorizer.checksWithoutIdentifiedKey())
+        .containsExactly(
+            authzCheck( // 'getEntries' in 'IcebergApiV1NamespaceResource.dropNamespace'
+                apiContext,
+                List.of(canReadEntries(branch), canReadContentKey(branch, myNamespace)),
+                Map.of()),
+            authzCheck( // 'commit'
+                apiContext,
+                List.of(
+                    canViewReference(branch),
+                    canCommitChangeAgainstReference(branch),
+                    check(DELETE_ENTITY, branch, myNamespace, Set.of("CATALOG_DROP_ENTITY"))),
+                Map.of()));
+  }
+
+  /** Verifies that the expected authz checks are issued with the right {@link ApiContext}. */
+  @Test
+  public void nessieApi() throws Exception {
+    withClientCustomizer(
+        c -> c.withAuthentication(BasicAuthenticationProvider.create("admin_user", "test123")));
+    soft.assertThat(api().getAllReferences().stream()).isNotEmpty();
+
+    // Verify that the ApiContext is correctly set
+    soft.assertThat(mockedAuthorizer.checks())
+        .containsExactly(
+            authzCheck(
+                apiContext("Nessie", 2),
+                List.of(canViewReference(BranchName.of("main"))),
+                Map.of()));
+  }
+
+  /**
+   * Simulates how an authorizer implementation can disallow creating/updating Iceberg entities via
+   * the Nessie API, but allow those via Iceberg, leveraging the {@code ApiContext}.
+   */
+  @Test
+  public void commitFailWithNessieSucceedWithIceberg() {
+    withClientCustomizer(
+        c -> c.withAuthentication(BasicAuthenticationProvider.create("admin_user", "test123")));
+
+    var catalog =
+        catalog(
+            Map.of("http.header.Authorization", basicAuthorizationHeader("admin_user", "test123")));
+
+    var branch = BranchName.of("main");
+
+    var myNamespaceKey = ContentKey.of("commit_nessie_iceberg");
+    var myNamespaceIceberg = Namespace.of("commit_nessie_iceberg");
+    var tableKey = ContentKey.of("commit_nessie_iceberg", "table_foo");
+    var tableIdentifier = TableIdentifier.of(myNamespaceIceberg, "table_foo");
+
+    var schema =
+        new Schema(
+            required(3, "id", Types.IntegerType.get()),
+            required(4, "data", Types.StringType.get()));
+    var spec = PartitionSpec.builderFor(schema).bucket("id", 16).build();
+
+    BiFunction<BatchAccessChecker, Collection<Check>, Map<Check, String>> responder =
+        (checker, checks) ->
+            checks.stream()
+                .filter(
+                    c ->
+                        (c.type() == CREATE_ENTITY || c.type() == UPDATE_ENTITY)
+                            && checker.getApiContext().getApiName().equals("Nessie"))
+                .collect(Collectors.toMap(Function.identity(), c -> "No no no"));
+
+    // Creating a namespace is forbidden for Nessie API
+    mockedAuthorizer.reset();
+    mockedAuthorizer.setResponder(responder);
+    soft.assertThatThrownBy(
+            () ->
+                api()
+                    .createNamespace()
+                    .refName(branch.getName())
+                    .namespace(org.projectnessie.model.Namespace.of(myNamespaceKey))
+                    .createWithResponse())
+        .isInstanceOf(NessieForbiddenException.class)
+        .hasMessageContaining("No no no");
+
+    // Creating a namespace is allowed for Iceberg API
+    mockedAuthorizer.reset();
+    mockedAuthorizer.setResponder(responder);
+    catalog.createNamespace(myNamespaceIceberg);
+
+    // Updating a namespace is forbidden for Nessie API
+    var props = new HashMap<String, String>();
+    props.put("foo", "bar");
+    mockedAuthorizer.reset();
+    mockedAuthorizer.setResponder(responder);
+    soft.assertThatThrownBy(
+            () ->
+                api()
+                    .updateProperties()
+                    .refName(branch.getName())
+                    .namespace(org.projectnessie.model.Namespace.of(myNamespaceKey))
+                    .updateProperties(props)
+                    .updateWithResponse())
+        .isInstanceOf(NessieForbiddenException.class)
+        .hasMessageContaining("No no no");
+
+    // Updating a namespace is allowed for Iceberg API
+    mockedAuthorizer.reset();
+    mockedAuthorizer.setResponder(responder);
+    catalog.setProperties(myNamespaceIceberg, props);
+
+    // Creating a table is forbidden for Nessie API
+    mockedAuthorizer.reset();
+    mockedAuthorizer.setResponder(responder);
+    soft.assertThatThrownBy(
+            () ->
+                api()
+                    .commitMultipleOperations()
+                    .branch(api().getDefaultBranch())
+                    .commitMeta(CommitMeta.fromMessage("attempt"))
+                    .operation(
+                        Operation.Put.of(tableKey, IcebergTable.of("ms://location", 1, 2, 3, 4)))
+                    .commitWithResponse())
+        .isInstanceOf(NessieForbiddenException.class)
+        .hasMessageContaining("No no no");
+
+    // Creating a table is allowed for Iceberg API
+    mockedAuthorizer.reset();
+    mockedAuthorizer.setResponder(responder);
+    catalog.createTable(tableIdentifier, schema, spec, "my://location", props);
+  }
+
+  public static class Profile extends S3UnitTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return ImmutableMap.<String, String>builder()
+          .putAll(super.getConfigOverrides())
+          .putAll(BaseConfigProfile.CONFIG_OVERRIDES)
+          .putAll(AUTH_CONFIG_OVERRIDES)
+          .putAll(SECURITY_CONFIG)
+          .put("quarkus.http.auth.basic", "true")
+          // Need a dummy URL to satisfy the Quarkus OIDC extension.
+          .put("quarkus.oidc.auth-server-url", "http://127.255.0.0:0/auth/realms/unset/")
+          //
+          .put("nessie.catalog.default-warehouse", WAREHOUSE_NAME)
+          .put(CatalogProperties.WAREHOUSE_LOCATION, WAREHOUSE_NAME)
+          //
+          .put("nessie.server.authorization.enabled", "true")
+          .put("nessie.server.authorization.type", "MOCKED")
+          .build();
+    }
+  }
+
+  public static String basicAuthorizationHeader(String username, String password) {
+    String userPass = username + ':' + password;
+    byte[] encoded = Base64.getEncoder().encode(userPass.getBytes(StandardCharsets.UTF_8));
+    String encodedString = new String(encoded, StandardCharsets.UTF_8);
+    return "Basic " + encodedString;
+  }
+}

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestApiContext.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestApiContext.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.services.rest;
+
+import org.projectnessie.services.authz.ApiContext;
+
+public final class RestApiContext {
+  private RestApiContext() {}
+
+  public static ApiContext NESSIE_V1 = ApiContext.apiContext("Nessie", 1);
+  public static ApiContext NESSIE_V2 = ApiContext.apiContext("Nessie", 2);
+}

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestConfigResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestConfigResource.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.services.rest;
 
+import static org.projectnessie.services.rest.RestApiContext.NESSIE_V1;
+
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -44,7 +46,7 @@ public class RestConfigResource implements HttpConfigApi {
   @Inject
   public RestConfigResource(
       ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
-    this.configService = new ConfigApiImpl(config, store, authorizer, accessContext, 1);
+    this.configService = new ConfigApiImpl(config, store, authorizer, accessContext, NESSIE_V1);
   }
 
   @Override

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestContentResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestContentResource.java
@@ -15,6 +15,9 @@
  */
 package org.projectnessie.services.rest;
 
+import static org.projectnessie.services.rest.RestApiContext.NESSIE_V1;
+import static org.projectnessie.versioned.RequestMeta.API_READ;
+
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -52,7 +55,7 @@ public class RestContentResource implements HttpContentApi {
   @Inject
   public RestContentResource(
       ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
-    this.contentService = new ContentApiImpl(config, store, authorizer, accessContext);
+    this.contentService = new ContentApiImpl(config, store, authorizer, accessContext, NESSIE_V1);
   }
 
   private ContentService resource() {
@@ -63,7 +66,7 @@ public class RestContentResource implements HttpContentApi {
   @JsonView(Views.V1.class)
   public Content getContent(ContentKey key, String ref, String hashOnRef)
       throws NessieNotFoundException {
-    return resource().getContent(key, ref, hashOnRef, false, false).getContent();
+    return resource().getContent(key, ref, hashOnRef, false, API_READ).getContent();
   }
 
   @Override
@@ -71,6 +74,7 @@ public class RestContentResource implements HttpContentApi {
   public GetMultipleContentsResponse getMultipleContents(
       String ref, String hashOnRef, GetMultipleContentsRequest request)
       throws NessieNotFoundException {
-    return resource().getMultipleContents(ref, hashOnRef, request.getRequestedKeys(), false, false);
+    return resource()
+        .getMultipleContents(ref, hashOnRef, request.getRequestedKeys(), false, API_READ);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestDiffResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestDiffResource.java
@@ -16,6 +16,7 @@
 package org.projectnessie.services.rest;
 
 import static org.projectnessie.services.impl.RefUtil.toReference;
+import static org.projectnessie.services.rest.RestApiContext.NESSIE_V1;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.enterprise.context.RequestScoped;
@@ -55,7 +56,7 @@ public class RestDiffResource implements HttpDiffApi {
   @Inject
   public RestDiffResource(
       ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
-    this.diffService = new DiffApiImpl(config, store, authorizer, accessContext);
+    this.diffService = new DiffApiImpl(config, store, authorizer, accessContext, NESSIE_V1);
   }
 
   private DiffService resource() {

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestNamespaceResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestNamespaceResource.java
@@ -15,6 +15,9 @@
  */
 package org.projectnessie.services.rest;
 
+import static org.projectnessie.services.rest.RestApiContext.NESSIE_V1;
+import static org.projectnessie.versioned.RequestMeta.API_WRITE;
+
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -57,7 +60,8 @@ public class RestNamespaceResource implements HttpNamespaceApi {
   @Inject
   public RestNamespaceResource(
       ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
-    this.namespaceService = new NamespaceApiImpl(config, store, authorizer, accessContext);
+    this.namespaceService =
+        new NamespaceApiImpl(config, store, authorizer, accessContext, NESSIE_V1);
   }
 
   private NamespaceService resource() {
@@ -68,7 +72,7 @@ public class RestNamespaceResource implements HttpNamespaceApi {
   @JsonView(Views.V1.class)
   public Namespace createNamespace(NamespaceParams params, Namespace namespace)
       throws NessieNamespaceAlreadyExistsException, NessieReferenceNotFoundException {
-    return resource().createNamespace(params.getRefName(), namespace);
+    return resource().createNamespace(params.getRefName(), namespace, API_WRITE);
   }
 
   @Override
@@ -105,6 +109,7 @@ public class RestNamespaceResource implements HttpNamespaceApi {
             params.getRefName(),
             params.getNamespace(),
             namespaceUpdate.getPropertyUpdates(),
-            namespaceUpdate.getPropertyRemovals());
+            namespaceUpdate.getPropertyRemovals(),
+            API_WRITE);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
@@ -17,7 +17,9 @@ package org.projectnessie.services.rest;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.projectnessie.services.impl.RefUtil.toReference;
+import static org.projectnessie.services.rest.RestApiContext.NESSIE_V1;
 import static org.projectnessie.services.spi.TreeService.MAX_COMMIT_LOG_ENTRIES;
+import static org.projectnessie.versioned.RequestMeta.API_WRITE;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.enterprise.context.RequestScoped;
@@ -73,7 +75,7 @@ public class RestTreeResource implements HttpTreeApi {
   @Inject
   public RestTreeResource(
       ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
-    this.treeService = new TreeApiImpl(config, store, authorizer, accessContext);
+    this.treeService = new TreeApiImpl(config, store, authorizer, accessContext, NESSIE_V1);
   }
 
   private TreeService resource() {
@@ -278,7 +280,7 @@ public class RestTreeResource implements HttpTreeApi {
       String branchName, String expectedHash, Operations operations)
       throws NessieNotFoundException, NessieConflictException {
     return resource()
-        .commitMultipleOperations(branchName, expectedHash, operations)
+        .commitMultipleOperations(branchName, expectedHash, operations, API_WRITE)
         .getTargetBranch();
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2ConfigResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2ConfigResource.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.services.rest;
 
+import static org.projectnessie.services.rest.RestApiContext.NESSIE_V2;
+
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -54,7 +56,7 @@ public class RestV2ConfigResource implements HttpConfigApi {
   @Inject
   public RestV2ConfigResource(
       ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
-    this.config = new ConfigApiImpl(config, store, authorizer, accessContext, 2);
+    this.config = new ConfigApiImpl(config, store, authorizer, accessContext, NESSIE_V2);
   }
 
   @Override

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
@@ -18,8 +18,11 @@ package org.projectnessie.services.rest;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.projectnessie.api.v2.params.ReferenceResolver.resolveReferencePathElement;
 import static org.projectnessie.services.impl.RefUtil.toReference;
+import static org.projectnessie.services.rest.RestApiContext.NESSIE_V2;
 import static org.projectnessie.services.rest.common.RestCommon.updateCommitMeta;
 import static org.projectnessie.services.spi.TreeService.MAX_COMMIT_LOG_ENTRIES;
+import static org.projectnessie.versioned.RequestMeta.API_READ;
+import static org.projectnessie.versioned.RequestMeta.API_WRITE;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.enterprise.context.RequestScoped;
@@ -102,10 +105,10 @@ public class RestV2TreeResource implements HttpTreeApi {
       Authorizer authorizer,
       AccessContext accessContext,
       HttpHeaders httpHeaders) {
-    this.configService = new ConfigApiImpl(config, store, authorizer, accessContext, 2);
-    this.treeService = new TreeApiImpl(config, store, authorizer, accessContext);
-    this.contentService = new ContentApiImpl(config, store, authorizer, accessContext);
-    this.diffService = new DiffApiImpl(config, store, authorizer, accessContext);
+    this.configService = new ConfigApiImpl(config, store, authorizer, accessContext, NESSIE_V2);
+    this.treeService = new TreeApiImpl(config, store, authorizer, accessContext, NESSIE_V2);
+    this.contentService = new ContentApiImpl(config, store, authorizer, accessContext, NESSIE_V2);
+    this.diffService = new DiffApiImpl(config, store, authorizer, accessContext, NESSIE_V2);
     this.httpHeaders = httpHeaders;
   }
 
@@ -356,7 +359,7 @@ public class RestV2TreeResource implements HttpTreeApi {
     ParsedReference reference = parseRefPathString(ref);
     return content()
         .getContent(
-            key, reference.name(), reference.hashWithRelativeSpec(), withDocumentation, forWrite);
+            key, reference.name(), reference.hashWithRelativeSpec(), withDocumentation, API_READ);
   }
 
   @JsonView(Views.V2.class)
@@ -381,7 +384,7 @@ public class RestV2TreeResource implements HttpTreeApi {
             reference.hashWithRelativeSpec(),
             request.getRequestedKeys(),
             withDocumentation,
-            forWrite);
+            API_READ);
   }
 
   @JsonView(Views.V2.class)
@@ -452,7 +455,8 @@ public class RestV2TreeResource implements HttpTreeApi {
             .commitMeta(commitMeta(CommitMeta.builder().from(operations.getCommitMeta())).build());
 
     ParsedReference ref = parseRefPathString(branch);
-    return tree().commitMultipleOperations(ref.name(), ref.hashWithRelativeSpec(), ops.build());
+    return tree()
+        .commitMultipleOperations(ref.name(), ref.hashWithRelativeSpec(), ops.build(), API_WRITE);
   }
 
   CommitMeta.Builder commitMeta(CommitMeta.Builder commitMeta) {

--- a/servers/services/src/main/java/org/projectnessie/services/authz/AbstractBatchAccessChecker.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/AbstractBatchAccessChecker.java
@@ -16,17 +16,19 @@
 package org.projectnessie.services.authz;
 
 import static java.util.Collections.emptyMap;
+import static org.projectnessie.services.authz.ApiContext.apiContext;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import org.projectnessie.model.IdentifiedContentKey;
 import org.projectnessie.model.RepositoryConfig;
 import org.projectnessie.versioned.NamedRef;
 
 public abstract class AbstractBatchAccessChecker implements BatchAccessChecker {
   public static final BatchAccessChecker NOOP_ACCESS_CHECKER =
-      new AbstractBatchAccessChecker() {
+      new AbstractBatchAccessChecker(apiContext("<unknown>", 0)) {
         @Override
         public Map<Check, String> check() {
           return emptyMap();
@@ -38,7 +40,17 @@ public abstract class AbstractBatchAccessChecker implements BatchAccessChecker {
         }
       };
 
+  private final ApiContext apiContext;
   private final Collection<Check> checks = new LinkedHashSet<>();
+
+  protected AbstractBatchAccessChecker(ApiContext apiContext) {
+    this.apiContext = apiContext;
+  }
+
+  @Override
+  public ApiContext getApiContext() {
+    return apiContext;
+  }
 
   protected Collection<Check> getChecks() {
     return checks;
@@ -85,6 +97,13 @@ public abstract class AbstractBatchAccessChecker implements BatchAccessChecker {
   }
 
   @Override
+  public BatchAccessChecker canReadContentKey(
+      NamedRef ref, IdentifiedContentKey identifiedKey, Set<String> actions) {
+    canViewReference(ref);
+    return can(Check.canReadContentKey(ref, identifiedKey, actions));
+  }
+
+  @Override
   public BatchAccessChecker canListCommitLog(NamedRef ref) {
     canViewReference(ref);
     return can(Check.canListCommitLog(ref));
@@ -103,10 +122,25 @@ public abstract class AbstractBatchAccessChecker implements BatchAccessChecker {
   }
 
   @Override
+  public BatchAccessChecker canReadEntityValue(
+      NamedRef ref, IdentifiedContentKey identifiedKey, Set<String> actions) {
+    canViewReference(ref);
+    return can(Check.canReadEntityValue(ref, identifiedKey, actions));
+  }
+
+  @Override
   @Deprecated
   public BatchAccessChecker canCreateEntity(NamedRef ref, IdentifiedContentKey identifiedKey) {
     canViewReference(ref);
     return can(Check.canCreateEntity(ref, identifiedKey));
+  }
+
+  @Override
+  @Deprecated
+  public BatchAccessChecker canCreateEntity(
+      NamedRef ref, IdentifiedContentKey identifiedKey, Set<String> actions) {
+    canViewReference(ref);
+    return can(Check.canCreateEntity(ref, identifiedKey, actions));
   }
 
   @Override
@@ -117,9 +151,24 @@ public abstract class AbstractBatchAccessChecker implements BatchAccessChecker {
   }
 
   @Override
+  @Deprecated
+  public BatchAccessChecker canUpdateEntity(
+      NamedRef ref, IdentifiedContentKey identifiedKey, Set<String> actions) {
+    canViewReference(ref);
+    return can(Check.canUpdateEntity(ref, identifiedKey, actions));
+  }
+
+  @Override
   public BatchAccessChecker canDeleteEntity(NamedRef ref, IdentifiedContentKey identifiedKey) {
     canViewReference(ref);
     return can(Check.canDeleteEntity(ref, identifiedKey));
+  }
+
+  @Override
+  public BatchAccessChecker canDeleteEntity(
+      NamedRef ref, IdentifiedContentKey identifiedKey, Set<String> actions) {
+    canViewReference(ref);
+    return can(Check.canDeleteEntity(ref, identifiedKey, actions));
   }
 
   @Override

--- a/servers/services/src/main/java/org/projectnessie/services/authz/ApiContext.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/ApiContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Dremio
+ * Copyright (C) 2024 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,16 @@
  */
 package org.projectnessie.services.authz;
 
-/**
- * Authorizers are used to bulk-check permissions.
- *
- * <p>Authorizers produce {@link BatchAccessChecker} instances, which collect all access checks
- * required for a certain version store operation and perform all access checks in a batch.
- */
-public interface Authorizer {
+import org.immutables.value.Value;
 
-  /**
-   * Start an access-check batch/bulk operation.
-   *
-   * @param context The context carrying the principal information.
-   * @param apiContext API contextual information
-   * @return access checker
-   */
-  BatchAccessChecker startAccessCheck(AccessContext context, ApiContext apiContext);
+@Value.Immutable
+@Value.Style(allParameters = true)
+public interface ApiContext {
+  String getApiName();
+
+  int getApiVersion();
+
+  static ApiContext apiContext(String apiName, int apiVersion) {
+    return ImmutableApiContext.of(apiName, apiVersion);
+  }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/authz/BatchAccessChecker.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/BatchAccessChecker.java
@@ -17,6 +17,7 @@ package org.projectnessie.services.authz;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Map;
+import java.util.Set;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.Detached;
@@ -53,6 +54,8 @@ public interface BatchAccessChecker {
    * @return map of failed checks or an empty collection, if all checks passed
    */
   Map<Check, String> check();
+
+  ApiContext getApiContext();
 
   /**
    * Convenience methods that throws an {@link AccessCheckException}, if {@link #check()} returns a
@@ -130,7 +133,12 @@ public interface BatchAccessChecker {
    *
    * @param ref current reference
    * @param identifiedKey content key / ID / type to check
+   * @param actions contextual information, API actions/operations performed
    */
+  @CanIgnoreReturnValue
+  BatchAccessChecker canReadContentKey(
+      NamedRef ref, IdentifiedContentKey identifiedKey, Set<String> actions);
+
   @CanIgnoreReturnValue
   BatchAccessChecker canReadContentKey(NamedRef ref, IdentifiedContentKey identifiedKey);
 
@@ -164,7 +172,12 @@ public interface BatchAccessChecker {
    *
    * @param ref The {@link NamedRef} to check
    * @param identifiedKey content key / ID / type to check
+   * @param actions contextual information, API actions/operations performed
    */
+  @CanIgnoreReturnValue
+  BatchAccessChecker canReadEntityValue(
+      NamedRef ref, IdentifiedContentKey identifiedKey, Set<String> actions);
+
   @CanIgnoreReturnValue
   BatchAccessChecker canReadEntityValue(NamedRef ref, IdentifiedContentKey identifiedKey);
 
@@ -177,7 +190,12 @@ public interface BatchAccessChecker {
    *
    * @param ref The {@link NamedRef} to check
    * @param identifiedKey content key / ID / type to check
+   * @param actions contextual information, API actions/operations performed
    */
+  @CanIgnoreReturnValue
+  BatchAccessChecker canCreateEntity(
+      NamedRef ref, IdentifiedContentKey identifiedKey, Set<String> actions);
+
   @CanIgnoreReturnValue
   BatchAccessChecker canCreateEntity(NamedRef ref, IdentifiedContentKey identifiedKey);
 
@@ -192,6 +210,10 @@ public interface BatchAccessChecker {
    * @param identifiedKey content key / ID / type to check
    */
   @CanIgnoreReturnValue
+  BatchAccessChecker canUpdateEntity(
+      NamedRef ref, IdentifiedContentKey identifiedKey, Set<String> actions);
+
+  @CanIgnoreReturnValue
   BatchAccessChecker canUpdateEntity(NamedRef ref, IdentifiedContentKey identifiedKey);
 
   /**
@@ -203,7 +225,12 @@ public interface BatchAccessChecker {
    *
    * @param ref The {@link NamedRef} to check
    * @param identifiedKey content key / ID / type to check
+   * @param actions contextual information, API actions/operations performed
    */
+  @CanIgnoreReturnValue
+  BatchAccessChecker canDeleteEntity(
+      NamedRef ref, IdentifiedContentKey identifiedKey, Set<String> actions);
+
   @CanIgnoreReturnValue
   BatchAccessChecker canDeleteEntity(NamedRef ref, IdentifiedContentKey identifiedKey);
 

--- a/servers/services/src/main/java/org/projectnessie/services/authz/Check.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/Check.java
@@ -16,6 +16,8 @@
 package org.projectnessie.services.authz;
 
 import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import java.util.Set;
 import org.immutables.value.Value;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
@@ -53,24 +55,43 @@ public interface Check {
   @Value.Parameter(order = 7)
   RepositoryConfig.Type repositoryConfigType();
 
+  @Value.Parameter(order = 8)
+  Set<String> actions();
+
   static Check check(CheckType type) {
-    return ImmutableCheck.of(type, null, null, null, null, null, null);
+    return ImmutableCheck.of(type, null, null, null, null, null, null, Set.of());
   }
 
   static Check check(CheckType type, RepositoryConfig.Type repositoryConfigType) {
-    return ImmutableCheck.of(type, null, null, null, null, null, repositoryConfigType);
+    return ImmutableCheck.of(type, null, null, null, null, null, repositoryConfigType, Set.of());
   }
 
   static Check check(CheckType type, @Nullable NamedRef ref) {
-    return ImmutableCheck.of(type, ref, null, null, null, null, null);
+    return ImmutableCheck.of(type, ref, null, null, null, null, null, Set.of());
   }
 
   static Check check(CheckType type, @Nullable NamedRef ref, @Nullable ContentKey key) {
-    return ImmutableCheck.of(type, ref, key, null, null, null, null);
+    return check(type, ref, key, Set.of());
+  }
+
+  static Check check(
+      CheckType type,
+      @Nullable NamedRef ref,
+      @Nullable ContentKey key,
+      @NotNull Set<String> actions) {
+    return ImmutableCheck.of(type, ref, key, null, null, null, null, actions);
   }
 
   static Check check(
       CheckType type, @Nullable NamedRef ref, @Nullable IdentifiedContentKey identifiedKey) {
+    return check(type, ref, identifiedKey, Set.of());
+  }
+
+  static Check check(
+      CheckType type,
+      @Nullable NamedRef ref,
+      @Nullable IdentifiedContentKey identifiedKey,
+      @NotNull Set<String> actions) {
     if (identifiedKey != null) {
       IdentifiedContentKey.IdentifiedElement element = identifiedKey.lastElement();
       return ImmutableCheck.of(
@@ -80,10 +101,11 @@ public interface Check {
           element.contentId(),
           identifiedKey.type(),
           identifiedKey,
-          null);
+          null,
+          actions);
     }
 
-    return ImmutableCheck.of(type, ref, null, null, null, null, null);
+    return ImmutableCheck.of(type, ref, null, null, null, null, null, actions);
   }
 
   static ImmutableCheck.Builder builder(CheckType type) {
@@ -167,8 +189,17 @@ public interface Check {
     return check(CheckType.READ_CONTENT_KEY, ref, key);
   }
 
+  static Check canReadContentKey(NamedRef ref, ContentKey key, Set<String> actions) {
+    return check(CheckType.READ_CONTENT_KEY, ref, key, actions);
+  }
+
   static Check canReadContentKey(NamedRef ref, IdentifiedContentKey identifiedKey) {
     return check(CheckType.READ_CONTENT_KEY, ref, identifiedKey);
+  }
+
+  static Check canReadContentKey(
+      NamedRef ref, IdentifiedContentKey identifiedKey, Set<String> actions) {
+    return check(CheckType.READ_CONTENT_KEY, ref, identifiedKey, actions);
   }
 
   static Check canListCommitLog(NamedRef ref) {
@@ -183,16 +214,36 @@ public interface Check {
     return check(CheckType.READ_ENTITY_VALUE, ref, identifiedKey);
   }
 
+  static Check canReadEntityValue(
+      NamedRef ref, IdentifiedContentKey identifiedKey, Set<String> actions) {
+    return check(CheckType.READ_ENTITY_VALUE, ref, identifiedKey, actions);
+  }
+
   static Check canCreateEntity(NamedRef ref, IdentifiedContentKey identifiedKey) {
     return check(CheckType.CREATE_ENTITY, ref, identifiedKey);
+  }
+
+  static Check canCreateEntity(
+      NamedRef ref, IdentifiedContentKey identifiedKey, Set<String> actions) {
+    return check(CheckType.CREATE_ENTITY, ref, identifiedKey, actions);
   }
 
   static Check canUpdateEntity(NamedRef ref, IdentifiedContentKey identifiedKey) {
     return check(CheckType.UPDATE_ENTITY, ref, identifiedKey);
   }
 
+  static Check canUpdateEntity(
+      NamedRef ref, IdentifiedContentKey identifiedKey, Set<String> actions) {
+    return check(CheckType.UPDATE_ENTITY, ref, identifiedKey, actions);
+  }
+
   static Check canDeleteEntity(NamedRef ref, IdentifiedContentKey identifiedKey) {
     return check(CheckType.DELETE_ENTITY, ref, identifiedKey);
+  }
+
+  static Check canDeleteEntity(
+      NamedRef ref, IdentifiedContentKey identifiedKey, Set<String> actions) {
+    return check(CheckType.DELETE_ENTITY, ref, identifiedKey, actions);
   }
 
   static Check canReadRepositoryConfig(RepositoryConfig.Type repositoryConfigType) {

--- a/servers/services/src/main/java/org/projectnessie/services/authz/RetriableAccessChecker.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/RetriableAccessChecker.java
@@ -29,19 +29,33 @@ import java.util.function.Supplier;
  */
 public final class RetriableAccessChecker {
   private final Supplier<BatchAccessChecker> validator;
+  private final ApiContext apiContext;
   private Collection<Check> validatedChecks;
   private Map<Check, String> result;
 
-  public RetriableAccessChecker(Supplier<BatchAccessChecker> validator) {
+  public RetriableAccessChecker(Supplier<BatchAccessChecker> validator, ApiContext apiContext) {
     Preconditions.checkNotNull(validator);
     this.validator = validator;
+    this.apiContext = apiContext;
   }
 
   public BatchAccessChecker newAttempt() {
-    return new Attempt();
+    return new Attempt(apiContext);
   }
 
   private class Attempt extends AbstractBatchAccessChecker {
+    private final ApiContext apiContext;
+
+    Attempt(ApiContext apiContext) {
+      super(apiContext);
+      this.apiContext = apiContext;
+    }
+
+    @Override
+    public ApiContext getApiContext() {
+      return apiContext;
+    }
+
     @Override
     public Map<Check, String> check() {
       // Shallow collection copy to ensure that we use what was current at the time of check

--- a/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
+++ b/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
@@ -50,6 +50,8 @@ public final class CELUtil {
   public static final String VAR_ROLE = "role";
   public static final String VAR_ROLES = "roles";
   public static final String VAR_OP = "op";
+  public static final String VAR_ACTIONS = "actions";
+  public static final String VAR_API = "api";
   public static final String VAR_OPERATIONS = "operations";
   public static final String VAR_CONTENT_TYPE = "contentType";
 

--- a/servers/services/src/main/java/org/projectnessie/services/impl/BaseApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/BaseApiImpl.java
@@ -34,6 +34,7 @@ import org.projectnessie.cel.tools.ScriptException;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.services.authz.AccessContext;
+import org.projectnessie.services.authz.ApiContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.authz.BatchAccessChecker;
 import org.projectnessie.services.config.ServerConfig;
@@ -47,14 +48,20 @@ public abstract class BaseApiImpl {
   private final VersionStore store;
   private final Authorizer authorizer;
   private final AccessContext accessContext;
+  private final ApiContext apiContext;
   private HashResolver hashResolver;
 
   protected BaseApiImpl(
-      ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
+      ServerConfig config,
+      VersionStore store,
+      Authorizer authorizer,
+      AccessContext accessContext,
+      ApiContext apiContext) {
     this.config = config;
     this.store = store;
     this.authorizer = authorizer;
     this.accessContext = accessContext;
+    this.apiContext = apiContext;
   }
 
   /**
@@ -104,6 +111,10 @@ public abstract class BaseApiImpl {
     return authorizer;
   }
 
+  protected ApiContext getApiContext() {
+    return apiContext;
+  }
+
   protected HashResolver getHashResolver() {
     if (hashResolver == null) {
       this.hashResolver = new HashResolver(config, store);
@@ -112,7 +123,7 @@ public abstract class BaseApiImpl {
   }
 
   protected BatchAccessChecker startAccessCheck() {
-    return getAuthorizer().startAccessCheck(accessContext);
+    return getAuthorizer().startAccessCheck(accessContext, apiContext);
   }
 
   protected MetadataRewriter<CommitMeta> commitMetaUpdate(

--- a/servers/services/src/main/java/org/projectnessie/services/impl/ConfigApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/ConfigApiImpl.java
@@ -26,6 +26,7 @@ import org.projectnessie.model.NessieConfiguration;
 import org.projectnessie.model.RepositoryConfig;
 import org.projectnessie.model.types.GenericRepositoryConfig;
 import org.projectnessie.services.authz.AccessContext;
+import org.projectnessie.services.authz.ApiContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.authz.BatchAccessChecker;
 import org.projectnessie.services.config.ServerConfig;
@@ -36,16 +37,13 @@ import org.projectnessie.versioned.VersionStore;
 
 public class ConfigApiImpl extends BaseApiImpl implements ConfigService {
 
-  private final int actualApiVersion;
-
   public ConfigApiImpl(
       ServerConfig config,
       VersionStore store,
       Authorizer authorizer,
       AccessContext accessContext,
-      int actualApiVersion) {
-    super(config, store, authorizer, accessContext);
-    this.actualApiVersion = actualApiVersion;
+      ApiContext apiContext) {
+    super(config, store, authorizer, accessContext, apiContext);
   }
 
   @Override
@@ -58,7 +56,7 @@ public class ConfigApiImpl extends BaseApiImpl implements ConfigService {
     return ImmutableNessieConfiguration.builder()
         .from(NessieConfiguration.getBuiltInConfig())
         .defaultBranch(defaultBranch)
-        .actualApiVersion(actualApiVersion)
+        .actualApiVersion(getApiContext().getApiVersion())
         .noAncestorHash(info.getNoAncestorHash())
         .repositoryCreationTimestamp(info.getRepositoryCreationTimestamp())
         .oldestPossibleCommitTimestamp(info.getOldestPossibleCommitTimestamp())

--- a/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
@@ -34,6 +34,7 @@ import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.DiffResponse.DiffEntry;
 import org.projectnessie.services.authz.AccessContext;
+import org.projectnessie.services.authz.ApiContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.authz.AuthzPaginationIterator;
 import org.projectnessie.services.authz.Check;
@@ -53,8 +54,12 @@ import org.projectnessie.versioned.paging.PaginationIterator;
 public class DiffApiImpl extends BaseApiImpl implements DiffService {
 
   public DiffApiImpl(
-      ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
-    super(config, store, authorizer, accessContext);
+      ServerConfig config,
+      VersionStore store,
+      Authorizer authorizer,
+      AccessContext accessContext,
+      ApiContext apiContext) {
+    super(config, store, authorizer, accessContext, apiContext);
   }
 
   @Override

--- a/servers/services/src/main/java/org/projectnessie/services/spi/ContentService.java
+++ b/servers/services/src/main/java/org/projectnessie/services/spi/ContentService.java
@@ -31,6 +31,7 @@ import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.ContentResponse;
 import org.projectnessie.model.GetMultipleContentsResponse;
 import org.projectnessie.services.authz.AccessCheckException;
+import org.projectnessie.versioned.RequestMeta;
 
 /**
  * Server-side interface to services managing the loading of content objects.
@@ -47,7 +48,7 @@ public interface ContentService {
    * @param namedRef name of the reference
    * @param hashOnRef optional, ID of the commit or a commit specification
    * @param withDocumentation unused, pass {@code false}
-   * @param forWrite if {@code false}, "natural" read access checks will be performed. If {@code
+   * @param requestMeta if {@code false}, "natural" read access checks will be performed. If {@code
    *     true}, update/create access checks will be performed in addition to the read access checks.
    * @return the content response, if the content object exists
    * @throws NessieNotFoundException if the content object or the reference does not exist
@@ -66,7 +67,7 @@ public interface ContentService {
               message = HASH_OR_RELATIVE_COMMIT_SPEC_MESSAGE)
           String hashOnRef,
       boolean withDocumentation,
-      boolean forWrite)
+      RequestMeta requestMeta)
       throws NessieNotFoundException;
 
   /**
@@ -76,7 +77,7 @@ public interface ContentService {
    * @param hashOnRef optional, ID of the commit or a commit specification
    * @param keys the keys of the content objects to retrieve
    * @param withDocumentation unused, pass {@code false}
-   * @param forWrite if {@code false}, "natural" read access checks will be performed. If {@code
+   * @param requestMeta if {@code false}, "natural" read access checks will be performed. If {@code
    *     true}, update/create access checks will be performed in addition to the read access checks.
    * @return the existing content objects
    * @throws NessieNotFoundException if the reference does not exist
@@ -92,8 +93,8 @@ public interface ContentService {
               regexp = HASH_OR_RELATIVE_COMMIT_SPEC_REGEX,
               message = HASH_OR_RELATIVE_COMMIT_SPEC_MESSAGE)
           String hashOnRef,
-      @Valid @Size @jakarta.validation.constraints.Size(min = 1) List<ContentKey> keys,
+      @Valid @Size @Size(min = 1) List<ContentKey> keys,
       boolean withDocumentation,
-      boolean forWrite)
+      RequestMeta requestMeta)
       throws NessieNotFoundException;
 }

--- a/servers/services/src/main/java/org/projectnessie/services/spi/NamespaceService.java
+++ b/servers/services/src/main/java/org/projectnessie/services/spi/NamespaceService.java
@@ -23,6 +23,7 @@ import org.projectnessie.error.NessieNamespaceNotFoundException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.GetNamespacesResponse;
 import org.projectnessie.model.Namespace;
+import org.projectnessie.versioned.RequestMeta;
 
 /**
  * Server-side interface to services managing namespaces.
@@ -32,14 +33,15 @@ import org.projectnessie.model.Namespace;
  */
 public interface NamespaceService {
 
-  Namespace createNamespace(String refName, Namespace namespace)
+  Namespace createNamespace(String refName, Namespace namespace, RequestMeta requestMeta)
       throws NessieNamespaceAlreadyExistsException, NessieReferenceNotFoundException;
 
   void updateProperties(
       String refName,
       Namespace namespaceToUpdate,
       Map<String, String> propertyUpdates,
-      Set<String> propertyRemovals)
+      Set<String> propertyRemovals,
+      RequestMeta requestMeta)
       throws NessieNamespaceNotFoundException, NessieReferenceNotFoundException;
 
   void deleteNamespace(String refName, Namespace namespaceToDelete)

--- a/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
+++ b/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
@@ -45,6 +45,7 @@ import org.projectnessie.model.Reference;
 import org.projectnessie.model.Reference.ReferenceType;
 import org.projectnessie.model.ReferenceHistoryResponse;
 import org.projectnessie.versioned.NamedRef;
+import org.projectnessie.versioned.RequestMeta;
 import org.projectnessie.versioned.WithHash;
 
 /**
@@ -201,6 +202,7 @@ public interface TreeService {
               regexp = HASH_OR_RELATIVE_COMMIT_SPEC_REGEX,
               message = HASH_OR_RELATIVE_COMMIT_SPEC_MESSAGE)
           String expectedHash,
-      @Valid Operations operations)
+      @Valid Operations operations,
+      @NotNull RequestMeta requestMeta)
       throws NessieNotFoundException, NessieConflictException;
 }

--- a/servers/services/src/test/java/org/projectnessie/services/authz/TestBatchAccessChecker.java
+++ b/servers/services/src/test/java/org/projectnessie/services/authz/TestBatchAccessChecker.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.Maps.immutableEntry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.projectnessie.services.authz.ApiContext.apiContext;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
@@ -139,7 +140,7 @@ public class TestBatchAccessChecker {
         checker.canReadEntries(c.ref());
         break;
       case READ_CONTENT_KEY:
-        checker.canReadContentKey(c.ref(), c.identifiedKey());
+        checker.canReadContentKey(c.ref(), c.identifiedKey(), c.actions());
         break;
       case ASSIGN_REFERENCE_TO_HASH:
         checker.canAssignRefToHash(c.ref());
@@ -151,16 +152,16 @@ public class TestBatchAccessChecker {
         checker.canCommitChangeAgainstReference(c.ref());
         break;
       case READ_ENTITY_VALUE:
-        checker.canReadEntityValue(c.ref(), c.identifiedKey());
+        checker.canReadEntityValue(c.ref(), c.identifiedKey(), c.actions());
         break;
       case CREATE_ENTITY:
-        checker.canCreateEntity(c.ref(), c.identifiedKey());
+        checker.canCreateEntity(c.ref(), c.identifiedKey(), c.actions());
         break;
       case UPDATE_ENTITY:
-        checker.canUpdateEntity(c.ref(), c.identifiedKey());
+        checker.canUpdateEntity(c.ref(), c.identifiedKey(), c.actions());
         break;
       case DELETE_ENTITY:
-        checker.canDeleteEntity(c.ref(), c.identifiedKey());
+        checker.canDeleteEntity(c.ref(), c.identifiedKey(), c.actions());
         break;
       case READ_REPOSITORY_CONFIG:
         checker.canReadRepositoryConfig(c.repositoryConfigType());
@@ -191,7 +192,7 @@ public class TestBatchAccessChecker {
 
   static BatchAccessChecker newAccessChecker(
       Function<Collection<Check>, Map<Check, String>> check) {
-    return new AbstractBatchAccessChecker() {
+    return new AbstractBatchAccessChecker(apiContext("Nessie", 1)) {
       @Override
       public Map<Check, String> check() {
         return check.apply(getChecks());

--- a/servers/services/src/test/java/org/projectnessie/services/impl/TestNamespaceApi.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/TestNamespaceApi.java
@@ -17,6 +17,8 @@ package org.projectnessie.services.impl;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.projectnessie.model.Namespace.Empty.EMPTY_NAMESPACE;
+import static org.projectnessie.services.authz.ApiContext.apiContext;
+import static org.projectnessie.versioned.RequestMeta.API_WRITE;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,8 +26,8 @@ public class TestNamespaceApi {
 
   @Test
   public void emptyNamespaceCreation() {
-    NamespaceApiImpl api = new NamespaceApiImpl(null, null, null, null);
-    assertThatThrownBy(() -> api.createNamespace("main", EMPTY_NAMESPACE))
+    NamespaceApiImpl api = new NamespaceApiImpl(null, null, null, null, apiContext("Nessie", 2));
+    assertThatThrownBy(() -> api.createNamespace("main", EMPTY_NAMESPACE, API_WRITE))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Namespace name must not be empty");
   }

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestAccessChecks.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestAccessChecks.java
@@ -27,12 +27,14 @@ import static org.projectnessie.model.FetchOption.ALL;
 import static org.projectnessie.model.FetchOption.MINIMAL;
 import static org.projectnessie.model.IdentifiedContentKey.IdentifiedElement.identifiedElement;
 import static org.projectnessie.model.MergeBehavior.NORMAL;
+import static org.projectnessie.services.authz.ApiContext.apiContext;
 import static org.projectnessie.services.authz.Check.canCommitChangeAgainstReference;
 import static org.projectnessie.services.authz.Check.canCreateEntity;
 import static org.projectnessie.services.authz.Check.canDeleteEntity;
 import static org.projectnessie.services.authz.Check.canReadEntityValue;
 import static org.projectnessie.services.authz.Check.canUpdateEntity;
 import static org.projectnessie.services.authz.Check.canViewReference;
+import static org.projectnessie.versioned.RequestMeta.API_READ;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
@@ -95,7 +97,7 @@ public abstract class AbstractTestAccessChecks extends BaseTestServiceImpl {
     Set<Check> checks = new HashSet<>();
     setBatchAccessChecker(
         c ->
-            new AbstractBatchAccessChecker() {
+            new AbstractBatchAccessChecker(apiContext("Nessie", 1)) {
               @Override
               public Map<Check, String> check() {
                 checks.addAll(getChecks());
@@ -416,7 +418,7 @@ public abstract class AbstractTestAccessChecks extends BaseTestServiceImpl {
 
     setBatchAccessChecker(
         x ->
-            new AbstractBatchAccessChecker() {
+            new AbstractBatchAccessChecker(apiContext("Nessie", 1)) {
               @Override
               public Map<Check, String> check() {
                 return getChecks().stream()
@@ -450,7 +452,7 @@ public abstract class AbstractTestAccessChecks extends BaseTestServiceImpl {
 
     setBatchAccessChecker(
         x ->
-            new AbstractBatchAccessChecker() {
+            new AbstractBatchAccessChecker(apiContext("Nessie", 1)) {
               @Override
               public Map<Check, String> check() {
                 getChecks()
@@ -474,7 +476,7 @@ public abstract class AbstractTestAccessChecks extends BaseTestServiceImpl {
   public void detachedRefAccessChecks() throws Exception {
 
     BatchAccessChecker accessChecker =
-        new AbstractBatchAccessChecker() {
+        new AbstractBatchAccessChecker(apiContext("Nessie", 1)) {
           @Override
           public Map<Check, String> check() {
             Map<Check, String> failed = new LinkedHashMap<>();
@@ -557,7 +559,7 @@ public abstract class AbstractTestAccessChecks extends BaseTestServiceImpl {
           .isInstanceOf(AccessCheckException.class)
           .hasMessageContaining(READ_MSG);
       soft.assertThatThrownBy(
-              () -> contentApi().getContent(key, ref.getName(), ref.getHash(), false, false))
+              () -> contentApi().getContent(key, ref.getName(), ref.getHash(), false, API_READ))
           .describedAs("ref='%s', getContent", ref)
           .isInstanceOf(AccessCheckException.class)
           .hasMessageContaining(ENTITIES_MSG);

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestCommitLog.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestCommitLog.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.projectnessie.model.CommitMeta.fromMessage;
 import static org.projectnessie.model.FetchOption.ALL;
 import static org.projectnessie.model.FetchOption.MINIMAL;
+import static org.projectnessie.versioned.RequestMeta.API_READ;
 
 import com.google.common.collect.ImmutableList;
 import java.time.Instant;
@@ -392,7 +393,9 @@ public abstract class AbstractTestCommitLog extends BaseTestServiceImpl {
       Put op;
       try {
         Content existing =
-            contentApi().getContent(key, branch.getName(), currentHash, false, false).getContent();
+            contentApi()
+                .getContent(key, branch.getName(), currentHash, false, API_READ)
+                .getContent();
         op = Put.of(key, IcebergTable.of("some-file-" + i, 42, 42, 42, 42, existing.getId()));
       } catch (NessieNotFoundException notFound) {
         op = Put.of(key, IcebergTable.of("some-file-" + i, 42, 42, 42, 42));

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestContents.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestContents.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.projectnessie.model.CommitMeta.fromMessage;
 import static org.projectnessie.model.FetchOption.ALL;
+import static org.projectnessie.versioned.RequestMeta.API_READ;
 
 import com.google.common.collect.Maps;
 import java.util.List;
@@ -293,7 +294,7 @@ public abstract class AbstractTestContents extends BaseTestServiceImpl {
       soft.assertThat(
               contentApi()
                   .getContent(
-                      fixedContentKey, committed.getName(), committed.getHash(), false, false))
+                      fixedContentKey, committed.getName(), committed.getHash(), false, API_READ))
           .extracting(ContentResponse::getContent)
           .extracting(this::clearIdOnContent)
           .isEqualTo(put.getContent());
@@ -320,7 +321,11 @@ public abstract class AbstractTestContents extends BaseTestServiceImpl {
               () ->
                   contentApi()
                       .getContent(
-                          fixedContentKey, committed.getName(), committed.getHash(), false, false))
+                          fixedContentKey,
+                          committed.getName(),
+                          committed.getHash(),
+                          false,
+                          API_READ))
           .isInstanceOf(NessieNotFoundException.class);
 
       // Compare operation on HEAD commit with the committed operation
@@ -343,7 +348,7 @@ public abstract class AbstractTestContents extends BaseTestServiceImpl {
       soft.assertThat(
               contentApi()
                   .getContent(
-                      fixedContentKey, committed.getName(), committed.getHash(), false, false))
+                      fixedContentKey, committed.getName(), committed.getHash(), false, API_READ))
           .extracting(ContentResponse::getContent)
           .extracting(this::clearIdOnContent)
           .isEqualTo(contentAndOperationType.prepare.getContent());

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestEntries.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestEntries.java
@@ -20,6 +20,7 @@ import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.projectnessie.model.CommitMeta.fromMessage;
+import static org.projectnessie.versioned.RequestMeta.API_WRITE;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -407,7 +408,8 @@ public abstract class AbstractTestEntries extends BaseTestServiceImpl {
       soft.assertThat(namespaceApi().getNamespace(reference.getName(), reference.getHash(), ns))
           .isNotNull();
 
-      soft.assertThatThrownBy(() -> namespaceApi().createNamespace(reference.getName(), ns))
+      soft.assertThatThrownBy(
+              () -> namespaceApi().createNamespace(reference.getName(), ns, API_WRITE))
           .cause()
           .isInstanceOf(NessieNamespaceAlreadyExistsException.class)
           .hasMessage(String.format("Namespace '%s' already exists", namespace));

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestInvalidRefs.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestInvalidRefs.java
@@ -17,6 +17,7 @@ package org.projectnessie.services.impl;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.projectnessie.model.FetchOption.MINIMAL;
+import static org.projectnessie.versioned.RequestMeta.API_READ;
 
 import org.junit.jupiter.api.Test;
 import org.projectnessie.error.BaseNessieClientServerException;
@@ -51,7 +52,7 @@ public abstract class AbstractTestInvalidRefs extends BaseTestServiceImpl {
             () ->
                 contentApi()
                     .getContent(
-                        ContentKey.of("table0"), branch.getName(), invalidHash, false, false))
+                        ContentKey.of("table0"), branch.getName(), invalidHash, false, API_READ))
         .isInstanceOf(NessieNotFoundException.class)
         .hasMessageContaining(String.format("Commit '%s' not found", invalidHash));
   }

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestMergeTransplant.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestMergeTransplant.java
@@ -28,6 +28,8 @@ import static org.projectnessie.model.FetchOption.MINIMAL;
 import static org.projectnessie.model.MergeBehavior.DROP;
 import static org.projectnessie.model.MergeBehavior.FORCE;
 import static org.projectnessie.model.MergeBehavior.NORMAL;
+import static org.projectnessie.versioned.RequestMeta.API_READ;
+import static org.projectnessie.versioned.RequestMeta.API_WRITE;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Collection;
@@ -159,7 +161,7 @@ public abstract class AbstractTestMergeTransplant extends BaseTestServiceImpl {
     table1 =
         (IcebergTable)
             contentApi()
-                .getContent(key1, committed1.getName(), committed1.getHash(), false, false)
+                .getContent(key1, committed1.getName(), committed1.getHash(), false, API_READ)
                 .getContent();
 
     Branch committed2 =
@@ -478,8 +480,8 @@ public abstract class AbstractTestMergeTransplant extends BaseTestServiceImpl {
     Namespace ns = Namespace.parse("a.b.c");
     base = ensureNamespacesForKeysExist(base, ns.toContentKey());
     branch = ensureNamespacesForKeysExist(branch, ns.toContentKey());
-    namespaceApi().createNamespace(base.getName(), ns);
-    namespaceApi().createNamespace(branch.getName(), ns);
+    namespaceApi().createNamespace(base.getName(), ns, API_WRITE);
+    namespaceApi().createNamespace(branch.getName(), ns, API_WRITE);
 
     base = (Branch) getReference(base.getName());
     branch = (Branch) getReference(branch.getName());
@@ -496,7 +498,7 @@ public abstract class AbstractTestMergeTransplant extends BaseTestServiceImpl {
     table1 =
         (IcebergTable)
             contentApi()
-                .getContent(key1, committed1.getName(), committed1.getHash(), false, false)
+                .getContent(key1, committed1.getName(), committed1.getHash(), false, API_READ)
                 .getContent();
 
     Branch committed2 =
@@ -664,7 +666,7 @@ public abstract class AbstractTestMergeTransplant extends BaseTestServiceImpl {
     ContentResponse tableOnRootAfterMerge =
         contentApi()
             .getContent(
-                setup.key, rootAfterMerge.getName(), rootAfterMerge.getHash(), false, false);
+                setup.key, rootAfterMerge.getName(), rootAfterMerge.getHash(), false, API_READ);
 
     soft.assertThat(setup.tableOnWork.getContent().getId())
         .isEqualTo(tableOnRootAfterMerge.getContent().getId());
@@ -729,7 +731,7 @@ public abstract class AbstractTestMergeTransplant extends BaseTestServiceImpl {
     soft.assertThat(root).isNotEqualTo(lastRoot);
 
     ContentResponse tableOnRoot =
-        contentApi().getContent(key, root.getName(), root.getHash(), false, false);
+        contentApi().getContent(key, root.getName(), root.getHash(), false, API_READ);
     soft.assertThat(tableOnRoot.getEffectiveReference()).isEqualTo(root);
 
     Branch work = createBranch("recreateBranch", root);
@@ -749,7 +751,7 @@ public abstract class AbstractTestMergeTransplant extends BaseTestServiceImpl {
     soft.assertThat(work).isNotEqualTo(lastWork);
 
     ContentResponse tableOnWork =
-        contentApi().getContent(key, work.getName(), work.getHash(), false, false);
+        contentApi().getContent(key, work.getName(), work.getHash(), false, API_READ);
     soft.assertThat(tableOnWork.getEffectiveReference()).isEqualTo(work);
 
     soft.assertThat(tableOnWork.getContent().getId())

--- a/site/in-dev/authorization.md
+++ b/site/in-dev/authorization.md
@@ -88,6 +88,80 @@ Certain variables are available within the `<rule_expression>` depending on cont
 * **path** - refers to the URI path representation (`ContentKey.toPathString()`) of the [content key](https://github.com/projectnessie/nessie/blob/main/api/model/src/main/java/org/projectnessie/model/ContentKey.java) for the object related to the authorization check.
 * **contentType** - refers to a (possibly empty) string representing the name of the object's [`Content.Type`](https://github.com/projectnessie/nessie/blob/main/api/model/src/main/java/org/projectnessie/model/Content.java).
 * **type** - refers to the repository config type to be retrieved or updated.
+* **api** - contains information about the receiving API. This is a composite object with two properties:
+  * **apiName** the name of the API, can be `Nessie` or `Iceberg`
+  * **apiVersion** the version of the API - for `Nessie` it can be 1 or 2, for `Iceberg` currently 1
+* **actions** a list of actions (strings), available for some Iceberg endpoints.
+
+#### Actions
+
+The list of `actions` (strings) is available for some Iceberg endpoints that perform changes against
+an entity (table, view, namespace). The list of actions is empty for the Nessie REST API.
+
+**Catalog operations**
+
+Available for all updating Iceberg endpoints
+for the `Check` types `CREATE_ENTITY`, `UPDATE_ENTITY` and `DELETE_ENTITY`.
+
+* `CATALOG_CREATE_ENTITY` - create a table/view/namespace
+* `CATALOG_UPDATE_ENTITY` - update a table/view/namespace
+* `CATALOG_DROP_ENTITY` - dropping a table/view/namespace
+* `CATALOG_RENAME_ENTITY_FROM` - renaming a table (from)
+* `CATALOG_RENAME_ENTITY_TO` - renaming a table (to)
+* `CATALOG_REGISTER_ENTITY` - registering a table (from)
+* `CATALOG_UPDATE_MULTIPLE` - update multiple tables
+* `CATALOG_S3_SIGN` - S3 request signing
+
+**Iceberg metadata updates**
+
+Available for Iceberg endpoints that update entities, represents the kinds of metadata updates,
+for the `Check` types `CREATE_ENTITY`, `UPDATE_ENTITY`.
+
+* `META_ADD_VIEW_VERSION`
+* `META_SET_CURRENT_VIEW_VERSION`
+* `META_SET_STATISTICS`
+* `META_REMOVE_STATISTICS`
+* `META_SET_PARTITION_STATISTICS`
+* `META_REMOVE_PARTITION_STATISTICS`
+* `META_ASSIGN_UUID`
+* `META_ADD_SCHEMA`
+* `META_SET_CURRENT_SCHEMA`
+* `META_ADD_PARTITION_SPEC`
+* `META_SET_DEFAULT_PARTITION_SPEC`
+* `META_ADD_SNAPSHOT`
+* `META_ADD_SORT_ORDER`
+* `META_SET_DEFAULT_SORT_ORDER`
+* `META_SET_LOCATION`
+* `META_SET_PROPERTIES`
+* `META_REMOVE_PROPERTIES`
+* `META_REMOVE_LOCATION_PROPERTY`
+* `META_SET_SNAPSHOT_REF`
+* `META_REMOVE_SNAPSHOT_REF`
+* `META_UPGRADE_FORMAT_VERSION`
+
+**from Iceberg's snapshot summary**
+
+Available for Iceberg updates that add a snapshot, for the `Check` types `CREATE_ENTITY`, `UPDATE_ENTITY`.
+
+* `SNAP_ADD_DATA_FILES`
+* `SNAP_DELETE_DATA_FILES`
+* `SNAP_ADD_DELETE_FILES`
+* `SNAP_ADD_EQUALITY_DELETE_FILES`
+* `SNAP_ADD_POSITION_DELETE_FILES`
+* `SNAP_REMOVE_DELETE_FILES`
+* `SNAP_REMOVE_EQUALITY_DELETE_FILES`
+* `SNAP_REMOVE_POSITION_DELETE_FILES`
+* `SNAP_ADDED_RECORDS`
+* `SNAP_DELETED_RECORDS`
+* `SNAP_ADDED_POSITION_DELETES`
+* `SNAP_DELETED_POSITION_DELETES`
+* `SNAP_ADDED_EQUALITY_DELETES`
+* `SNAP_DELETED_EQUALITY_DELETES`
+* `SNAP_REPLACE_PARTITIONS`
+* `SNAP_OP_APPEND`
+* `SNAP_OP_REPLACE`
+* `SNAP_OP_OVERWRITE`
+* `SNAP_OP_DELETE`
 
 #### Checks for Reference operations
 
@@ -100,12 +174,15 @@ Applicable `op` types:
 * `DELETE_REFERENCE`
 * `READ_ENTRIES`
 * `LIST_COMMIT_LOG`
+* `COMMIT_CHANGE_AGAINST_REFERENCE`
 
 Available variables:
 
 * `role`
 * `roles`
 * `ref`
+* `ref`
+* `api`
 
 #### Checks for Content operations
 
@@ -124,6 +201,8 @@ Available variables:
 * `ref`
 * `path`
 * `contentType`
+* `api`
+* `actions` (for `CREATE_ENTITY`, `UPDATE_ENTITY`, `DELETE_ENTITY` against Iceberg REST)
 
 #### Checks for Repository Config operations
 
@@ -137,6 +216,7 @@ Available variables:
 * `role`
 * `roles`
 * `type`
+* `api`
 
 #### Relevant CEL features
 

--- a/versioned/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedClientBuilder.java
+++ b/versioned/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedClientBuilder.java
@@ -16,12 +16,14 @@
 package org.projectnessie.nessie.combined;
 
 import static org.projectnessie.nessie.combined.EmptyHttpHeaders.emptyHttpHeaders;
+import static org.projectnessie.services.authz.ApiContext.apiContext;
 
 import org.projectnessie.client.NessieClientBuilder;
 import org.projectnessie.client.api.NessieApi;
 import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.services.authz.AbstractBatchAccessChecker;
 import org.projectnessie.services.authz.AccessContext;
+import org.projectnessie.services.authz.ApiContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.services.rest.RestV2ConfigResource;
@@ -38,6 +40,7 @@ public class CombinedClientBuilder extends NessieClientBuilder.AbstractNessieCli
   private Persist persist;
   private RestV2ConfigResource configResource;
   private RestV2TreeResource treeResource;
+  private ApiContext apiContext = apiContext("Nessie", 2);
 
   public CombinedClientBuilder() {}
 
@@ -63,6 +66,11 @@ public class CombinedClientBuilder extends NessieClientBuilder.AbstractNessieCli
 
   public CombinedClientBuilder withPersist(Persist persist) {
     this.persist = persist;
+    return this;
+  }
+
+  public CombinedClientBuilder withApiContext(ApiContext apiContext) {
+    this.apiContext = apiContext;
     return this;
   }
 
@@ -97,7 +105,7 @@ public class CombinedClientBuilder extends NessieClientBuilder.AbstractNessieCli
         };
 
     VersionStore versionStore = new VersionStoreImpl(persist);
-    Authorizer authorizer = c -> AbstractBatchAccessChecker.NOOP_ACCESS_CHECKER;
+    Authorizer authorizer = (c, apiContext) -> AbstractBatchAccessChecker.NOOP_ACCESS_CHECKER;
 
     AccessContext accessContext = () -> null;
 

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/RequestMeta.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/RequestMeta.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.immutables.value.Value;
+import org.projectnessie.model.ContentKey;
+
+/** Additional information related to the incoming API request. */
+@Value.Immutable
+@Value.Style(allParameters = true)
+public interface RequestMeta {
+  /** Indicates whether access checks shall be performed for a write/update request. */
+  boolean forWrite();
+
+  @Value.Default
+  default Map<ContentKey, Set<String>> keyActions() {
+    return Map.of();
+  }
+
+  default Set<String> keyActions(ContentKey key) {
+    return keyActions().getOrDefault(key, Set.of());
+  }
+
+  static RequestMetaBuilder apiWrite() {
+    return new RequestMetaBuilder().forWrite(true);
+  }
+
+  static RequestMetaBuilder apiRead() {
+    return new RequestMetaBuilder().forWrite(false);
+  }
+
+  RequestMeta API_WRITE = apiWrite().build();
+  RequestMeta API_READ = apiRead().build();
+
+  final class RequestMetaBuilder {
+    private final Map<ContentKey, Set<String>> keyActions = new HashMap<>();
+    private boolean forWrite;
+
+    public RequestMetaBuilder forWrite(boolean forWrite) {
+      this.forWrite = forWrite;
+      return this;
+    }
+
+    public RequestMetaBuilder addKeyAction(ContentKey key, String name) {
+      keyActions.computeIfAbsent(key, x -> new HashSet<>()).add(name);
+      return this;
+    }
+
+    public RequestMetaBuilder addKeyActions(ContentKey key, Set<String> names) {
+      keyActions.computeIfAbsent(key, x -> new HashSet<>()).addAll(names);
+      return this;
+    }
+
+    public RequestMetaBuilder newBuilder() {
+      RequestMetaBuilder newBuilder = new RequestMetaBuilder().forWrite(forWrite);
+      keyActions.forEach(newBuilder::addKeyActions);
+      return newBuilder;
+    }
+
+    public RequestMeta build() {
+      var immutableKeyActions = ImmutableMap.<ContentKey, Set<String>>builder();
+      keyActions.forEach((k, v) -> immutableKeyActions.put(k, Set.copyOf(v)));
+      return ImmutableRequestMeta.of(forWrite, immutableKeyActions.build());
+    }
+  }
+}


### PR DESCRIPTION
This change introduces the ability to distinguish individual checks by the (external) API being used (Nessie, Iceberg) and for Nessie Catalog (Iceberg REST) to information about the kind(s) of changes being applied.

The individual changes that can be distinguished are:
* Catalog API operation
* Metadata update actions, with special actions wrt to the `location` property
* Snapshot operation
* Snapshot summary extracts (for example whether a snapshot added or removed data/delete files)

All new attributes can be retrieved from the existing `Check` type via new attributes.

Fixes #9559 (and more)