### PR TITLE
[Catalog] More flexible named buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Breaking changes
 
+- ADLS: The way how storage URIs are resolved to ADLS "buckets" (container @ storage-account) has been
+  changed (fixed). An ADLS "bucket" is technically identified by the storage-account, optionally further
+  identified by a container/file-system name. It is recommended to specify the newly added via the
+  `nessie.catalog.service.adls.file-systems.<key>.authority=container@storageAccount` option(s).
+  The `container@storageAccount` part is what is mentioned as `<file_system>@<account_name>` in the [Azure
+  docs](https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction-abfs-uri).
+
 ### New Features
 
 - Access check SPI has been enhanced to provide richer information in the `Check` type about the receiving
@@ -19,6 +26,17 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Changes
 
+- S3/GCS/ADLS: Bucket settings
+  - The resolution of the specific bucket options has been enhanced to select the specific bucket options
+    using the longest matching option including an optional path-prefix.
+  - All bucket specific options (`nessie.catalog.service.adls.buckets.<key>.`,
+    `nessie.catalog.service.gcs.buckets.<key>.`, `nessie.catalog.service.adls.file-systems.<key>.`) got a
+    new option `path-prefix`, which is used to restrict settings to a specific object store path prefix.
+  - All bucket specific options (`nessie.catalog.service.adls.buckets.<key>.`,
+    `nessie.catalog.service.gcs.buckets.<key>.`, `nessie.catalog.service.adls.file-systems.<key>.`) got a
+    new option `authority`, which is recommended to specify the technical bucket name. If `authority` is
+    not specified, it will default to the value of the `name` option, then default to the `key` part of the
+    formerly mentioned maps.
 - The base `location` of a new entity (e.g. tables) created via Iceberg REST is derived from the nearest
   parent namespace that has an explicitly set `location` property. (Path separator character is `/`.)
 - The `location` property on tables (and view) created via Iceberg REST may be explicitly configured, as

--- a/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/AdlsNamedFileSystemOptions.java
+++ b/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/AdlsNamedFileSystemOptions.java
@@ -18,27 +18,13 @@ package org.projectnessie.catalog.files.config;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableAdlsNamedFileSystemOptions.class)
 @JsonDeserialize(as = ImmutableAdlsNamedFileSystemOptions.class)
 @SuppressWarnings("immutables:subtype")
-public interface AdlsNamedFileSystemOptions extends AdlsFileSystemOptions {
-
-  AdlsFileSystemOptions FALLBACK = ImmutableAdlsNamedFileSystemOptions.builder().build();
-
-  /**
-   * The name of the filesystem. If unset, the name of the bucket will be extracted from the
-   * configuration option, e.g. if {@code
-   * nessie.catalog.service.adls.filesystem1.name=my-filesystem} is set, the name of the filesystem
-   * will be {@code my-filesystem}; otherwise, it will be {@code filesystem1}.
-   *
-   * <p>This should only be defined if the filesystem name contains non-alphanumeric characters,
-   * such as dots or dashes.
-   */
-  Optional<String> name();
+public interface AdlsNamedFileSystemOptions extends AdlsFileSystemOptions, PerBucket {
 
   @Value.NonAttribute
   @JsonIgnore
@@ -46,6 +32,8 @@ public interface AdlsNamedFileSystemOptions extends AdlsFileSystemOptions {
     return ImmutableAdlsNamedFileSystemOptions.builder()
         .from(AdlsFileSystemOptions.super.deepClone())
         .name(name())
+        .authority(authority())
+        .pathPrefix(pathPrefix())
         .build();
   }
 }

--- a/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/GcsNamedBucketOptions.java
+++ b/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/GcsNamedBucketOptions.java
@@ -18,26 +18,13 @@ package org.projectnessie.catalog.files.config;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableGcsNamedBucketOptions.class)
 @JsonDeserialize(as = ImmutableGcsNamedBucketOptions.class)
 @SuppressWarnings("immutables:subtype")
