### PR TITLE
Remove unused `sourceHashes` from `TransplantResult`

### DIFF
--- a/events/quarkus/src/test/java/org/projectnessie/events/quarkus/scenarios/EventScenarios.java
+++ b/events/quarkus/src/test/java/org/projectnessie/events/quarkus/scenarios/EventScenarios.java
@@ -95,7 +95,6 @@ public class EventScenarios {
     TransplantResult result =
         TransplantResult.builder()
             .sourceRef(BranchName.of("branch1"))
-            .sourceHashes(List.of(Hash.of("11111111"), Hash.of("22222222"), Hash.of("33333333")))
             .targetBranch(BranchName.of("branch2"))
             .effectiveTargetHash(Hash.of("567890ab"))
             .resultantTargetHash(Hash.of("90abcedf"))

--- a/events/service/src/test/java/org/projectnessie/events/service/TestEventFactory.java
+++ b/events/service/src/test/java/org/projectnessie/events/service/TestEventFactory.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableMap;
 import java.security.Principal;
 import java.time.Clock;
 import java.time.Instant;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -161,7 +160,6 @@ class TestEventFactory {
     TransplantResult result =
         TransplantResult.builder()
             .sourceRef(BranchName.of("branch1"))
-            .sourceHashes(List.of(Hash.of("11111111"), Hash.of("22222222"), Hash.of("33333333")))
             .targetBranch(BranchName.of("branch2"))
             .effectiveTargetHash(Hash.of("cafebabe")) // hash before
             .resultantTargetHash(Hash.of("deadbeef")) // hash after

--- a/events/service/src/test/java/org/projectnessie/events/service/TestEventService.java
+++ b/events/service/src/test/java/org/projectnessie/events/service/TestEventService.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -162,7 +161,6 @@ public class TestEventService {
             .build(),
         TransplantResult.builder()
             .sourceRef(BranchName.of("branch1"))
-            .sourceHashes(List.of(Hash.of("11111111"), Hash.of("22222222"), Hash.of("33333333")))
             .targetBranch(BranchName.of("branch2"))
             .effectiveTargetHash(Hash.of("cafebabe")) // hash before
             .resultantTargetHash(Hash.of("deadbeef")) // hash after

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TransplantResult.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TransplantResult.java
@@ -15,8 +15,6 @@
  */
 package org.projectnessie.versioned;
 
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import java.util.List;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -27,17 +25,11 @@ public interface TransplantResult extends MergeTransplantResultBase {
     return ResultType.TRANSPLANT;
   }
 
-  List<Hash> getSourceHashes();
-
   static TransplantResult.Builder builder() {
     return ImmutableTransplantResult.builder();
   }
 
   interface Builder extends MergeTransplantResultBase.Builder<TransplantResult, Builder> {
-
-    @CanIgnoreReturnValue
-    Builder sourceHashes(Iterable<? extends Hash> hashes);
-
     TransplantResult build();
   }
 }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TransplantIndividualImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TransplantIndividualImpl.java
@@ -83,8 +83,7 @@ final class TransplantIndividualImpl extends BaseCommitHelper implements Transpl
         TransplantResult.builder()
             .targetBranch(branch)
             .effectiveTargetHash(objIdToHash(headId()))
-            .sourceRef(transplantOp.fromRef())
-            .sourceHashes(transplantOp.sequenceToTransplant());
+            .sourceRef(transplantOp.fromRef());
 
     referenceHash.ifPresent(transplantResult::expectedHash);
 


### PR DESCRIPTION
This attribute is not returned to clients and never read/used elsewhere.
