### PR TITLE
MySQL/MariaDB: change from `BLOB` type to `LONGBLOB`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Highlights
 
+- Alert: If you are using MySQL or MariaDB, make sure to update `objs` table immediately:
+  ```sql
+  ALTER TABLE objs MODIFY c_headers LONGBLOB;
+  ALTER TABLE objs MODIFY c_incremental_index LONGBLOB;
+  ALTER TABLE objs MODIFY c_reference_index_stripes LONGBLOB;
+  ALTER TABLE objs MODIFY i_index LONGBLOB;
+  ALTER TABLE objs MODIFY i_stripes LONGBLOB;
+  ALTER TABLE objs MODIFY s_text LONGBLOB;
+  ALTER TABLE objs MODIFY t_headers LONGBLOB;
+  ALTER TABLE objs MODIFY t_signature LONGBLOB;
+  ALTER TABLE objs MODIFY u_value LONGBLOB;
+  ALTER TABLE objs MODIFY v_data LONGBLOB;
+  ALTER TABLE objs MODIFY x_data LONGBLOB;
+  ```
+
 ### Upgrade notes
 
 ### Breaking changes
@@ -19,6 +34,8 @@ as necessary. Empty sections will not end in the release notes.
 ### Deprecations
 
 ### Fixes
+
+- MySQL: Change type of binary columns from `BLOB` to `LONGBLOB`.
 
 ### Commits
 

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/DatabaseSpecifics.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/DatabaseSpecifics.java
@@ -192,7 +192,7 @@ public final class DatabaseSpecifics {
       typeIdMap.put(JdbcColumnType.OBJ_ID_LIST, Types.VARCHAR);
       typeMap.put(JdbcColumnType.BOOL, "BIT(1)");
       typeIdMap.put(JdbcColumnType.BOOL, Types.BIT);
-      typeMap.put(JdbcColumnType.VARBINARY, "BLOB");
+      typeMap.put(JdbcColumnType.VARBINARY, "LONGBLOB");
       typeIdMap.put(JdbcColumnType.VARBINARY, Types.BLOB);
       typeMap.put(JdbcColumnType.BIGINT, "BIGINT");
       typeIdMap.put(JdbcColumnType.BIGINT, Types.BIGINT);

--- a/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/DatabaseSpecifics.java
+++ b/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/DatabaseSpecifics.java
@@ -193,7 +193,7 @@ public final class DatabaseSpecifics {
       typeIdMap.put(Jdbc2ColumnType.OBJ_ID, Types.VARBINARY);
       typeMap.put(Jdbc2ColumnType.BOOL, "BIT(1)");
       typeIdMap.put(Jdbc2ColumnType.BOOL, Types.BIT);
-      typeMap.put(Jdbc2ColumnType.VARBINARY, "BLOB");
+      typeMap.put(Jdbc2ColumnType.VARBINARY, "LONGBLOB");
       typeIdMap.put(Jdbc2ColumnType.VARBINARY, Types.BLOB);
       typeMap.put(Jdbc2ColumnType.BIGINT, "BIGINT");
       typeIdMap.put(Jdbc2ColumnType.BIGINT, Types.BIGINT);


### PR DESCRIPTION
Unfortunately, the type for binary columns was set to `BLOB`, which is way too small (max 2^16 bytes = 64k). This change updates the type to `LONGBLOB`, which is max 4G, way more than we'll ever need.