### PR TITLE
Persistable `LakehouseConfig`

### DIFF
--- a/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/GcsConfig.java
+++ b/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/GcsConfig.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.files.config;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import org.projectnessie.nessie.docgen.annotations.ConfigDocs.ConfigItem;
+import org.projectnessie.nessie.immutables.NessieImmutable;
+
+/** System level configuration for Google Cloud Storage (GCS) object stores. */
+@NessieImmutable
+@JsonSerialize(as = ImmutableGcsConfig.class)
+@JsonDeserialize(as = ImmutableGcsConfig.class)
+public interface GcsConfig {
+
+  /** Override the default read timeout. */
+  @ConfigItem(section = "transport")
+  Optional<Duration> readTimeout();
+
+  /** Override the default connection timeout. */
+  @ConfigItem(section = "transport")
+  Optional<Duration> connectTimeout();
+
+  /** Override the default maximum number of attempts. */
+  @ConfigItem(section = "transport")
+  OptionalInt maxAttempts();
+
+  /** Override the default logical request timeout. */
+  @ConfigItem(section = "transport")
+  Optional<Duration> logicalTimeout();
+
+  /** Override the default total timeout. */
+  @ConfigItem(section = "transport")
+  Optional<Duration> totalTimeout();
+
+  /** Override the default initial retry delay. */
+  @ConfigItem(section = "transport")
+  Optional<Duration> initialRetryDelay();
+
+  /** Override the default maximum retry delay. */
+  @ConfigItem(section = "transport")
+  Optional<Duration> maxRetryDelay();
+
+  /** Override the default retry delay multiplier. */
+  @ConfigItem(section = "transport")
+  OptionalDouble retryDelayMultiplier();
+
+  /** Override the default initial RPC timeout. */
+  @ConfigItem(section = "transport")
+  Optional<Duration> initialRpcTimeout();
+
+  /** Override the default maximum RPC timeout. */
+  @ConfigItem(section = "transport")
+  Optional<Duration> maxRpcTimeout();
+
+  /** Override the default RPC timeout multiplier. */
+  @ConfigItem(section = "transport")
+  OptionalDouble rpcTimeoutMultiplier();
+}

--- a/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/GcsOptions.java
+++ b/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/GcsOptions.java
@@ -18,12 +18,9 @@ package org.projectnessie.catalog.files.config;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalDouble;
-import java.util.OptionalInt;
 import org.immutables.value.Value;
 import org.projectnessie.nessie.docgen.annotations.ConfigDocs.ConfigItem;
 import org.projectnessie.nessie.docgen.annotations.ConfigDocs.ConfigPropertyName;
