### PR TITLE
Cache: keep (deserialized) object around

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Changes
 
+- The persistence cache tries to avoid deserialization overhead when getting an object from the
+  cache by using Java's `SoftReference`. There is no guarantee that cached objects keep their
+  Java object tree around, but it should eventually for the majority of accesses to frequently
+  accessed cached objects. The default cache capacity fraction has been reduced from 70% of the
+  heap size to 60% of the heap size. However, extreme heap pressure may let Java GC clear all
+  `SoftReference`s.
+
 ### Deprecations
 
 ### Fixes

--- a/servers/quarkus-config/src/main/java/org/projectnessie/quarkus/config/QuarkusStoreConfig.java
+++ b/servers/quarkus-config/src/main/java/org/projectnessie/quarkus/config/QuarkusStoreConfig.java
@@ -135,7 +135,7 @@ public interface QuarkusStoreConfig extends StoreConfig {
   /**
    * Fraction of Java’s max heap size to use for cache objects, set to 0 to disable. Must not be
    * used with fixed cache sizing. If neither this value nor a fixed size is configured, a default
-   * of .7 (70%) is assumed.
+   * of {@code .6} (60%) is assumed.
    */
   @WithName(CONFIG_CACHE_CAPACITY_FRACTION_OF_HEAP)
   OptionalDouble cacheCapacityFractionOfHeap();

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CacheSizing.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CacheSizing.java
@@ -27,7 +27,7 @@ public interface CacheSizing {
 
   int DEFAULT_HEAP_SIZE_KEEP_FREE = 256;
   int DEFAULT_MIN_SIZE_MB = 64;
-  double DEFAULT_HEAP_FRACTION = 0.7d;
+  double DEFAULT_HEAP_FRACTION = 0.6d;
 
   OptionalInt fixedSizeInMB();
 

--- a/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCacheExpiration.java
+++ b/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCacheExpiration.java
@@ -57,7 +57,8 @@ public class TestCacheExpiration {
     backend.put("repo", dynamicCachingObj);
     backend.put("repo", stdObj);
 
-    ConcurrentMap<CaffeineCacheBackend.CacheKeyValue, byte[]> cacheMap = backend.cache.asMap();
+    ConcurrentMap<CaffeineCacheBackend.CacheKeyValue, CaffeineCacheBackend.CacheKeyValue> cacheMap =
+        backend.cache.asMap();
 
     soft.assertThat(cacheMap)
         .doesNotContainKey(CaffeineCacheBackend.cacheKey("repo", nonCachingObj.id()))

--- a/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCacheSizing.java
+++ b/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCacheSizing.java
@@ -82,14 +82,14 @@ public class TestCacheSizing {
   void defaultSettings4G() {
     // Assuming a 4G max heap, requesting 70% (358MB), sizing must yield 2867MB.
     soft.assertThat(CacheSizing.builder().build().calculateEffectiveSizeInMB(BYTES_4G))
-        .isEqualTo(2867);
+        .isEqualTo(2457);
   }
 
   @Test
   void defaultSettings1G() {
     soft.assertThat(CacheSizing.builder().build().calculateEffectiveSizeInMB(BYTES_1G))
         // 70 % of 1024 MB
-        .isEqualTo(716);
+        .isEqualTo(614);
   }
 
   @Test


### PR DESCRIPTION
Refactor the cached-key-value to keep the deserialized object around leveraging a `java.lang.ref.SoftReference` to it. While this increases the overall heap pressure for each cached entity, the referenced objects are eligible for garbage collection, if Java GC decides to do so. This change continues to keep the serialized representation around (using a strong reference) - a "simple" `byte[]` is still way less individual Java objects compared to an "exploded" `Obj`, so less effort for GC.

This change should help to reducing the deserializing effort especially for very frequently accessed objects, despite the semantics of `SoftReference`.