### PR TITLE
Derive `location` of new tables from parent namespaces, add some validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Changes
 
+- The base `location` of a new entity (e.g. tables) created via Iceberg REST is derived from the nearest
+  parent namespace that has an explicitly set `location` property. (Path separator character is `/`.)
+- The `location` property on tables (and view) created via Iceberg REST may be explicitly configured, as
+  long as it can be resolved against the configured object storage locations. (Path separator character
+  is `/`.)
+
 ### Deprecations
 
 ### Fixes

--- a/catalog/files/api/src/main/java/org/projectnessie/catalog/files/api/ObjectIO.java
+++ b/catalog/files/api/src/main/java/org/projectnessie/catalog/files/api/ObjectIO.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
 import org.projectnessie.storage.uri.StorageUri;
@@ -60,4 +61,11 @@ public interface ObjectIO {
       StorageUri warehouse,
       Map<String, String> icebergConfig,
       BiConsumer<String, String> properties);
+
+  /**
+   * Checks whether the given storage URI can be resolved.
+   *
+   * @return an empty optional, if the URI can be resolved, otherwise an error message.
+   */
+  Optional<String> canResolve(StorageUri uri);
 }

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/DelegatingObjectIO.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/DelegatingObjectIO.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
 import org.projectnessie.catalog.files.api.ObjectIO;