-public interface GcsNamedBucketOptions extends GcsBucketOptions {
-
-  GcsBucketOptions FALLBACK = ImmutableGcsNamedBucketOptions.builder().build();
-
-  /**
-   * The name of the bucket. If unset, the name of the bucket will be extracted from the
-   * configuration option, e.g. if {@code nessie.catalog.service.gcs.bucket1.name=my-bucket} is set,
-   * the bucket name will be {@code my-bucket}; otherwise, it will be {@code bucket1}.
-   *
-   * <p>This should only be defined if the bucket name contains non-alphanumeric characters, such as
-   * dots or dashes.
-   */
-  Optional<String> name();
+public interface GcsNamedBucketOptions extends GcsBucketOptions, PerBucket {
 
   @Value.NonAttribute
   @JsonIgnore
@@ -45,6 +32,8 @@ public interface GcsNamedBucketOptions extends GcsBucketOptions {
     return ImmutableGcsNamedBucketOptions.builder()
         .from(GcsBucketOptions.super.deepClone())
         .name(name())
+        .authority(authority())
+        .pathPrefix(pathPrefix())
         .build();
   }
 }

--- a/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/OptionsUtil.java
+++ b/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/OptionsUtil.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.files.config;
+
+import java.util.Map;
+import java.util.Optional;
+import org.projectnessie.storage.uri.StorageUri;
+
+final class OptionsUtil {
+  private OptionsUtil() {}
+
+  static <B extends PerBucket> Optional<B> resolveSpecializedBucket(
+      StorageUri uri, Map<String, B> buckets) {
+    String bucketName = uri.requiredAuthority();
+    String path = uri.pathWithoutLeadingTrailingSlash();
+
+    B specific = null;
+    int matchLen = -1;
+    for (Map.Entry<String, B> entry : buckets.entrySet()) {
+      String key = entry.getKey();
+      B bucket = entry.getValue();
+
+      String authority =
+          bucket.authority().isPresent() ? bucket.authority().get() : bucket.name().orElse(key);
+
+      if (!authority.equals(bucketName)) {
+        continue;
+      }
+      String bucketPathPrefix = bucket.pathPrefix().orElse("");
+      if (!path.startsWith(bucketPathPrefix)) {
+        continue;
+      }
+      int len = bucketPathPrefix.length();
+      if (matchLen == -1 || matchLen < len) {
+        matchLen = len;
+        specific = bucket;
+      }
+    }
+
+    return Optional.ofNullable(specific);
+  }
+}

--- a/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/PerBucket.java
+++ b/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/PerBucket.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.files.config;
+
+import java.util.Optional;
+
+public interface PerBucket {
+  /**
+   * The human consumable name of the bucket. If unset, the name of the bucket will be extracted
+   * from the configuration option name, e.g. if {@code
+   * nessie.catalog.service.s3.bucket1.name=my-bucket} is set, the bucket name will be {@code
+   * my-bucket}; otherwise, it will be {@code bucket1}.
+   *
+   * <p>This should only be defined if the bucket name contains non-alphanumeric characters, such as
+   * dots or dashes.
+   */
+  Optional<String> name();
+
+  /**
+   * The authority part in a storage location URI. This is the bucket name for S3 and GCS, for ADLS
+   * this is the storage account name (optionally prefixed with the container/file-system name).
+   * Defaults to {@link #name()}.
+   *
+   * <p>For S3 and GCS this option should mention the name of the bucket.
+   *
+   * <p>For ADLS: The value of this option is using the {@code container@storageAccount} syntax. It
+   * is mentioned as {@code <file_system>@<account_name>} in the <a
+   * href="https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction-abfs-uri">Azure
+   * Docs</a>. Note that the {@code <file_system>@} part is optional.
+   */
+  Optional<String> authority();
+
+  /** The path prefix for this storage location. */
+  Optional<String> pathPrefix();
+}

--- a/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/PerBucket.java
+++ b/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/PerBucket.java
@@ -24,8 +24,8 @@ public interface PerBucket {
    * nessie.catalog.service.s3.bucket1.name=my-bucket} is set, the bucket name will be {@code
    * my-bucket}; otherwise, it will be {@code bucket1}.
    *
-   * <p>This should only be defined if the bucket name contains non-alphanumeric characters, such as
-   * dots or dashes.
+   * <p>This can be used; if the bucket name contains non-alphanumeric characters, such as dots or
+   * dashes.
    */
   Optional<String> name();
 
@@ -39,7 +39,8 @@ public interface PerBucket {
    * <p>For ADLS: The value of this option is using the {@code container@storageAccount} syntax. It
    * is mentioned as {@code <file_system>@<account_name>} in the <a
    * href="https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction-abfs-uri">Azure
-   * Docs</a>. Note that the {@code <file_system>@} part is optional.
+   * Docs</a>. Note that the {@code <file_system>@} part is optional, {@code <account_name>} is the
+   * fully qualified name, usually ending in {@code .dfs.core.windows.net}.
    */
   Optional<String> authority();
 

--- a/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/S3NamedBucketOptions.java
+++ b/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/S3NamedBucketOptions.java
@@ -18,26 +18,13 @@ package org.projectnessie.catalog.files.config;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableS3NamedBucketOptions.class)
 @JsonDeserialize(as = ImmutableS3NamedBucketOptions.class)
 @SuppressWarnings("immutables:subtype")
-public interface S3NamedBucketOptions extends S3BucketOptions {
-
-  S3BucketOptions FALLBACK = ImmutableS3NamedBucketOptions.builder().build();
-
-  /**
-   * The name of the bucket. If unset, the name of the bucket will be extracted from the
-   * configuration option, e.g. if {@code nessie.catalog.service.s3.bucket1.name=my-bucket} is set,
-   * the bucket name will be {@code my-bucket}; otherwise, it will be {@code bucket1}.
-   *
-   * <p>This should only be defined if the bucket name contains non-alphanumeric characters, such as
-   * dots or dashes.
-   */
-  Optional<String> name();
+public interface S3NamedBucketOptions extends S3BucketOptions, PerBucket {
 
   @Value.NonAttribute
   @JsonIgnore
@@ -45,6 +32,8 @@ public interface S3NamedBucketOptions extends S3BucketOptions {
     return ImmutableS3NamedBucketOptions.builder()
         .from(S3BucketOptions.super.deepClone())
         .name(name())
+        .authority(authority())
+        .pathPrefix(pathPrefix())
         .build();
   }
 }

--- a/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/S3Options.java
+++ b/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/S3Options.java
@@ -15,16 +15,18 @@
  */
 package org.projectnessie.catalog.files.config;
 
+import static org.projectnessie.catalog.files.config.OptionsUtil.resolveSpecializedBucket;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.immutables.value.Value;
 import org.projectnessie.nessie.docgen.annotations.ConfigDocs.ConfigItem;
 import org.projectnessie.nessie.docgen.annotations.ConfigDocs.ConfigPropertyName;
 import org.projectnessie.nessie.immutables.NessieImmutable;
+import org.projectnessie.storage.uri.StorageUri;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableS3Options.class)
@@ -39,33 +41,32 @@ public interface S3Options {
 
   /**
    * Per-bucket configurations. The effective value for a bucket is taken from the per-bucket
-   * setting. If no per-bucket setting is present, uses the values from top-level S3 settings.
+   * setting. If no per-bucket setting is present, uses the defaults from the top-level S3 settings
+   * in {@code default-options}.
    */
   @ConfigItem(section = "buckets")
-  @ConfigPropertyName("bucket-name")
+  @ConfigPropertyName("key")
   Map<String, S3NamedBucketOptions> buckets();
 
-  default S3BucketOptions effectiveOptionsForBucket(Optional<String> bucketName) {
-    S3BucketOptions defaultOptions =
-        defaultOptions().map(S3BucketOptions.class::cast).orElse(S3NamedBucketOptions.FALLBACK);
+  default S3NamedBucketOptions resolveOptionsForUri(StorageUri uri) {
+    Optional<S3NamedBucketOptions> specific = resolveSpecializedBucket(uri, buckets());
 
-    if (bucketName.isEmpty()) {
-      return defaultOptions;
-    }
-
-    S3BucketOptions specific = buckets().get(bucketName.orElse(null));
-    if (specific == null) {
-      return defaultOptions;
-    }
-
-    ImmutableS3NamedBucketOptions.Builder builder =
-        ImmutableS3NamedBucketOptions.builder().from(defaultOptions).from(specific);
+    ImmutableS3NamedBucketOptions.Builder builder = ImmutableS3NamedBucketOptions.builder();
+    defaultOptions().ifPresent(builder::from);
+    specific.ifPresent(builder::from);
     ImmutableS3ServerIam.Builder serverIam = ImmutableS3ServerIam.builder();
     ImmutableS3ClientIam.Builder clientIam = ImmutableS3ClientIam.builder();
-    defaultOptions.serverIam().ifPresent(serverIam::from);
-    defaultOptions.clientIam().ifPresent(clientIam::from);
-    specific.serverIam().ifPresent(serverIam::from);
-    specific.clientIam().ifPresent(clientIam::from);
+    defaultOptions()
+        .ifPresent(
+            d -> {
+              d.serverIam().ifPresent(serverIam::from);
+              d.clientIam().ifPresent(clientIam::from);
+            });
+    specific.ifPresent(
+        d -> {
+          d.serverIam().ifPresent(serverIam::from);
+          d.clientIam().ifPresent(clientIam::from);
+        });
     builder.serverIam(serverIam.build());
     builder.clientIam(clientIam.build());
 
@@ -76,35 +77,6 @@ public interface S3Options {
     defaultOptions().ifPresent(options -> options.validate("<default>"));
     buckets().forEach((key, opts) -> opts.validate(opts.name().orElse(key)));
     return this;
-  }
-
-  @Value.Check
-  default S3Options normalizeBuckets() {
-    Map<String, S3NamedBucketOptions> buckets = new HashMap<>();
-    boolean changed = false;
-    for (String bucketName : buckets().keySet()) {
-      S3NamedBucketOptions options = buckets().get(bucketName);
-      if (options.name().isPresent()) {
-        String explicitName = options.name().get();
-        changed |= !explicitName.equals(bucketName);
-        bucketName = options.name().get();
-      } else {
-        changed = true;
-        options = ImmutableS3NamedBucketOptions.builder().from(options).name(bucketName).build();
-      }
-      if (buckets.put(bucketName, options) != null) {
-        throw new IllegalArgumentException(
-            "Duplicate S3 bucket name '" + bucketName + "', check your S3 bucket configurations");
-      }
-    }
-
-    return changed
-        ? ImmutableS3Options.builder()
-            .from(this)
-            .defaultOptions(defaultOptions())
-            .buckets(buckets)
-            .build()
-        : this;
   }
 
   @Value.NonAttribute

--- a/catalog/files/impl/src/jmh/java/org/projectnessie/catalog/files/gcs/GcsClientResourceBench.java
+++ b/catalog/files/impl/src/jmh/java/org/projectnessie/catalog/files/gcs/GcsClientResourceBench.java
@@ -18,7 +18,6 @@ package org.projectnessie.catalog.files.gcs;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.projectnessie.catalog.files.BenchUtils.mockServer;
-import static org.projectnessie.catalog.files.gcs.GcsLocation.gcsLocation;
 import static org.projectnessie.catalog.secrets.TokenSecret.tokenSecret;
 import static org.projectnessie.catalog.secrets.UnsafePlainTextSecretsManager.unsafePlainTextSecretsProvider;
 
@@ -102,8 +101,7 @@ public class GcsClientResourceBench {
 
   @Benchmark
   public void gcsClient(BenchmarkParam param, Blackhole bh) {
-    GcsLocation gcsLocation = gcsLocation("bucket", "key");
-    GcsBucketOptions bucketOptions = param.storageSupplier.bucketOptions(gcsLocation);
+    GcsBucketOptions bucketOptions = param.storageSupplier.bucketOptions(StorageUri.of("gs://key"));
     bh.consume(param.storageSupplier.forLocation(bucketOptions));
   }
 

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsLocation.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsLocation.java
@@ -26,10 +26,13 @@ public final class AdlsLocation {
   private final StorageUri uri;
   private final String storageAccount;
   private final String container;
+  private final String authority;
   private final String path;
 
-  private AdlsLocation(StorageUri uri, String storageAccount, String container, String path) {
+  private AdlsLocation(
+      StorageUri uri, String authority, String storageAccount, String container, String path) {
     this.uri = uri;
+    this.authority = authority;
     this.storageAccount = requireNonNull(storageAccount, "storageAccount argument missing");
     this.container = container;
     this.path =
@@ -55,7 +58,7 @@ public final class AdlsLocation {
 
     String path = location.path();
     path = path == null ? "" : path.startsWith("/") ? path.substring(1) : path;
-    return new AdlsLocation(location, storageAccount, container, path);
+    return new AdlsLocation(location, authority, storageAccount, container, path);
   }
 
   public static boolean isAdlsScheme(String scheme) {
@@ -77,5 +80,9 @@ public final class AdlsLocation {
 
   public String path() {
     return this.path;
+  }
+
+  public String authority() {
+    return authority;
   }
 }

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsStorageSupplier.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsStorageSupplier.java
@@ -46,6 +46,7 @@ import org.projectnessie.catalog.files.config.GcsDownscopedCredentials;
 import org.projectnessie.catalog.files.config.GcsOptions;
 import org.projectnessie.catalog.secrets.SecretsProvider;
 import org.projectnessie.catalog.secrets.TokenSecret;
+import org.projectnessie.storage.uri.StorageUri;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,8 +78,8 @@ public final class GcsStorageSupplier {
     return secretsProvider;
   }
 
-  public GcsBucketOptions bucketOptions(GcsLocation location) {
-    return gcsOptions.effectiveOptionsForBucket(Optional.of(location.bucket()));
+  public GcsBucketOptions bucketOptions(StorageUri location) {
+    return gcsOptions.resolveOptionsForUri(location);
   }
 
   public Storage forLocation(GcsBucketOptions bucketOptions) {

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3Signer.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3Signer.java
@@ -27,6 +27,7 @@ import org.projectnessie.catalog.files.api.SigningResponse;
 import org.projectnessie.catalog.files.config.S3BucketOptions;
 import org.projectnessie.catalog.files.config.S3Options;
 import org.projectnessie.catalog.secrets.SecretsProvider;
+import org.projectnessie.storage.uri.StorageUri;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
@@ -70,7 +71,9 @@ public class S3Signer implements RequestSigner {
             .method(SdkHttpMethod.fromValue(clientRequest.method()))
             .headers(clientRequest.headers());
 
-    S3BucketOptions bucketOptions = s3Options.effectiveOptionsForBucket(clientRequest.bucket());
+    S3BucketOptions bucketOptions =
+        s3Options.resolveOptionsForUri(
+            StorageUri.of(S3Utils.asS3Location(clientRequest.uri().toString())));
     AwsCredentialsProvider credentialsProvider =
         S3Clients.serverCredentialsProvider(bucketOptions, s3sessions, secretsProvider);
     AwsCredentialsIdentity credentials = credentialsProvider.resolveCredentials();

--- a/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/adls/TestAdlsClients.java
+++ b/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/adls/TestAdlsClients.java
@@ -70,6 +70,7 @@ public class TestAdlsClients extends AbstractClients {
                     .endpoint(server1.getAdlsGen2BaseUri().toString())
                     .authType(AdlsFileSystemOptions.AzureAuthType.STORAGE_SHARED_KEY)
                     .account(secretUri)
+                    .authority(BUCKET_1 + "@storageAccount")
                     .build());
     if (server2 != null) {
       adlsOptions.putFileSystem(
@@ -78,6 +79,7 @@ public class TestAdlsClients extends AbstractClients {
               .endpoint(server2.getAdlsGen2BaseUri().toString())
               .authType(AdlsFileSystemOptions.AzureAuthType.STORAGE_SHARED_KEY)
               .account(secretUri)
+              .authority(BUCKET_2 + "@storageAccount")
               .build());
     }
 

--- a/catalog/service/common/build.gradle.kts
+++ b/catalog/service/common/build.gradle.kts
@@ -21,6 +21,7 @@ publishingHelper { mavenName = "Nessie - Catalog - Service Common" }
 dependencies {
   implementation(project(":nessie-model"))
   implementation(project(":nessie-catalog-files-api"))
+  implementation(project(":nessie-catalog-files-impl"))
   implementation(project(":nessie-catalog-model"))
   implementation(project(":nessie-services"))
   implementation(project(":nessie-versioned-spi"))

--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/config/SecretsValidation.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/config/SecretsValidation.java
@@ -66,8 +66,8 @@ public abstract class SecretsValidation {
     var failures = new ArrayList<SecretValidationFailure>();
     s3.defaultOptions().map(b -> validateS3Bucket(b, "<default>")).ifPresent(failures::addAll);
     s3.buckets()
-        .values()
-        .forEach(b -> failures.addAll(validateS3Bucket(b, b.name().orElseThrow())));
+        .forEach(
+            (key, value) -> failures.addAll(validateS3Bucket(value, value.name().orElse(key))));
     return failures;
   }
 
@@ -89,8 +89,8 @@ public abstract class SecretsValidation {
     var failures = new ArrayList<SecretValidationFailure>();
     gcs.defaultOptions().map(b -> validateGcsBucket(b, "<default>")).ifPresent(failures::addAll);
     gcs.buckets()
-        .values()
-        .forEach(b -> failures.addAll(validateGcsBucket(b, b.name().orElseThrow())));
+        .forEach(
+            (key, value) -> failures.addAll(validateGcsBucket(value, value.name().orElse(key))));
     return failures;
   }
 
@@ -100,8 +100,9 @@ public abstract class SecretsValidation {
         .map(fs -> validateAdlsFileSystem(fs, "<default>"))
         .ifPresent(failures::addAll);
     adls.fileSystems()
-        .values()
-        .forEach(fs -> failures.addAll(validateAdlsFileSystem(fs, fs.name().orElseThrow())));
+        .forEach(
+            (key, value) ->
+                failures.addAll(validateAdlsFileSystem(value, value.name().orElse(key))));
     return failures;
   }
 

--- a/catalog/service/common/src/test/java/org/projectnessie/catalog/service/config/TestSecretsValidation.java
+++ b/catalog/service/common/src/test/java/org/projectnessie/catalog/service/config/TestSecretsValidation.java
@@ -126,7 +126,7 @@ public class TestSecretsValidation {
 
     return Stream.of(
         arguments(builder.get().build(), List.of()),
-        //
+        // 1
         arguments(
             builder
                 .get()
@@ -143,6 +143,7 @@ public class TestSecretsValidation {
                     NOT_FOUND,
                     Optional.empty(),
                     "secret does not exist"))),
+        // 2
         arguments(
             builder
                 .get()
@@ -160,7 +161,7 @@ public class TestSecretsValidation {
                     NOT_FOUND,
                     Optional.empty(),
                     "secret does not exist"))),
-        //
+        // 3
         arguments(
             builder
                 .get()
@@ -179,6 +180,7 @@ public class TestSecretsValidation {
                     NOT_FOUND,
                     Optional.empty(),
                     "secret does not exist"))),
+        // 4
         arguments(
             builder
                 .get()
@@ -195,6 +197,7 @@ public class TestSecretsValidation {
                     NOT_FOUND,
                     Optional.empty(),
                     "secret does not exist"))),
+        // 5
         arguments(
             builder
                 .get()
@@ -211,6 +214,7 @@ public class TestSecretsValidation {
                     NOT_FOUND,
                     Optional.empty(),
                     "secret does not exist"))),
+        // 6
         arguments(
             builder
                 .get()
@@ -230,7 +234,7 @@ public class TestSecretsValidation {
                     NOT_FOUND,
                     Optional.empty(),
                     "secret does not exist"))),
-        //
+        // 7
         arguments(
             builder
                 .get()

--- a/helm/nessie/templates/_helpers.tpl
+++ b/helm/nessie/templates/_helpers.tpl
@@ -170,6 +170,8 @@ Apply S3 catalog options.
 {{- $map := index . 2 -}}{{/* the destination map */}}
 {{- with $root -}}
 {{- include "nessie.addConfigOption" (list .name $map ( print $prefix "name" )) -}}
+{{- include "nessie.addConfigOption" (list .authority $map ( print $prefix "authority" )) -}}
+{{- include "nessie.addConfigOption" (list .pathPrefix $map ( print $prefix "path-prefix" )) -}}
 {{- include "nessie.addConfigOption" (list .region $map ( print $prefix "region" )) -}}
 {{- include "nessie.addConfigOption" (list .endpoint $map ( print $prefix "endpoint" )) -}}
 {{- include "nessie.addConfigOption" (list .externalEndpoint $map ( print $prefix "external-endpoint" )) -}}
@@ -233,6 +235,8 @@ Apply GCS catalog options.
 {{- $map := index . 2 -}}{{/* the destination map */}}
 {{- with $root -}}
 {{- include "nessie.addConfigOption" (list .name $map ( print $prefix "name" )) -}}
+{{- include "nessie.addConfigOption" (list .authority $map ( print $prefix "authority" )) -}}
+{{- include "nessie.addConfigOption" (list .pathPrefix $map ( print $prefix "path-prefix" )) -}}
 {{- include "nessie.addConfigOption" (list .host $map ( print $prefix "host" )) -}}
 {{- include "nessie.addConfigOption" (list .externalHost $map ( print $prefix "external-host" )) -}}
 {{- include "nessie.addConfigOption" (list .userProject $map ( print $prefix "user-project" )) -}}
@@ -275,6 +279,8 @@ Apply ADLS catalog options.
 {{- $map := index . 2 -}}{{/* the destination map */}}
 {{- with $root -}}
 {{- include "nessie.addConfigOption" (list .name $map ( print $prefix "name" )) -}}
+{{- include "nessie.addConfigOption" (list .authority $map ( print $prefix "authority" )) -}}
+{{- include "nessie.addConfigOption" (list .pathPrefix $map ( print $prefix "path-prefix" )) -}}
 {{- include "nessie.addConfigOption" (list .endpoint $map ( print $prefix "endpoint" )) -}}
 {{- include "nessie.addConfigOption" (list .externalEndpoint $map ( print $prefix "external-endpoint" )) -}}
 {{- include "nessie.addConfigOption" (list .retryPolicy $map ( print $prefix "retry-policy" )) -}}

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -308,6 +308,8 @@ catalog:
       # -- Per-bucket S3 settings. Override the general settings above.
       buckets: []
       # - name: bucket1
+      #   authority: bucket1
+      #   pathPrefix: path/in/the/bucket
       #   endpoint: "https://bucket1.s3.amazonaws.com"
       #   accessKeySecret:
       #     name: awscreds
@@ -401,6 +403,8 @@ catalog:
       # -- Per-bucket GCS settings. Override the general settings above.
       buckets: []
       # - name: bucket1
+      #   authority: bucket1
+      #   pathPrefix: path/in/the/bucket
       #   authType: ACCESS_TOKEN
       #   oauth2TokenSecret:
       #     name: gcs-creds
@@ -480,6 +484,8 @@ catalog:
       # -- Per-filesystem ADLS settings. Override the general settings above.
       filesystems: []
       # - name: filesystem1
+      #   authority: bucket1
+      #   pathPrefix: path/in/the/bucket
       #   endpoint: http://localhost/adlsgen2/bucket
       #   accountSecret:
       #     name: adls-account-secret

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/ObjectStorageMockTestResourceLifecycleManager.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/ObjectStorageMockTestResourceLifecycleManager.java
@@ -39,8 +39,8 @@ public class ObjectStorageMockTestResourceLifecycleManager
   public static final String S3A_WAREHOUSE_LOCATION = bucketWarehouseLocation("s3a");
   public static final String S3N_WAREHOUSE_LOCATION = bucketWarehouseLocation("s3n");
   public static final String GCS_WAREHOUSE_LOCATION = bucketWarehouseLocation("gs");
-  public static final String ADLS_WAREHOUSE_LOCATION =
-      "abfs://" + BUCKET + "@account.dfs.core.windows.net/warehouse";
+  public static final String ADLS_AUTHORITY = BUCKET + "@account.dfs.core.windows.net";
+  public static final String ADLS_WAREHOUSE_LOCATION = "abfs://" + ADLS_AUTHORITY + "/warehouse";
 
   public static final String INIT_ADDRESS =
       "ObjectStorageMockTestResourceLifecycleManager.initAddress";
@@ -89,6 +89,7 @@ public class ObjectStorageMockTestResourceLifecycleManager
         .put("nessie.catalog.service.gcs.buckets.mock-bucket.auth-type", "none")
         // ADLS
         .put("nessie.catalog.service.adls.file-systems.mock-fs.name", BUCKET)
+        .put("nessie.catalog.service.adls.file-systems.mock-fs.authority", ADLS_AUTHORITY)
         .put("nessie.catalog.service.adls.file-systems.mock-fs.endpoint", adlsEndpoint)
         .put(
             "nessie.catalog.service.adls.file-systems.mock-fs.sas-token",


### PR DESCRIPTION
This (big) change addresses a couple of things:

* Fix an issue for ADLS to consider the whole URI-authority to select a named ADLS "bucket" - this is the storage-account-name, optionally narrowed with a container/file-system name. This has been wrong in Nessie.
* Added new attributes `authority` and `pathPrefix` to the named buckets (S3/GCS/ADLS). `authority` is the bucket name (S3/GCS) or the storage-account-name + container name (ADLS). The optional `pathPrefix` can be used to restrict selecting a named bucket configuration.
* The `authority` attribute defaults to the `name` property, which in turn defaults to the named-buckets map key. In other words, both the `name` and the `authority` attributes are optional, if the map-key is the bucket name. Recommendation is to configure the `authority` attribute explicitly.
* The named bucket configuration with the longest storage location URI match will be selected. The `authority` must match, the longest matching `pathPrefix` will be used.
* `S3Sts` (renamed to `S3StsCache`) has been moved out of `S3Options`, because it is statically configured (per server).
* Technical GCS config options have been moved from `GcsOptions` into `GcsConfig`, because those are statically configured (per server).
* Named buckets normalization became unnecessary and has been removed.
