### PR TITLE
[Catalog] Do not return `*FileIO` options from the Iceberg REST config endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ as necessary. Empty sections will not end in the release notes.
 - Sends the following default options, which are convenient when using pyiceberg:
   * `py-io-impl=pyiceberg.io.fsspec.FsspecFileIO`
   * `s3.signer=S3V4RestSigner` when S3 signing is being used
-
+- Iceberg REST: No longer return `*FileIO` options from the Iceberg REST config endpoint
 
 ### Deprecations
 

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergConfigurer.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergConfigurer.java
@@ -95,6 +95,8 @@ public class IcebergConfigurer {
 
     Map<String, String> config = new HashMap<>();
     icebergWarehouseConfig(reference, warehouse, (k, v) -> {}, config::put);
+    objectIO.configureIcebergWarehouse(
+        StorageUri.of(warehouseConfig.location()), config::put, config::put);
 
     Properties properties = new Properties();
 
@@ -111,8 +113,6 @@ public class IcebergConfigurer {
     }
 
     objectIO.trinoSampleConfig(location, config, properties::put);
-
-    properties.entrySet().forEach(System.err::println);
 
     List<String> header =
         List.of(
@@ -187,8 +187,6 @@ public class IcebergConfigurer {
     configDefault.accept(METRICS_REPORTING_ENABLED, "false");
     configDefault.accept(ICEBERG_WAREHOUSE_LOCATION, warehouseConfig.location());
     uriInfo.icebergConfigDefaults(configDefault);
-    objectIO.configureIcebergWarehouse(
-        StorageUri.of(warehouseConfig.location()), configDefault, configOverride);
     // allow users to override the 'rest-page-size' in the Nessie configuration
     configDefault.accept("rest-page-size", "200");
     lakehouseConfig.catalog().icebergConfigDefaults().forEach(configDefault);

--- a/cli/cli/src/intTest/java/org/projectnessie/nessie/cli/commands/WithNessie.java
+++ b/cli/cli/src/intTest/java/org/projectnessie/nessie/cli/commands/WithNessie.java
@@ -58,6 +58,11 @@ import software.amazon.awssdk.http.SdkHttpClient;
 public abstract class WithNessie {
 
   public static final String S3_BUCKET = "s3://bucket/";
+  public static final String GCS_BUCKET = "gs://bucket/";
+  public static final String ADLS_BUCKET = "abfs://bucket/";
+  public static final String S3_WAREHOUSE = "warehouse";
+  public static final String GCS_WAREHOUSE = "gcs_warehouse";
+  public static final String ADLS_WAREHOUSE = "adls_warehouse";
   static String nessieApiUri;
   static String icebergUri;
 
@@ -86,8 +91,11 @@ public abstract class WithNessie {
         ObjectStorageMock.builder().putBuckets("bucket", bucket.bucket()).build().start();
 
     Map<String, String> nessieProperties = new HashMap<>();
-    nessieProperties.put("nessie.catalog.default-warehouse", "warehouse");
-    nessieProperties.put("nessie.catalog.warehouses.warehouse.location", S3_BUCKET);
+    nessieProperties.put("nessie.catalog.default-warehouse", S3_WAREHOUSE);
+    nessieProperties.put("nessie.catalog.warehouses." + S3_WAREHOUSE + ".location", S3_BUCKET);
+    nessieProperties.put("nessie.catalog.warehouses." + GCS_WAREHOUSE + ".location", GCS_BUCKET);
+    nessieProperties.put("nessie.catalog.warehouses." + ADLS_WAREHOUSE + ".location", ADLS_BUCKET);
+
     nessieProperties.put(
         "nessie.catalog.service.s3.default-options.endpoint",
         objectStorage.getS3BaseUri().toString());
@@ -98,6 +106,27 @@ public abstract class WithNessie {
         "urn:nessie-secret:quarkus:with-nessie-access-key");
     nessieProperties.put("with-nessie-access-key.name", "accessKey");
     nessieProperties.put("with-nessie-access-key.secret", "secretKey");
+
+    nessieProperties.put(
+        "nessie.catalog.service.gcs.default-options.host",
+        objectStorage.getGcsBaseUri().toString());
+    nessieProperties.put("nessie.catalog.service.gcs.default-options.project-id", "nessie");
+    nessieProperties.put("nessie.catalog.service.gcs.default-options.auth-type", "access_token");
+    nessieProperties.put(
+        "nessie.catalog.service.gcs.default-options.oauth2-token",
+        "urn:nessie-secret:quarkus:my-secrets.gcs-default");
+    nessieProperties.put("my-secrets.gcs-default.token", "tokenRef");
+
+    nessieProperties.put(
+        "nessie.catalog.service.adls.default-options.endpoint",
+        objectStorage.getAdlsGen2BaseUri().toString());
+    nessieProperties.put("nessie.catalog.service.adls.default-options.auth-type", "none");
+    nessieProperties.put(
+        "nessie.catalog.service.adls.default-options.account",
+        "urn:nessie-secret:quarkus:my-secrets.adls-default");
+    nessieProperties.put("my-secrets.adls-default.name", "account");
+    nessieProperties.put("my-secrets.adls-default.secret", "secret");
+
     nessieProperties.putAll(serverConfig);
 
     NessieProcess.start(nessieProperties);

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/ConnectCommand.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/ConnectCommand.java
@@ -123,6 +123,11 @@ public class ConnectCommand extends NessieCommand<ConnectCommandSpec> {
         writer.flush();
         bearerToken = new String(System.console().readPassword()).trim();
 
+        String warehouse = connectOptions.get("warehouse");
+        if (warehouse != null) {
+          icebergProperties.put("warehouse", warehouse);
+        }
+
         nessieOptions.put(CONF_NESSIE_AUTH_TOKEN, bearerToken);
         icebergProperties.put("token", bearerToken);
       }

--- a/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/s3/ITS3IcebergCatalog.java
+++ b/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/s3/ITS3IcebergCatalog.java
@@ -53,7 +53,10 @@ public class ITS3IcebergCatalog extends AbstractIcebergCatalogIntTests {
 
   @Override
   protected FileIO temporaryFileIO(RESTCatalog catalog, FileIO io) {
-    String ioImpl = catalog.properties().get(CatalogProperties.FILE_IO_IMPL);
+    String ioImpl =
+        catalog
+            .properties()
+            .getOrDefault(CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.io.ResolvingFileIO");
     Map<String, String> props = new HashMap<>(io.properties());
     props.put(S3FileIOProperties.REMOTE_SIGNING_ENABLED, "false");
     props.put(S3FileIOProperties.ACCESS_KEY_ID, minio.accessKey());

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/AbstractIcebergCatalogTests.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/AbstractIcebergCatalogTests.java
@@ -576,7 +576,10 @@ public abstract class AbstractIcebergCatalogTests extends CatalogTests<RESTCatal
   }
 
   protected FileIO temporaryFileIO(RESTCatalog catalog, FileIO io) {
-    String ioImpl = catalog.properties().get(CatalogProperties.FILE_IO_IMPL);
+    String ioImpl =
+        catalog
+            .properties()
+            .getOrDefault(CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.io.ResolvingFileIO");
     Map<String, String> props = new HashMap<>(io.properties());
     props.put(S3FileIOProperties.REMOTE_SIGNING_ENABLED, "false");
     // dummy credentials - must be overridden if the test requires real credentials


### PR DESCRIPTION
Nessie returns all necessary `*FileIO` configurations via the `loadTable` (et al) responses, so it is not necessary to return that information from the Iceberg REST config endpoint and is therefore removed by this change.