@@ -41,6 +42,16 @@ public abstract class DelegatingObjectIO implements ObjectIO {
   @Override
   public InputStream readObject(StorageUri uri) throws IOException {
     return resolve(uri).readObject(uri);
+  }
+
+  @Override
+  public Optional<String> canResolve(StorageUri uri) {
+    try {
+      ObjectIO resolved = resolve(uri);
+      return resolved.canResolve(uri);
+    } catch (IllegalArgumentException e) {
+      return Optional.of(e.getMessage());
+    }
   }
 
   @Override

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsClientSupplier.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsClientSupplier.java
@@ -84,10 +84,6 @@ public final class AdlsClientSupplier {
     return adlsOptions;
   }
 
-  SecretsProvider secretsProvider() {
-    return secretsProvider;
-  }
-
   public DataLakeFileClient fileClientForLocation(StorageUri uri) {
     AdlsLocation location = adlsLocation(uri);
 

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsObjectIO.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsObjectIO.java
@@ -117,6 +117,16 @@ public class AdlsObjectIO implements ObjectIO {
   }
 
   @Override
+  public Optional<String> canResolve(StorageUri uri) {
+    try {
+      DataLakeFileClient file = clientSupplier.fileClientForLocation(uri);
+      return file != null ? Optional.empty() : Optional.of("ADLS client could not be constructed");
+    } catch (IllegalArgumentException e) {
+      return Optional.of(e.getMessage());
+    }
+  }
+
+  @Override
   public void configureIcebergWarehouse(
       StorageUri warehouse,
       BiConsumer<String, String> defaultConfig,

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsObjectIO.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsObjectIO.java
@@ -158,6 +158,19 @@ public class GcsObjectIO implements ObjectIO {
   }
 
   @Override
+  public Optional<String> canResolve(StorageUri uri) {
+    try {
+      GcsLocation location = gcsLocation(uri);
+      GcsBucketOptions bucketOptions = storageSupplier.bucketOptions(location);
+      @SuppressWarnings("resource")
+      Storage client = storageSupplier.forLocation(bucketOptions);
+      return client != null ? Optional.empty() : Optional.of("GCS client could not be constructed");
+    } catch (IllegalArgumentException e) {
+      return Optional.of(e.getMessage());
+    }
+  }
+
+  @Override
   public void configureIcebergWarehouse(
       StorageUri warehouse,
       BiConsumer<String, String> defaultConfig,

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/local/LocalObjectIO.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/local/LocalObjectIO.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
 import org.projectnessie.catalog.files.api.ObjectIO;
@@ -96,6 +97,16 @@ public class LocalObjectIO implements ObjectIO {
       StorageUri warehouse,
       Map<String, String> icebergConfig,
       BiConsumer<String, String> properties) {}
+
+  @Override
+  public Optional<String> canResolve(StorageUri uri) {
+    Path path = LocalObjectIO.filePath(uri);
+    // We expect a directory here (or non-existing here), because the URI is meant to store other
+    // files
+    return Files.isRegularFile(path)
+        ? Optional.of(path + " does must not be file")
+        : Optional.empty();
+  }
 
   private static Path filePath(StorageUri uri) {
     return Paths.get(uri.requiredPath());

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3ObjectIO.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3ObjectIO.java
@@ -135,6 +135,23 @@ public class S3ObjectIO implements ObjectIO {
     }
   }
 
+  @Override
+  public Optional<String> canResolve(StorageUri uri) {
+    String scheme = uri.scheme();
+    if (!isS3scheme(scheme)) {
+      return Optional.of("Not an S3 URI");
+    }
+
+    try {
+      S3Client s3client = s3clientSupplier.getClient(uri);
+      return s3client != null
+          ? Optional.empty()
+          : Optional.of("S3 client could not be constructed");
+    } catch (IllegalArgumentException e) {
+      return Optional.of(e.getMessage());
+    }
+  }
+
   private static String withoutLeadingSlash(StorageUri uri) {
     String path = uri.requiredPath();
     return path.startsWith("/") ? path.substring(1) : path;

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/NessieModelIceberg.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/NessieModelIceberg.java
@@ -128,10 +128,8 @@ import org.projectnessie.catalog.model.statistics.NessieIcebergBlobMetadata;
 import org.projectnessie.catalog.model.statistics.NessiePartitionStatisticsFile;
 import org.projectnessie.catalog.model.statistics.NessieStatisticsFile;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.IcebergView;
-import org.projectnessie.model.Namespace;
 
 public class NessieModelIceberg {
   private NessieModelIceberg() {}
@@ -795,14 +793,8 @@ public class NessieModelIceberg {
    *
    * <p>Also: we deliberately ignore the TableProperties.WRITE_METADATA_LOCATION property here.
    */
-  public static String icebergBaseLocation(String warehouseLocation, ContentKey key) {
+  public static String icebergNewEntityBaseLocation(String baseLocation) {
     // FIXME escape or remove forbidden chars, cf. #8524
-    String baseLocation = warehouseLocation;
-    Namespace ns = key.getNamespace();
-    if (!ns.isEmpty()) {
-      baseLocation = concatLocation(warehouseLocation, ns.toString());
-    }
-    baseLocation = concatLocation(baseLocation, key.getName());
     return baseLocation + "_" + randomUUID();
   }
 

--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/api/CatalogService.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/api/CatalogService.java
@@ -18,6 +18,8 @@ package org.projectnessie.catalog.service.api;
 import jakarta.annotation.Nullable;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -25,6 +27,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.projectnessie.api.v2.params.ParsedReference;
 import org.projectnessie.catalog.model.snapshot.NessieEntitySnapshot;
+import org.projectnessie.catalog.service.config.WarehouseConfig;
 import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.CommitMeta;
@@ -32,6 +35,7 @@ import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.Reference;
 import org.projectnessie.services.authz.ApiContext;
+import org.projectnessie.storage.uri.StorageUri;
 import org.projectnessie.versioned.RequestMeta;
 
 public interface CatalogService {
@@ -78,4 +82,21 @@ public interface CatalogService {
     URI icebergSnapshot(
         Reference effectiveReference, ContentKey key, NessieEntitySnapshot<?> snapshot);
   }
+
+  Optional<String> validateStorageLocation(String location);
+
+  StorageUri locationForEntity(
+      WarehouseConfig warehouse,
+      ContentKey contentKey,
+      Content.Type contentType,
+      ApiContext apiContext,
+      String refName,
+      String hash)
+      throws NessieNotFoundException;
+
+  StorageUri locationForEntity(
+      WarehouseConfig warehouse,
+      ContentKey contentKey,
+      List<ContentKey> keysInOrder,
+      Map<ContentKey, Content> contentsMap);
 }

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1TableResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1TableResource.java
@@ -467,8 +467,15 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
           IcebergJson.objectMapper().readValue(metadataInput, IcebergTableMetadata.class);
     }
 
-    // TODO allow updating the "location" property, rely on AuthZ
-    // TODO verify the "location" can be mapped to a configured object-store
+    catalogService
+        .validateStorageLocation(tableMetadata.location())
+        .ifPresent(
+            msg -> {
+              throw new IllegalArgumentException(
+                  format(
+                      "Location for table '%s' to be registered cannot be associated with any configured object storage location: %s",
+                      tableRef.contentKey(), msg));
+            });
 
     ToIntFunction<Integer> safeUnbox = i -> i != null ? i : 0;
 

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/authz/TestAuthzMeta.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/authz/TestAuthzMeta.java
@@ -154,6 +154,13 @@ public class TestAuthzMeta extends BaseClientAuthTest {
                     check(READ_ENTITY_VALUE, branch, tableKey),
                     check(CREATE_ENTITY, branch, tableKey)),
                 Map.of()),
+            // 'CatalogServiceImpl.locationForEntity'
+            authzCheck(
+                apiContext,
+                List.of(
+                    canViewReference(branch),
+                    check(READ_ENTITY_VALUE, branch, tableKey.getParent())),
+                Map.of()),
             // 'CatalogServiceImpl.commit'
             authzCheck(
                 apiContext,
@@ -226,8 +233,11 @@ public class TestAuthzMeta extends BaseClientAuthTest {
                     canCommitChangeAgainstReference(branch)),
                 Map.of()));
 
+    Map<String, String> meta = catalog.loadNamespaceMetadata(myNamespaceIceberg);
+    String location = meta.get("location");
+
     var props = new HashMap<String, String>();
-    props.put("location", "my_location");
+    props.put("location", location + "/foo_bar/baz");
     mockedAuthorizer.reset();
     catalog.createNamespace(myNamespaceIcebergInner, props);
     soft.assertThat(mockedAuthorizer.checksWithoutIdentifiedKey())

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/AbstractIcebergCatalogTests.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/AbstractIcebergCatalogTests.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.server.catalog;
 
+import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static java.util.Collections.singletonMap;
@@ -82,6 +83,7 @@ import org.projectnessie.model.EntriesResponse;
 import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.LogResponse;
 import org.projectnessie.model.Reference;
+import org.projectnessie.storage.uri.StorageUri;
 
 public abstract class AbstractIcebergCatalogTests extends CatalogTests<RESTCatalog> {
 
@@ -132,7 +134,7 @@ public abstract class AbstractIcebergCatalogTests extends CatalogTests<RESTCatal
   protected NessieClientBuilder nessieClientBuilder() {
     int catalogServerPort = Integer.getInteger("quarkus.http.port");
     return NessieClientBuilder.createClientBuilderFromSystemSettings()
-        .withUri(String.format("http://127.0.0.1:%d/api/v2/", catalogServerPort));
+        .withUri(format("http://127.0.0.1:%d/api/v2/", catalogServerPort));
   }
 
   @Override
@@ -171,6 +173,47 @@ public abstract class AbstractIcebergCatalogTests extends CatalogTests<RESTCatal
   protected abstract String scheme();
 
   @Test
+  public void testNewTableLocationFromParentNamespace() {
+    @SuppressWarnings("resource")
+    RESTCatalog catalog = catalog();
+
+    if (this.requiresNamespaceCreate()) {
+      catalog.createNamespace(NS);
+    }
+
+    catalog.buildTable(TABLE, SCHEMA).withPartitionSpec(SPEC).withSortOrder(WRITE_ORDER).create();
+
+    Table pokeTable = catalog.loadTable(TABLE);
+
+    String pokeTableLocation = pokeTable.location();
+
+    int idx = pokeTableLocation.indexOf(format("/%s/", TABLE.namespace().level(0)));
+    StorageUri rootIshUri = StorageUri.of(pokeTableLocation.substring(0, idx));
+
+    String namespaceLocation = rootIshUri + "/some/custom/path";
+    Map<String, String> namespaceProps = new HashMap<>();
+    namespaceProps.put("location", namespaceLocation);
+    Namespace namespace = Namespace.of("new_table_location_from_namespace");
+    catalog.createNamespace(namespace, namespaceProps);
+
+    Map<String, String> namespaceMeta = catalog.loadNamespaceMetadata(namespace);
+    assertThat(namespaceMeta).containsEntry("location", namespaceLocation);
+
+    Namespace nestedNamespace = Namespace.of("new_table_location_from_namespace", "nested_level");
+    catalog.createNamespace(nestedNamespace, namespaceProps);
+
+    Table tableWithNsLoc =
+        catalog
+            .buildTable(TableIdentifier.of(nestedNamespace, "table_loc_from_ns"), SCHEMA)
+            .withPartitionSpec(SPEC)
+            .withSortOrder(WRITE_ORDER)
+            .create();
+
+    String tableLocation = tableWithNsLoc.location();
+    assertThat(tableLocation).startsWith(namespaceLocation + "/nested_level/table_loc_from_ns_");
+  }
+
+  @Test
   public void testNessieCreateOnDifferentBranch() throws Exception {
     @SuppressWarnings("resource")
     RESTCatalog catalog = catalog();
@@ -191,7 +234,7 @@ public abstract class AbstractIcebergCatalogTests extends CatalogTests<RESTCatal
       api.createReference().reference(branch).sourceRefName(defaultBranch.getName()).create();
 
       TableIdentifier onDifferentBranch =
-          TableIdentifier.of(NS, String.format("`%s@%s`", tableName, branch.getName()));
+          TableIdentifier.of(NS, format("`%s@%s`", tableName, branch.getName()));
 
       // "Create ICEBERG_TABLE" commit
       Table table =
@@ -351,7 +394,7 @@ public abstract class AbstractIcebergCatalogTests extends CatalogTests<RESTCatal
         CommitMeta commit = commitLog.get(i);
         IcebergTable c = contents.get(i);
 
-        String tableSpec = String.format("`%s@main#%s`", tableName, commit.getHash());
+        String tableSpec = format("`%s@main#%s`", tableName, commit.getHash());
         table = catalog.loadTable(TableIdentifier.of(NS, tableSpec));
         soft.assertThat(table)
             .describedAs("using branch + commit ID #%d, table '%s'", i, tableSpec)
@@ -360,7 +403,7 @@ public abstract class AbstractIcebergCatalogTests extends CatalogTests<RESTCatal
                 t -> t.properties().get("nessie.commit.id"))
             .containsExactly(c.getSnapshotId(), commit.getHash());
 
-        tableSpec = String.format("`%s@main#%s`", tableName, commit.getCommitTime());
+        tableSpec = format("`%s@main#%s`", tableName, commit.getCommitTime());
         table = catalog.loadTable(TableIdentifier.of(NS, tableSpec));
         soft.assertThat(table)
             .describedAs("using branch + commit timestamp #%d, table '%s'", i, tableSpec)
@@ -369,7 +412,7 @@ public abstract class AbstractIcebergCatalogTests extends CatalogTests<RESTCatal
                 t -> t.properties().get("nessie.commit.id"))
             .containsExactly(c.getSnapshotId(), commit.getHash());
 
-        tableSpec = String.format("`%s#%s`", tableName, commit.getHash());
+        tableSpec = format("`%s#%s`", tableName, commit.getHash());
         table = catalog.loadTable(TableIdentifier.of(NS, tableSpec));
         soft.assertThat(table)
             .describedAs("using commit ID #%d, table '%s'", i, tableSpec)
@@ -378,7 +421,7 @@ public abstract class AbstractIcebergCatalogTests extends CatalogTests<RESTCatal
                 t -> t.properties().get("nessie.commit.id"))
             .containsExactly(c.getSnapshotId(), commit.getHash());
 
-        tableSpec = String.format("`%s#%s`", tableName, commit.getCommitTime());
+        tableSpec = format("`%s#%s`", tableName, commit.getCommitTime());
         table = catalog.loadTable(TableIdentifier.of(NS, tableSpec));
         soft.assertThat(table)
             .describedAs("using commit timestamp #%d, table '%s'", i, tableSpec)
@@ -388,7 +431,7 @@ public abstract class AbstractIcebergCatalogTests extends CatalogTests<RESTCatal
             .containsExactly(c.getSnapshotId(), commit.getHash());
 
         tableSpec =
-            String.format(
+            format(
                 "`%s#%s`",
                 tableName,
                 ISO_OFFSET_DATE_TIME.format(


### PR DESCRIPTION
Whether the `location` property/attribute can be set is delegated to access checks, therefore the currently existing restriction that the location cannot be set is relaxed w/ this change if no access control for it is in place.

This change also adds somewhat rudimentary checks whether the configured location is valid.

Fixes #9331
Fixes #9558