@@ -58,53 +55,8 @@ public interface GcsOptions {
   @ConfigPropertyName("bucket-name")
   Map<String, GcsNamedBucketOptions> buckets();
 
-  /** Override the default read timeout. */
-  @ConfigItem(section = "transport")
-  Optional<Duration> readTimeout();
-
-  /** Override the default connection timeout. */
-  @ConfigItem(section = "transport")
-  Optional<Duration> connectTimeout();
-
-  /** Override the default maximum number of attempts. */
-  @ConfigItem(section = "transport")
-  OptionalInt maxAttempts();
-
-  /** Override the default logical request timeout. */
-  @ConfigItem(section = "transport")
-  Optional<Duration> logicalTimeout();
-
-  /** Override the default total timeout. */
-  @ConfigItem(section = "transport")
-  Optional<Duration> totalTimeout();
-
-  /** Override the default initial retry delay. */
-  @ConfigItem(section = "transport")
-  Optional<Duration> initialRetryDelay();
-
-  /** Override the default maximum retry delay. */
-  @ConfigItem(section = "transport")
-  Optional<Duration> maxRetryDelay();
-
-  /** Override the default retry delay multiplier. */
-  @ConfigItem(section = "transport")
-  OptionalDouble retryDelayMultiplier();
-
-  /** Override the default initial RPC timeout. */
-  @ConfigItem(section = "transport")
-  Optional<Duration> initialRpcTimeout();
-
-  /** Override the default maximum RPC timeout. */
-  @ConfigItem(section = "transport")
-  Optional<Duration> maxRpcTimeout();
-
-  /** Override the default RPC timeout multiplier. */
-  @ConfigItem(section = "transport")
-  OptionalDouble rpcTimeoutMultiplier();
-
   default GcsBucketOptions effectiveOptionsForBucket(Optional<String> bucketName) {
-    GcsBucketOptions defaultOptions =
-        defaultOptions().map(GcsBucketOptions.class::cast).orElse(GcsNamedBucketOptions.FALLBACK);
+    GcsBucketOptions defaultOptions = defaultOptions().orElse(GcsNamedBucketOptions.FALLBACK);
 
     if (bucketName.isEmpty()) {
       return defaultOptions;

--- a/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/S3Options.java
+++ b/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/S3Options.java
@@ -31,15 +31,6 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 @JsonDeserialize(as = ImmutableS3Options.class)
 public interface S3Options {
 
-  @ConfigItem(section = "sts")
-  Optional<S3Sts> sts();
-
-  @Value.NonAttribute
-  @JsonIgnore
-  default S3Sts effectiveSts() {
-    return sts().orElse(ImmutableS3Sts.builder().build());
-  }
-
   /**
    * Default bucket configuration, default/fallback values for all buckets are taken from this one.
    */
@@ -120,7 +111,6 @@ public interface S3Options {
   @JsonIgnore
   default S3Options deepClone() {
     ImmutableS3Options.Builder b = ImmutableS3Options.builder().from(this).buckets(Map.of());
-    sts().ifPresent(v -> b.sts(ImmutableS3Sts.copyOf(v)));
     defaultOptions().ifPresent(v -> b.defaultOptions(v.deepClone()));
     buckets().forEach((n, v) -> b.putBucket(n, v.deepClone()));
     return b.build();

--- a/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/S3StsCache.java
+++ b/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/S3StsCache.java
@@ -25,9 +25,9 @@ import org.immutables.value.Value;
 import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
-@JsonSerialize(as = ImmutableS3Sts.class)
-@JsonDeserialize(as = ImmutableS3Sts.class)
-public interface S3Sts {
+@JsonSerialize(as = ImmutableS3StsCache.class)
+@JsonDeserialize(as = ImmutableS3StsCache.class)
+public interface S3StsCache {
 
   /** Default value for {@link #sessionCacheMaxSize()}. */
   int DEFAULT_MAX_SESSION_CREDENTIAL_CACHE_ENTRIES = 1000;

--- a/catalog/files/api/src/test/java/org/projectnessie/catalog/files/config/TestGcsOptions.java
+++ b/catalog/files/api/src/test/java/org/projectnessie/catalog/files/config/TestGcsOptions.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URI;
-import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.catalog.files.config.GcsBucketOptions.GcsAuthType;
 
@@ -29,17 +28,6 @@ class TestGcsOptions {
   void deepClone() {
     GcsOptions input =
         ImmutableGcsOptions.builder()
-            .readTimeout(Duration.ofSeconds(1))
-            .connectTimeout(Duration.ofSeconds(2))
-            .maxAttempts(2)
-            .logicalTimeout(Duration.ofSeconds(3))
-            .totalTimeout(Duration.ofSeconds(4))
-            .initialRetryDelay(Duration.ofSeconds(5))
-            .maxRetryDelay(Duration.ofSeconds(6))
-            .retryDelayMultiplier(7)
-            .initialRpcTimeout(Duration.ofSeconds(8))
-            .maxRpcTimeout(Duration.ofSeconds(9))
-            .rpcTimeoutMultiplier(10)
             .defaultOptions(
                 ImmutableGcsNamedBucketOptions.builder()
                     .host(URI.create("https://host"))
@@ -85,17 +73,6 @@ class TestGcsOptions {
             .build();
     GcsOptions expected =
         ImmutableGcsOptions.builder()
-            .readTimeout(Duration.ofSeconds(1))
-            .connectTimeout(Duration.ofSeconds(2))
-            .maxAttempts(2)
-            .logicalTimeout(Duration.ofSeconds(3))
-            .totalTimeout(Duration.ofSeconds(4))
-            .initialRetryDelay(Duration.ofSeconds(5))
-            .maxRetryDelay(Duration.ofSeconds(6))
-            .retryDelayMultiplier(7)
-            .initialRpcTimeout(Duration.ofSeconds(8))
-            .maxRpcTimeout(Duration.ofSeconds(9))
-            .rpcTimeoutMultiplier(10)
             .defaultOptions(
                 ImmutableGcsNamedBucketOptions.builder()
                     .host(URI.create("https://host"))

--- a/catalog/files/api/src/test/java/org/projectnessie/catalog/files/config/TestS3Options.java
+++ b/catalog/files/api/src/test/java/org/projectnessie/catalog/files/config/TestS3Options.java
@@ -388,12 +388,6 @@ public class TestS3Options {
         //
         arguments(
             ImmutableS3Options.builder()
-                .sts(
-                    ImmutableS3Sts.builder()
-                        .sessionGracePeriod(Duration.ofSeconds(1))
-                        .sessionCacheMaxSize(2)
-                        .clientsCacheMaxSize(3)
-                        .build())
                 .defaultOptions(
                     ImmutableS3NamedBucketOptions.builder()
                         .endpoint(URI.create("https://host"))
@@ -459,12 +453,6 @@ public class TestS3Options {
                         .build())
                 .build(),
             ImmutableS3Options.builder()
-                .sts(
-                    ImmutableS3Sts.builder()
-                        .sessionGracePeriod(Duration.ofSeconds(1))
-                        .sessionCacheMaxSize(2)
-                        .clientsCacheMaxSize(3)
-                        .build())
                 .defaultOptions(
                     ImmutableS3NamedBucketOptions.builder()
                         .endpoint(URI.create("https://host"))
@@ -533,12 +521,6 @@ public class TestS3Options {
         //
         arguments(
             ImmutableS3Options.builder()
-                .sts(
-                    ImmutableS3Sts.builder()
-                        .sessionGracePeriod(Duration.ofSeconds(1))
-                        .sessionCacheMaxSize(2)
-                        .clientsCacheMaxSize(3)
-                        .build())
                 .defaultOptions(
                     ImmutableS3NamedBucketOptions.builder()
                         .endpoint(URI.create("https://host"))
@@ -577,12 +559,6 @@ public class TestS3Options {
                         .build())
                 .build(),
             ImmutableS3Options.builder()
-                .sts(
-                    ImmutableS3Sts.builder()
-                        .sessionGracePeriod(Duration.ofSeconds(1))
-                        .sessionCacheMaxSize(2)
-                        .clientsCacheMaxSize(3)
-                        .build())
                 .defaultOptions(
                     ImmutableS3NamedBucketOptions.builder()
                         .endpoint(URI.create("https://host"))

--- a/catalog/files/impl/src/jmh/java/org/projectnessie/catalog/files/gcs/GcsClientResourceBench.java
+++ b/catalog/files/impl/src/jmh/java/org/projectnessie/catalog/files/gcs/GcsClientResourceBench.java
@@ -41,7 +41,9 @@ import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 import org.projectnessie.catalog.files.config.GcsBucketOptions;
+import org.projectnessie.catalog.files.config.GcsConfig;
 import org.projectnessie.catalog.files.config.GcsOptions;
+import org.projectnessie.catalog.files.config.ImmutableGcsConfig;
 import org.projectnessie.catalog.files.config.ImmutableGcsNamedBucketOptions;
 import org.projectnessie.catalog.files.config.ImmutableGcsOptions;
 import org.projectnessie.catalog.secrets.ResolvingSecretsProvider;
@@ -86,8 +88,10 @@ public class GcsClientResourceBench {
                       .host(server.getGcsBaseUri())
                       .build())
               .build();
+      GcsConfig gcsConfig = ImmutableGcsConfig.builder().build();
 
-      storageSupplier = new GcsStorageSupplier(httpTransportFactory, gcsOptions, secretsProvider);
+      storageSupplier =
+          new GcsStorageSupplier(httpTransportFactory, gcsConfig, gcsOptions, secretsProvider);
     }
 
     @TearDown

--- a/catalog/files/impl/src/jmh/java/org/projectnessie/catalog/files/s3/S3SessionCacheResourceBench.java
+++ b/catalog/files/impl/src/jmh/java/org/projectnessie/catalog/files/s3/S3SessionCacheResourceBench.java
@@ -48,9 +48,11 @@ import org.projectnessie.catalog.files.config.ImmutableS3ClientIam;
 import org.projectnessie.catalog.files.config.ImmutableS3NamedBucketOptions;
 import org.projectnessie.catalog.files.config.ImmutableS3Options;
 import org.projectnessie.catalog.files.config.ImmutableS3ServerIam;
+import org.projectnessie.catalog.files.config.ImmutableS3StsCache;
 import org.projectnessie.catalog.files.config.S3BucketOptions;
 import org.projectnessie.catalog.files.config.S3Config;
 import org.projectnessie.catalog.files.config.S3Options;
+import org.projectnessie.catalog.files.config.S3StsCache;
 import org.projectnessie.catalog.secrets.ResolvingSecretsProvider;
 import org.projectnessie.catalog.secrets.SecretsProvider;
 import org.projectnessie.objectstoragemock.ObjectStorageMock;
@@ -105,9 +107,9 @@ public class S3SessionCacheResourceBench {
                       .build())
               .build();
 
-      StsClientsPool stsClientsPool = new StsClientsPool(s3options, httpClient, null);
-      stsCredentialsManager =
-          new StsCredentialsManager(s3options, stsClientsPool, secretsProvider, null);
+      S3StsCache sts = ImmutableS3StsCache.builder().build();
+      StsClientsPool stsClientsPool = new StsClientsPool(sts, httpClient, null);
+      stsCredentialsManager = new StsCredentialsManager(sts, stsClientsPool, secretsProvider, null);
 
       List<String> regions =
           Region.regions().stream()

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsStorageSupplier.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsStorageSupplier.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import org.projectnessie.catalog.files.api.StorageLocations;
 import org.projectnessie.catalog.files.config.GcsBucketOptions;
+import org.projectnessie.catalog.files.config.GcsConfig;
 import org.projectnessie.catalog.files.config.GcsDownscopedCredentials;
 import org.projectnessie.catalog.files.config.GcsOptions;
 import org.projectnessie.catalog.secrets.SecretsProvider;
@@ -53,14 +54,17 @@ public final class GcsStorageSupplier {
   static final String RANDOMIZED_PART = "([A-Za-z0-9=]+/)?";
 
   private final HttpTransportFactory httpTransportFactory;
+  private final GcsConfig gcsConfig;
   private final GcsOptions gcsOptions;
   private final SecretsProvider secretsProvider;
 
   public GcsStorageSupplier(
       HttpTransportFactory httpTransportFactory,
+      GcsConfig gcsConfig,
       GcsOptions gcsOptions,
       SecretsProvider secretsProvider) {
     this.httpTransportFactory = httpTransportFactory;
+    this.gcsConfig = gcsConfig;
     this.gcsOptions = gcsOptions;
     this.secretsProvider = secretsProvider;
   }
@@ -78,8 +82,7 @@ public final class GcsStorageSupplier {
   }
 
   public Storage forLocation(GcsBucketOptions bucketOptions) {
-    return GcsClients.buildStorage(
-        gcsOptions, bucketOptions, httpTransportFactory, secretsProvider);
+    return GcsClients.buildStorage(gcsConfig, bucketOptions, httpTransportFactory, secretsProvider);
   }
 
   public Optional<TokenSecret> generateDelegationToken(

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3ClientSupplier.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3ClientSupplier.java
@@ -65,10 +65,6 @@ public class S3ClientSupplier {
     return s3options;
   }
 
-  SecretsProvider secretsProvider() {
-    return secretsProvider;
-  }
-
   /**
    * Produces an S3 client for the set of S3 options and secrets. S3 options are retrieved from the
    * per-bucket config, which derives from the global config. References to the secrets that contain

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/StsClientsPool.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/StsClientsPool.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.projectnessie.catalog.files.config.S3BucketOptions;
-import org.projectnessie.catalog.files.config.S3Options;
+import org.projectnessie.catalog.files.config.S3StsCache;
 import org.projectnessie.nessie.immutables.NessieImmutable;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -43,9 +43,9 @@ public class StsClientsPool {
   private final Function<StsClientKey, StsClient> clientBuilder;
 
   public StsClientsPool(
-      S3Options options, SdkHttpClient sdkHttpClient, MeterRegistry meterRegistry) {
+      S3StsCache effectiveSts, SdkHttpClient sdkHttpClient, MeterRegistry meterRegistry) {
     this(
-        options.effectiveSts().effectiveClientsCacheMaxSize(),
+        effectiveSts.effectiveClientsCacheMaxSize(),
         key -> defaultStsClient(key, sdkHttpClient),
         Optional.ofNullable(meterRegistry));
   }

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/StsCredentialsManager.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/StsCredentialsManager.java
@@ -32,8 +32,8 @@ import org.checkerframework.checker.index.qual.NonNegative;
 import org.projectnessie.catalog.files.api.StorageLocations;
 import org.projectnessie.catalog.files.config.S3BucketOptions;
 import org.projectnessie.catalog.files.config.S3ClientIam;
-import org.projectnessie.catalog.files.config.S3Options;
 import org.projectnessie.catalog.files.config.S3ServerIam;
+import org.projectnessie.catalog.files.config.S3StsCache;
 import org.projectnessie.catalog.secrets.SecretsProvider;
 import org.projectnessie.nessie.immutables.NessieImmutable;
 import software.amazon.awssdk.services.sts.model.Credentials;
@@ -47,13 +47,13 @@ public class StsCredentialsManager {
   private final StsCredentialsFetcher credentialsFetcher;
 
   public StsCredentialsManager(
-      S3Options options,
+      S3StsCache effectiveSts,
       StsClientsPool clients,
       SecretsProvider secretsProvider,
       MeterRegistry meterRegistry) {
     this(
-        options.effectiveSts().effectiveSessionCacheMaxSize(),
-        options.effectiveSts().effectiveSessionGracePeriod(),
+        effectiveSts.effectiveSessionCacheMaxSize(),
+        effectiveSts.effectiveSessionGracePeriod(),
         new StsCredentialsFetcherImpl(clients, secretsProvider),
         System::currentTimeMillis,
         Optional.ofNullable(meterRegistry));

--- a/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/gcs/TestGcsClients.java
+++ b/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/gcs/TestGcsClients.java
@@ -24,6 +24,7 @@ import org.projectnessie.catalog.files.AbstractClients;
 import org.projectnessie.catalog.files.api.BackendExceptionMapper;
 import org.projectnessie.catalog.files.api.ObjectIO;
 import org.projectnessie.catalog.files.config.GcsBucketOptions;
+import org.projectnessie.catalog.files.config.ImmutableGcsConfig;
 import org.projectnessie.catalog.files.config.ImmutableGcsNamedBucketOptions;
 import org.projectnessie.catalog.files.config.ImmutableGcsOptions;
 import org.projectnessie.catalog.secrets.ResolvingSecretsProvider;
@@ -65,10 +66,12 @@ public class TestGcsClients extends AbstractClients {
               .authType(GcsBucketOptions.GcsAuthType.NONE)
               .build());
     }
+    ImmutableGcsConfig.Builder gcsConfig = ImmutableGcsConfig.builder();
 
     GcsStorageSupplier supplier =
         new GcsStorageSupplier(
             httpTransportFactory,
+            gcsConfig.build(),
             gcsOptions.build(),
             ResolvingSecretsProvider.builder()
                 .putSecretsManager("plain", unsafePlainTextSecretsProvider(Map.of()))

--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/api/LakehouseConfigManagement.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/api/LakehouseConfigManagement.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.service.api;
+
+import org.projectnessie.catalog.service.config.LakehouseConfig;
+import org.projectnessie.catalog.service.config.SmallryeConfigs;
+
+/**
+ * Management service to get and update {@link LakehouseConfig}.
+ *
+ * <p>The implementation allow "managing" <em>static</em> configuration (retrieved from the Quarkus
+ * configuration) and <em>dynamic</em> configuration, which is retrieved and persisted by Nessie.
+ * The static vs dynamic behavior is controlled by {@link
+ * SmallryeConfigs#usePersistedLakehouseConfig()}.
+ *
+ * <p>A migration from managing a static configuration to a dynamically maintained one will be added
+ * later.
+ */
+public interface LakehouseConfigManagement {
+  LakehouseConfig currentConfig();
+
+  void updateConfig(LakehouseConfig config, LakehouseConfig expected);
+}

--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/config/SmallryeConfigs.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/config/SmallryeConfigs.java
@@ -15,15 +15,21 @@
  */
 package org.projectnessie.catalog.service.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 import io.smallrye.config.WithParentName;
+import java.util.Optional;
+import org.immutables.value.Value;
 import org.projectnessie.catalog.files.config.AdlsConfig;
 import org.projectnessie.catalog.files.config.AdlsOptions;
+import org.projectnessie.catalog.files.config.GcsConfig;
 import org.projectnessie.catalog.files.config.GcsOptions;
+import org.projectnessie.catalog.files.config.ImmutableS3StsCache;
 import org.projectnessie.catalog.files.config.S3Config;
 import org.projectnessie.catalog.files.config.S3Options;
+import org.projectnessie.catalog.files.config.S3StsCache;
 import org.projectnessie.nessie.docgen.annotations.ConfigDocs.ConfigItem;
 import org.projectnessie.nessie.immutables.NessieImmutable;
 
@@ -40,6 +46,16 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 @ConfigMapping(prefix = "nessie.catalog")
 @NessieImmutable
 public interface SmallryeConfigs {
+  /**
+   * Flag whether the lakehouse config is managed (persisted in Nessie) or static (retrieved from
+   * Quarkus configs).
+   *
+   * @hidden hidden from docs on projectnessie website
+   */
+  @WithName("advanced.persist-config")
+  @WithDefault("false")
+  boolean usePersistedLakehouseConfig();
+
   @WithName("service.s3")
   @ConfigItem(section = "s3", sectionDocFromType = true)
   S3Options s3();
@@ -62,6 +78,20 @@ public interface SmallryeConfigs {
   @WithName("service.s3")
   @ConfigItem(section = "s3_config", sectionDocFromType = true)
   S3Config s3config();
+
+  @WithName("service.gcs")
+  @ConfigItem(section = "gcs_config", sectionDocFromType = true)
+  GcsConfig gcsConfig();
+
+  @WithName("service.s3.sts")
+  @ConfigItem(section = "s3_config_sts", sectionDocFromType = true)
+  Optional<S3StsCache> s3StsCache();
+
+  @Value.NonAttribute
+  @JsonIgnore
+  default S3StsCache effectiveS3StsCache() {
+    return s3StsCache().orElse(ImmutableS3StsCache.builder().build());
+  }
 
   @WithName("service.adls")
   @ConfigItem(section = "adls_config", sectionDocFromType = true)

--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/CatalogObjTypeBundle.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/CatalogObjTypeBundle.java
@@ -25,5 +25,6 @@ public class CatalogObjTypeBundle implements ObjTypeBundle {
     registrar.accept(EntityObj.OBJ_TYPE);
     registrar.accept(EntitySnapshotObj.OBJ_TYPE);
     registrar.accept(SignerKeysObj.OBJ_TYPE);
+    registrar.accept(LakehouseConfigObj.OBJ_TYPE);
   }
 }

--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/LakehouseConfigObj.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/objtypes/LakehouseConfigObj.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.service.objtypes;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.projectnessie.versioned.storage.common.objtypes.CustomObjType.customObjType;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+import org.projectnessie.catalog.service.config.LakehouseConfig;
+import org.projectnessie.nessie.immutables.NessieImmutable;
+import org.projectnessie.versioned.storage.common.objtypes.UpdateableObj;
+import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
+
+@NessieImmutable
+@JsonSerialize(as = ImmutableLakehouseConfigObj.class)
+@JsonDeserialize(as = ImmutableLakehouseConfigObj.class)
+// Suppress: "Constructor parameters should be better defined on the same level of inheritance
+// hierarchy..."
+@SuppressWarnings("immutables:subtype")
+public interface LakehouseConfigObj extends UpdateableObj {
+  ObjType OBJ_TYPE = customObjType("lakehouse-config", "lh-cfg", LakehouseConfigObj.class);
+
+  ObjId OBJ_ID = ObjId.objIdFromByteArray("lakehouse-config".getBytes(UTF_8));
+
+  static ImmutableLakehouseConfigObj.Builder builder() {
+    return ImmutableLakehouseConfigObj.builder();
+  }
+
+  @Override
+  @Value.Default
+  default ObjId id() {
+    return OBJ_ID;
+  }
+
+  @Override
+  @Value.Default
+  default ObjType type() {
+    return OBJ_TYPE;
+  }
+
+  LakehouseConfig lakehouseConfig();
+}

--- a/catalog/service/common/src/test/java/org/projectnessie/catalog/service/config/TestSecretsValidation.java
+++ b/catalog/service/common/src/test/java/org/projectnessie/catalog/service/config/TestSecretsValidation.java
@@ -35,6 +35,7 @@ import org.projectnessie.catalog.files.config.ImmutableAdlsFileSystemOptions;
 import org.projectnessie.catalog.files.config.ImmutableAdlsNamedFileSystemOptions;
 import org.projectnessie.catalog.files.config.ImmutableAdlsOptions;
 import org.projectnessie.catalog.files.config.ImmutableGcsBucketOptions;
+import org.projectnessie.catalog.files.config.ImmutableGcsConfig;
 import org.projectnessie.catalog.files.config.ImmutableGcsNamedBucketOptions;
 import org.projectnessie.catalog.files.config.ImmutableGcsOptions;
 import org.projectnessie.catalog.files.config.ImmutableS3BucketOptions;
@@ -355,9 +356,11 @@ public class TestSecretsValidation {
     Supplier<ImmutableSmallryeConfigs.Builder> forS3config =
         () ->
             ImmutableSmallryeConfigs.builder()
+                .usePersistedLakehouseConfig(false) // doesn't have any effect in this test
                 .validateSecrets(true) // doesn't have any effect in this test
                 .s3(ImmutableS3Options.builder().build())
                 .gcs(ImmutableGcsOptions.builder().build())
+                .gcsConfig(ImmutableGcsConfig.builder().build())
                 .adls(ImmutableAdlsOptions.builder().build())
                 .adlsconfig(AdlsConfig.builder().build())
                 .serviceConfig(

--- a/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/CatalogServiceImpl.java
+++ b/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/CatalogServiceImpl.java
@@ -87,7 +87,7 @@ import org.projectnessie.catalog.service.api.CatalogEntityAlreadyExistsException
 import org.projectnessie.catalog.service.api.CatalogService;
 import org.projectnessie.catalog.service.api.SnapshotReqParams;
 import org.projectnessie.catalog.service.api.SnapshotResponse;
-import org.projectnessie.catalog.service.config.CatalogConfig;
+import org.projectnessie.catalog.service.config.LakehouseConfig;
 import org.projectnessie.catalog.service.config.ServiceConfig;
 import org.projectnessie.catalog.service.config.WarehouseConfig;
 import org.projectnessie.catalog.service.impl.MultiTableUpdate.SingleTableUpdate;
@@ -129,7 +129,7 @@ public class CatalogServiceImpl implements CatalogService {
 
   @Inject ObjectIO objectIO;
   @Inject ServerConfig serverConfig;
-  @Inject CatalogConfig catalogConfig;
+  @Inject LakehouseConfig lakehouseConfig;
   @Inject VersionStore versionStore;
   @Inject Authorizer authorizer;
   @Inject AccessContext accessContext;
@@ -791,7 +791,7 @@ public class CatalogServiceImpl implements CatalogService {
       }
     }
     if (location == null) {
-      WarehouseConfig w = catalogConfig.getWarehouse(op.warehouse());
+      WarehouseConfig w = lakehouseConfig.catalog().getWarehouse(op.warehouse());
       location =
           icebergNewEntityBaseLocation(
               locationForEntity(

--- a/catalog/service/impl/src/test/java/org/projectnessie/catalog/service/impl/AbstractCatalogService.java
+++ b/catalog/service/impl/src/test/java/org/projectnessie/catalog/service/impl/AbstractCatalogService.java
@@ -53,6 +53,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectnessie.api.v2.params.ParsedReference;
 import org.projectnessie.catalog.files.api.BackendExceptionMapper;
 import org.projectnessie.catalog.files.api.ObjectIO;
+import org.projectnessie.catalog.files.config.ImmutableAdlsOptions;
+import org.projectnessie.catalog.files.config.ImmutableGcsOptions;
 import org.projectnessie.catalog.files.config.ImmutableS3NamedBucketOptions;
 import org.projectnessie.catalog.files.config.ImmutableS3Options;
 import org.projectnessie.catalog.files.config.S3Config;
@@ -69,6 +71,7 @@ import org.projectnessie.catalog.secrets.ResolvingSecretsProvider;
 import org.projectnessie.catalog.secrets.SecretsProvider;
 import org.projectnessie.catalog.service.api.CatalogCommit;
 import org.projectnessie.catalog.service.config.ImmutableCatalogConfig;
+import org.projectnessie.catalog.service.config.ImmutableLakehouseConfig;
 import org.projectnessie.catalog.service.config.ImmutableServiceConfig;
 import org.projectnessie.catalog.service.config.ImmutableWarehouseConfig;
 import org.projectnessie.client.api.NessieApiV2;
@@ -199,14 +202,20 @@ public abstract class AbstractCatalogService {
 
   private void setupCatalogService() {
     catalogService = new CatalogServiceImpl();
-    catalogService.catalogConfig =
-        ImmutableCatalogConfig.builder()
-            .defaultWarehouse(WAREHOUSE)
-            .putWarehouse(
-                WAREHOUSE,
-                ImmutableWarehouseConfig.builder()
-                    .location("s3://" + BUCKET + "/foo/bar/baz/")
+    catalogService.lakehouseConfig =
+        ImmutableLakehouseConfig.builder()
+            .catalog(
+                ImmutableCatalogConfig.builder()
+                    .defaultWarehouse(WAREHOUSE)
+                    .putWarehouse(
+                        WAREHOUSE,
+                        ImmutableWarehouseConfig.builder()
+                            .location("s3://" + BUCKET + "/foo/bar/baz/")
+                            .build())
                     .build())
+            .s3(ImmutableS3Options.builder().build())
+            .gcs(ImmutableGcsOptions.builder().build())
+            .adls(ImmutableAdlsOptions.builder().build())
             .build();
     catalogService.serviceConfig =
         ImmutableServiceConfig.builder().objectStoresHealthCheck(false).build();

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1GenericResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1GenericResource.java
@@ -44,7 +44,7 @@ import org.projectnessie.catalog.formats.iceberg.rest.IcebergCommitTransactionRe
 import org.projectnessie.catalog.formats.iceberg.rest.IcebergConfigResponse;
 import org.projectnessie.catalog.service.api.CatalogCommit;
 import org.projectnessie.catalog.service.api.SnapshotReqParams;
-import org.projectnessie.catalog.service.config.CatalogConfig;
+import org.projectnessie.catalog.service.config.LakehouseConfig;
 import org.projectnessie.catalog.service.rest.IcebergErrorMapper.IcebergEntityKind;
 import org.projectnessie.services.authz.AccessContext;
 import org.projectnessie.services.authz.Authorizer;
@@ -71,11 +71,11 @@ public class IcebergApiV1GenericResource extends IcebergApiV1ResourceBase {
   @Inject
   public IcebergApiV1GenericResource(
       ServerConfig serverConfig,
-      CatalogConfig catalogConfig,
+      LakehouseConfig lakehouseConfig,
       VersionStore store,
       Authorizer authorizer,
       AccessContext accessContext) {
-    super(serverConfig, catalogConfig, store, authorizer, accessContext);
+    super(serverConfig, lakehouseConfig, store, authorizer, accessContext);
   }
 
   @ServerExceptionMapper

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1NamespaceResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1NamespaceResource.java
@@ -61,7 +61,7 @@ import org.projectnessie.catalog.formats.iceberg.rest.IcebergGetNamespaceRespons
 import org.projectnessie.catalog.formats.iceberg.rest.IcebergListNamespacesResponse;
 import org.projectnessie.catalog.formats.iceberg.rest.IcebergUpdateNamespacePropertiesRequest;
 import org.projectnessie.catalog.formats.iceberg.rest.IcebergUpdateNamespacePropertiesResponse;
-import org.projectnessie.catalog.service.config.CatalogConfig;
+import org.projectnessie.catalog.service.config.LakehouseConfig;
 import org.projectnessie.catalog.service.config.WarehouseConfig;
 import org.projectnessie.catalog.service.rest.IcebergErrorMapper.IcebergEntityKind;
 import org.projectnessie.error.NessieContentNotFoundException;
@@ -104,11 +104,11 @@ public class IcebergApiV1NamespaceResource extends IcebergApiV1ResourceBase {
   @Inject
   public IcebergApiV1NamespaceResource(
       ServerConfig serverConfig,
-      CatalogConfig catalogConfig,
+      LakehouseConfig lakehouseConfig,
       VersionStore store,
       Authorizer authorizer,
       AccessContext accessContext) {
-    super(serverConfig, catalogConfig, store, authorizer, accessContext);
+    super(serverConfig, lakehouseConfig, store, authorizer, accessContext);
   }
 
   @ServerExceptionMapper
@@ -354,7 +354,7 @@ public class IcebergApiV1NamespaceResource extends IcebergApiV1ResourceBase {
 
     Map<String, String> properties = new HashMap<>(nessieNamespace.getProperties());
     if (!properties.containsKey("location")) {
-      WarehouseConfig warehouse = catalogConfig.getWarehouse(decoded.warehouse());
+      WarehouseConfig warehouse = lakehouseConfig.catalog().getWarehouse(decoded.warehouse());
       StorageUri location =
           catalogService
               .locationForEntity(warehouse, contentKey, keysInOrder, namespacesMap)

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ResourceBase.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ResourceBase.java
@@ -56,7 +56,7 @@ import org.projectnessie.catalog.service.api.CatalogEntityAlreadyExistsException
 import org.projectnessie.catalog.service.api.CatalogService;
 import org.projectnessie.catalog.service.api.SnapshotReqParams;
 import org.projectnessie.catalog.service.api.SnapshotResponse;
-import org.projectnessie.catalog.service.config.CatalogConfig;
+import org.projectnessie.catalog.service.config.LakehouseConfig;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieContentNotFoundException;
 import org.projectnessie.error.NessieNotFoundException;
@@ -91,18 +91,18 @@ abstract class IcebergApiV1ResourceBase extends AbstractCatalogResource {
   final TreeService treeService;
   final ContentService contentService;
   final ServerConfig serverConfig;
-  final CatalogConfig catalogConfig;
+  final LakehouseConfig lakehouseConfig;
 
   static final ApiContext ICEBERG_V1 = apiContext("Iceberg", 1);
 
   protected IcebergApiV1ResourceBase(
       ServerConfig serverConfig,
-      CatalogConfig catalogConfig,
+      LakehouseConfig lakehouseConfig,
       VersionStore store,
       Authorizer authorizer,
       AccessContext accessContext) {
     this.serverConfig = serverConfig;
-    this.catalogConfig = catalogConfig;
+    this.lakehouseConfig = lakehouseConfig;
     this.treeService = new TreeApiImpl(serverConfig, store, authorizer, accessContext, ICEBERG_V1);
     this.contentService =
         new ContentApiImpl(serverConfig, store, authorizer, accessContext, ICEBERG_V1);
@@ -317,7 +317,7 @@ abstract class IcebergApiV1ResourceBase extends AbstractCatalogResource {
           ParsedReference.parsedReference(serverConfig.getDefaultBranch(), null, BRANCH);
     }
 
-    String resolvedWarehouse = catalogConfig.resolveWarehouseName(warehouse);
+    String resolvedWarehouse = lakehouseConfig.catalog().resolveWarehouseName(warehouse);
 
     return decodedPrefix(parsedReference, resolvedWarehouse);
   }

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1S3SignResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1S3SignResource.java
@@ -38,7 +38,7 @@ import org.projectnessie.catalog.files.api.RequestSigner;
 import org.projectnessie.catalog.formats.iceberg.rest.IcebergS3SignRequest;
 import org.projectnessie.catalog.formats.iceberg.rest.IcebergS3SignResponse;
 import org.projectnessie.catalog.service.api.SignerKeysService;
-import org.projectnessie.catalog.service.config.CatalogConfig;
+import org.projectnessie.catalog.service.config.LakehouseConfig;
 import org.projectnessie.catalog.service.objtypes.SignerKey;
 import org.projectnessie.catalog.service.rest.IcebergErrorMapper.IcebergEntityKind;
 import org.projectnessie.model.ContentKey;
@@ -75,11 +75,11 @@ public class IcebergApiV1S3SignResource extends IcebergApiV1ResourceBase {
   @Inject
   public IcebergApiV1S3SignResource(
       ServerConfig serverConfig,
-      CatalogConfig catalogConfig,
+      LakehouseConfig lakehouseConfig,
       VersionStore store,
       Authorizer authorizer,
       AccessContext accessContext) {
-    super(serverConfig, catalogConfig, store, authorizer, accessContext);
+    super(serverConfig, lakehouseConfig, store, authorizer, accessContext);
   }
 
   @ServerExceptionMapper

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1TableResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1TableResource.java
@@ -98,7 +98,7 @@ import org.projectnessie.catalog.model.snapshot.NessieTableSnapshot;
 import org.projectnessie.catalog.service.api.CatalogEntityAlreadyExistsException;
 import org.projectnessie.catalog.service.api.SnapshotReqParams;
 import org.projectnessie.catalog.service.api.SnapshotResponse;
-import org.projectnessie.catalog.service.config.CatalogConfig;
+import org.projectnessie.catalog.service.config.LakehouseConfig;
 import org.projectnessie.catalog.service.config.WarehouseConfig;
 import org.projectnessie.catalog.service.rest.IcebergErrorMapper.IcebergEntityKind;
 import org.projectnessie.error.NessieContentNotFoundException;
@@ -138,11 +138,11 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
   @Inject
   public IcebergApiV1TableResource(
       ServerConfig serverConfig,
-      CatalogConfig catalogConfig,
+      LakehouseConfig lakehouseConfig,
       VersionStore store,
       Authorizer authorizer,
       AccessContext accessContext) {
-    super(serverConfig, catalogConfig, store, authorizer, accessContext);
+    super(serverConfig, lakehouseConfig, store, authorizer, accessContext);
   }
 
   @ServerExceptionMapper
@@ -172,7 +172,7 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
       throws NessieNotFoundException {
     ContentKey key = tableRef.contentKey();
 
-    WarehouseConfig warehouse = catalogConfig.getWarehouse(tableRef.warehouse());
+    WarehouseConfig warehouse = lakehouseConfig.catalog().getWarehouse(tableRef.warehouse());
 
     return snapshotResponse(
             key,
@@ -323,7 +323,7 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
 
     createEntityVerifyNotExists(tableRef, ICEBERG_TABLE);
 
-    WarehouseConfig warehouse = catalogConfig.getWarehouse(tableRef.warehouse());
+    WarehouseConfig warehouse = lakehouseConfig.catalog().getWarehouse(tableRef.warehouse());
 
     ParsedReference ref = tableRef.reference();
     String location =

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ViewResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ViewResource.java
@@ -65,7 +65,7 @@ import org.projectnessie.catalog.formats.iceberg.rest.IcebergRenameTableRequest;
 import org.projectnessie.catalog.formats.iceberg.rest.IcebergUpdateRequirement;
 import org.projectnessie.catalog.service.api.SnapshotReqParams;
 import org.projectnessie.catalog.service.api.SnapshotResponse;
-import org.projectnessie.catalog.service.config.CatalogConfig;
+import org.projectnessie.catalog.service.config.LakehouseConfig;
 import org.projectnessie.catalog.service.rest.IcebergErrorMapper.IcebergEntityKind;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
@@ -97,11 +97,11 @@ public class IcebergApiV1ViewResource extends IcebergApiV1ResourceBase {
   @Inject
   public IcebergApiV1ViewResource(
       ServerConfig serverConfig,
-      CatalogConfig catalogConfig,
+      LakehouseConfig lakehouseConfig,
       VersionStore store,
       Authorizer authorizer,
       AccessContext accessContext) {
-    super(serverConfig, catalogConfig, store, authorizer, accessContext);
+    super(serverConfig, lakehouseConfig, store, authorizer, accessContext);
   }
 
   @ServerExceptionMapper

--- a/servers/quarkus-catalog/src/main/java/org/projectnessie/server/catalog/LakehouseConfigManagementImpl.java
+++ b/servers/quarkus-catalog/src/main/java/org/projectnessie/server/catalog/LakehouseConfigManagementImpl.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.server.catalog;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.UUID;
+import org.projectnessie.catalog.files.config.ImmutableAdlsOptions;
+import org.projectnessie.catalog.files.config.ImmutableGcsOptions;
+import org.projectnessie.catalog.files.config.ImmutableS3Options;
+import org.projectnessie.catalog.service.api.LakehouseConfigManagement;
+import org.projectnessie.catalog.service.config.ImmutableCatalogConfig;
+import org.projectnessie.catalog.service.config.ImmutableLakehouseConfig;
+import org.projectnessie.catalog.service.config.LakehouseConfig;
+import org.projectnessie.catalog.service.objtypes.ImmutableLakehouseConfigObj;
+import org.projectnessie.catalog.service.objtypes.LakehouseConfigObj;
+import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
+import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+
+public class LakehouseConfigManagementImpl implements LakehouseConfigManagement {
+  private final Persist persist;
+  private final boolean dynamic;
+  private final LakehouseConfig staticLakehouseConfig;
+
+  public LakehouseConfigManagementImpl(
+      Persist persist, boolean dynamic, LakehouseConfig staticLakehouseConfig) {
+    this.persist = persist;
+    this.dynamic = dynamic;
+    this.staticLakehouseConfig = staticLakehouseConfig;
+  }
+
+  @Override
+  public LakehouseConfig currentConfig() {
+    if (!dynamic) {
+      return staticLakehouseConfig;
+    }
+
+    try {
+      // We could eventually save the persistence round-trip in a followup change.
+      LakehouseConfigObj obj = loadCurrent();
+      return obj.lakehouseConfig();
+    } catch (ObjNotFoundException e) {
+      return ImmutableLakehouseConfig.builder()
+          .catalog(ImmutableCatalogConfig.builder().build())
+          .s3(ImmutableS3Options.builder().build())
+          .gcs(ImmutableGcsOptions.builder().build())
+          .adls(ImmutableAdlsOptions.builder().build())
+          .build();
+    }
+  }
+
+  private LakehouseConfigObj loadCurrent() throws ObjNotFoundException {
+    return persist.fetchTypedObj(
+        LakehouseConfigObj.OBJ_ID, LakehouseConfigObj.OBJ_TYPE, LakehouseConfigObj.class);
+  }
+
+  @Override
+  public void updateConfig(LakehouseConfig config, LakehouseConfig expected) {
+    checkState(dynamic, "Cannot update the lakehouse config in Quarkus configuration");
+
+    checkArgument(
+        config != null && expected != null, "Updated config and expected must not be null");
+    checkArgument(!config.equals(expected), "Updated config and expected config must not be equal");
+
+    ImmutableLakehouseConfigObj newObj =
+        LakehouseConfigObj.builder()
+            .versionToken(UUID.randomUUID().toString())
+            .lakehouseConfig(config)
+            .build();
+
+    try {
+      while (true) {
+        try {
+          LakehouseConfigObj existing = loadCurrent();
+          checkArgument(
+              existing.lakehouseConfig().equals(expected),
+              "Currently persisted lakehouse configuration changed, cannot apply changes");
+
+          if (persist.updateConditional(newObj, existing)) {
+            // changed obj persisted, we're good
+            return;
+          }
+
+        } catch (ObjNotFoundException e) {
+          if (persist.storeObj(newObj)) {
+            // new obj persisted, we're good
+            return;
+          }
+        }
+      }
+    } catch (ObjTooLargeException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/servers/quarkus-catalog/src/main/java/org/projectnessie/server/catalog/ObjectStoresHealthCheck.java
+++ b/servers/quarkus-catalog/src/main/java/org/projectnessie/server/catalog/ObjectStoresHealthCheck.java
@@ -26,7 +26,7 @@ import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 import org.eclipse.microprofile.health.Readiness;
 import org.projectnessie.catalog.files.api.ObjectIO;
-import org.projectnessie.catalog.service.config.CatalogConfig;
+import org.projectnessie.catalog.service.config.LakehouseConfig;
 import org.projectnessie.catalog.service.config.ServiceConfig;
 import org.projectnessie.catalog.service.config.WarehouseConfig;
 import org.projectnessie.services.config.ServerConfig;
@@ -42,7 +42,7 @@ public class ObjectStoresHealthCheck implements HealthCheck {
   public static final String NAME = "Warehouses Object Stores";
 
   @Inject ServiceConfig serviceConfig;
-  @Inject CatalogConfig catalogConfig;
+  @Inject LakehouseConfig lakehouseConfig;
   @Inject ObjectIO objectIO;
   @Inject ServerConfig serverConfig;
 
@@ -51,7 +51,8 @@ public class ObjectStoresHealthCheck implements HealthCheck {
     HealthCheckResponseBuilder healthCheckResponse = HealthCheckResponse.builder().name(NAME);
     boolean up = true;
     if (serviceConfig.objectStoresHealthCheck()) {
-      for (Map.Entry<String, WarehouseConfig> warehouse : catalogConfig.warehouses().entrySet()) {
+      for (Map.Entry<String, WarehouseConfig> warehouse :
+          lakehouseConfig.catalog().warehouses().entrySet()) {
         String name = warehouse.getKey();
         WarehouseConfig warehouseConfig = warehouse.getValue();
 

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -109,6 +109,7 @@ dependencies {
   testFixturesApi(project(":nessie-quarkus-tests"))
   testFixturesApi(project(":nessie-catalog-files-api"))
   testFixturesApi(project(":nessie-catalog-files-impl"))
+  testFixturesApi(project(":nessie-catalog-service-common"))
   testFixturesApi(project(":nessie-events-api"))
   testFixturesApi(project(":nessie-events-spi"))
   testFixturesApi(project(":nessie-events-service"))

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/TestLakehouseConfigManagement.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/TestLakehouseConfigManagement.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.server.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ManagedContext;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import java.net.URI;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.projectnessie.catalog.files.config.ImmutableAdlsOptions;
+import org.projectnessie.catalog.files.config.ImmutableGcsOptions;
+import org.projectnessie.catalog.files.config.ImmutableS3NamedBucketOptions;
+import org.projectnessie.catalog.files.config.ImmutableS3Options;
+import org.projectnessie.catalog.service.api.LakehouseConfigManagement;
+import org.projectnessie.catalog.service.config.ImmutableCatalogConfig;
+import org.projectnessie.catalog.service.config.ImmutableLakehouseConfig;
+import org.projectnessie.catalog.service.config.ImmutableWarehouseConfig;
+import org.projectnessie.catalog.service.config.LakehouseConfig;
+import org.projectnessie.objectstoragemock.HeapStorageBucket;
+import org.projectnessie.objectstoragemock.ObjectStorageMock;
+
+@QuarkusTest
+@TestProfile(TestLakehouseConfigManagement.Profile.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TestLakehouseConfigManagement {
+  public static final String BUCKET = "bucket1";
+
+  private HeapStorageBucket heapStorageBucket;
+  private ObjectStorageMock.MockServer server;
+
+  @Inject LakehouseConfigManagement configManagement;
+
+  @BeforeEach
+  public void setUp() {
+    heapStorageBucket = HeapStorageBucket.newHeapStorageBucket();
+    server =
+        ObjectStorageMock.builder()
+            .initAddress("localhost")
+            .putBuckets(BUCKET, heapStorageBucket.bucket())
+            .build()
+            .start();
+  }
+
+  @AfterEach
+  public void stop() {
+    if (server != null) {
+      try {
+        server.close();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      } finally {
+        server = null;
+      }
+    }
+  }
+
+  @Test
+  @Order(1)
+  public void initiallyEmpty() {
+    LakehouseConfig current = configManagement.currentConfig();
+    ImmutableLakehouseConfig empty =
+        ImmutableLakehouseConfig.builder()
+            .catalog(ImmutableCatalogConfig.builder().build())
+            .s3(ImmutableS3Options.builder().build())
+            .gcs(ImmutableGcsOptions.builder().build())
+            .adls(ImmutableAdlsOptions.builder().build())
+            .build();
+    assertThat(current).isEqualTo(empty);
+
+    // Verify for `@RequestScoped`
+    ManagedContext rc = Arc.container().requestContext();
+    rc.activate();
+    try {
+      LakehouseConfig configFromContainer = Arc.container().instance(LakehouseConfig.class).get();
+      assertThat(ImmutableLakehouseConfig.builder().from(configFromContainer).build())
+          .isEqualTo(empty);
+    } finally {
+      rc.terminate();
+    }
+  }
+
+  @Test
+  @Order(2)
+  public void updateS3Bucket() {
+    String s3Endpoint = server.getS3BaseUri().toString();
+
+    LakehouseConfig current = configManagement.currentConfig();
+    LakehouseConfig updated =
+        ImmutableLakehouseConfig.builder()
+            .from(current)
+            .catalog(
+                ImmutableCatalogConfig.builder()
+                    .defaultWarehouse("my-warehouse")
+                    .putWarehouse(
+                        "my-warehouse",
+                        ImmutableWarehouseConfig.builder().location("s3://" + BUCKET).build())
+                    .build())
+            .s3(
+                ImmutableS3Options.builder()
+                    .putBucket(
+                        BUCKET,
+                        ImmutableS3NamedBucketOptions.builder()
+                            .endpoint(URI.create(s3Endpoint))
+                            .region("us-east-1")
+                            .pathStyleAccess(true)
+                            .build())
+                    .build())
+            .build();
+
+    configManagement.updateConfig(updated, current);
+
+    LakehouseConfig actual = configManagement.currentConfig();
+    assertThat(actual).isEqualTo(updated);
+
+    // Verify for `@RequestScoped`
+    ManagedContext rc = Arc.container().requestContext();
+    rc.activate();
+    try {
+      LakehouseConfig configFromContainer = Arc.container().instance(LakehouseConfig.class).get();
+      assertThat(ImmutableLakehouseConfig.builder().from(configFromContainer).build())
+          .isEqualTo(updated);
+    } finally {
+      rc.terminate();
+    }
+  }
+
+  public static class Profile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of("nessie.catalog.advanced.persist-config", "true");
+    }
+  }
+}

--- a/site/in-dev/configuration.md
+++ b/site/in-dev/configuration.md
@@ -124,14 +124,6 @@ Related Quarkus settings:
 
 {% include './generated-docs/smallrye-nessie_catalog_s3_config.md' %}
 
-##### S3 transport
-
-{% include './generated-docs/smallrye-nessie_catalog_s3_config_transport.md' %}
-
-##### S3 STS, assume-role global settings
-
-{% include './generated-docs/smallrye-nessie_catalog_s3_sts.md' %}
-
 ##### S3 default bucket settings
 
 {% include './generated-docs/smallrye-nessie_catalog_s3_default_options.md' %}
@@ -140,14 +132,22 @@ Related Quarkus settings:
 
 {% include './generated-docs/smallrye-nessie_catalog_s3_buckets.md' %}
 
+##### S3 transport
+
+{% include './generated-docs/smallrye-nessie_catalog_s3_config_transport.md' %}
+
+##### S3 STS, assume-role global settings
+
+{% include './generated-docs/smallrye-nessie_catalog_s3_config_sts.md' %}
+
 #### Google Cloud Storage settings
 
 !!! note
     Support for GCS is experimental.
 
-##### GCS transport
+##### GCS buckets
 
-{% include './generated-docs/smallrye-nessie_catalog_gcs_transport.md' %}
+{% include './generated-docs/smallrye-nessie_catalog_gcs.md' %}
 
 ##### GCS default bucket settings
 
@@ -157,16 +157,16 @@ Related Quarkus settings:
 
 {% include './generated-docs/smallrye-nessie_catalog_gcs_buckets.md' %}
 
+##### GCS transport
+
+{% include './generated-docs/smallrye-nessie_catalog_gcs_config_transport.md' %}
+
 #### ADLS settings
 
 !!! note
     Support for ADLS is experimental.
 
 {% include './generated-docs/smallrye-nessie_catalog_adls.md' %}
-
-##### ADLS transport
-
-{% include './generated-docs/smallrye-nessie_catalog_adls_config_transport.md' %}
 
 ##### ADLS default file-system settings
 
@@ -175,6 +175,10 @@ Related Quarkus settings:
 ##### ADLS per file-system  settings
 
 {% include './generated-docs/smallrye-nessie_catalog_adls_buckets.md' %}
+
+##### ADLS transport
+
+{% include './generated-docs/smallrye-nessie_catalog_adls_config_transport.md' %}
 
 #### Advanced catalog settings
 


### PR DESCRIPTION
This change allows to use the `LakehouseConfig` from the Quarkus configuration, which is the current behavior, and with change to alternatively persist the `LakehouseConfig`.

For this to work, the `LakehouseConfig` object tree needs to be injectable via the CDI request-scope, so some refactoring to make this work is included in this change.

Some options, which were still in the `LakehouseConfig`, had been moved into two object types `S3StsCache` (the old `S3Sts`, but moved out of the LC tree) and `GcsConfig`.

Retrieving and updating the `LakehouseConfig` object is implemented via `LakehouseConfigManagement` (plus its implementation).
