### PR TITLE
Helm chart: fix Azure SAS token settings

### DIFF
--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/config/SecretsValidation.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/config/SecretsValidation.java
@@ -128,8 +128,7 @@ public abstract class SecretsValidation {
       AdlsFileSystemOptions fs, String name) {
     var failures = new ArrayList<SecretValidationFailure>();
     validateSecret(fs.account(), BASIC, List.of("adls", name, "account")).ifPresent(failures::add);
-    validateSecret(fs.sasToken(), EXPIRING_TOKEN, List.of("adls", name, "sasToken"))
-        .ifPresent(failures::add);
+    validateSecret(fs.sasToken(), KEY, List.of("adls", name, "sasToken")).ifPresent(failures::add);
     return failures;
   }
 

--- a/helm/nessie/templates/_helpers.tpl
+++ b/helm/nessie/templates/_helpers.tpl
@@ -311,12 +311,12 @@ Define environkent variables for catalog storage options.
 {{- end -}}
 {{ include "nessie.catalogSecretToEnv" (list .Values.catalog.storage.adls.defaultOptions.accountSecret "accountName" "adls.default-options.account" "name" true . ) }}
 {{- include "nessie.catalogSecretToEnv" (list .Values.catalog.storage.adls.defaultOptions.accountSecret "accountKey" "adls.default-options.account" "secret" false . ) }}
-{{- include "nessie.catalogSecretToEnv" (list .Values.catalog.storage.adls.defaultOptions.sasTokenSecret "sasToken" "adls.default-options.sas-token" "token" true . ) }}
+{{- include "nessie.catalogSecretToEnv" (list .Values.catalog.storage.adls.defaultOptions.sasTokenSecret "sasToken" "adls.default-options.sas-token" "key" true . ) }}
 {{- range $i, $filesystem := .Values.catalog.storage.adls.filesystems -}}
 {{- with $global }}
 {{- include "nessie.catalogSecretToEnv" (list $filesystem.accountSecret "accountName" (printf "adls.file-systems.filesystem%d.account" (add $i 1)) "name" true . ) }}
 {{- include "nessie.catalogSecretToEnv" (list $filesystem.accountSecret "accountKey" (printf "adls.file-systems.filesystem%d.account" (add $i 1)) "secret" false . ) }}
-{{- include "nessie.catalogSecretToEnv" (list $filesystem.sasTokenSecret "sasToken" (printf "adls.file-systems.filesystem%d.sas-token" (add $i 1)) "token" true . ) }}
+{{- include "nessie.catalogSecretToEnv" (list $filesystem.sasTokenSecret "sasToken" (printf "adls.file-systems.filesystem%d.sas-token" (add $i 1)) "key" true . ) }}
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Also fixes `SecretsValidation.validateAdlsFileSystem()`.