### PR TITLE
Fix deprecation of `o.t.containers.CassandraContainer` + `KafkaContainer`

### DIFF
--- a/events/ri/src/intTest/java/org/projectnessie/events/ri/kafka/AbstractKafkaEventSubscriberTests.java
+++ b/events/ri/src/intTest/java/org/projectnessie/events/ri/kafka/AbstractKafkaEventSubscriberTests.java
@@ -61,9 +61,9 @@ import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.ImmutableCommitMeta;
 import org.projectnessie.model.Reference;
 import org.projectnessie.nessie.testing.containerspec.ContainerSpecHelper;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
 
 @TestInstance(Lifecycle.PER_CLASS)
 abstract class AbstractKafkaEventSubscriberTests {
@@ -71,13 +71,14 @@ abstract class AbstractKafkaEventSubscriberTests {
   protected static final Network NETWORK = Network.newNetwork();
 
   @Container
-  protected static final KafkaContainer KAFKA =
-      new KafkaContainer(
+  protected static final ConfluentKafkaContainer KAFKA =
+      new ConfluentKafkaContainer(
               ContainerSpecHelper.builder()
                   .name("kafka")
                   .containerClass(ITKafkaAvroEventSubscriber.class)
                   .build()
-                  .dockerImageName(null))
+                  .dockerImageName(null)
+                  .asCompatibleSubstituteFor("confluentinc/cp-kafka"))
           .withNetwork(NETWORK)
           .withNetworkAliases("broker");
 

--- a/events/ri/src/intTest/java/org/projectnessie/events/ri/kafka/ITKafkaAvroEventSubscriber.java
+++ b/events/ri/src/intTest/java/org/projectnessie/events/ri/kafka/ITKafkaAvroEventSubscriber.java
@@ -64,7 +64,7 @@ public class ITKafkaAvroEventSubscriber extends AbstractKafkaEventSubscriberTest
           .dependsOn(KAFKA)
           .withExposedPorts(8081)
           .withEnv("SCHEMA_REGISTRY_HOST_NAME", "schemaregistry")
-          .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "broker:9092");
+          .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "broker:9093");
 
   @Override
   protected Class<?> subscriberClass() {

--- a/events/ri/src/intTest/resources/org/projectnessie/events/ri/kafka/Dockerfile-kafka-version
+++ b/events/ri/src/intTest/resources/org/projectnessie/events/ri/kafka/Dockerfile-kafka-version
@@ -1,4 +1,4 @@
 # Dockerfile to provide the image name and tag to a test.
 # Version is managed by Renovate - do not edit.
-FROM confluentinc/cp-kafka:7.7.1
+FROM docker.io/confluentinc/cp-kafka:7.7.1
 

--- a/events/ri/src/intTest/resources/org/projectnessie/events/ri/kafka/Dockerfile-schema-registry-version
+++ b/events/ri/src/intTest/resources/org/projectnessie/events/ri/kafka/Dockerfile-schema-registry-version
@@ -1,4 +1,4 @@
 # Dockerfile to provide the image name and tag to a test.
 # Version is managed by Renovate - do not edit.
-FROM confluentinc/cp-schema-registry:7.7.1
+FROM docker.io/confluentinc/cp-schema-registry:7.7.1
 

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -184,6 +184,7 @@ dependencies {
   intTestCompileOnly(project(":nessie-immutables"))
   intTestAnnotationProcessor(project(":nessie-immutables", configuration = "processor"))
 
+  intTestImplementation(enforcedPlatform(libs.testcontainers.bom))
   intTestImplementation("io.quarkus:quarkus-test-keycloak-server")
   intTestImplementation(project(":nessie-keycloak-testcontainer"))
   intTestImplementation(libs.lowkey.vault.testcontainers)

--- a/tools/server-admin/build.gradle.kts
+++ b/tools/server-admin/build.gradle.kts
@@ -86,6 +86,7 @@ dependencies {
 
   testFixturesApi(project(":nessie-quarkus-tests"))
   testFixturesApi(project(":nessie-versioned-tests"))
+  intTestImplementation(enforcedPlatform(libs.testcontainers.bom))
   intTestImplementation(project(":nessie-versioned-storage-mongodb-tests"))
   intTestImplementation(project(":nessie-versioned-storage-mongodb2-tests"))
   intTestImplementation(project(":nessie-versioned-storage-jdbc-tests"))

--- a/versioned/storage/cassandra-tests/src/main/java/org/projectnessie/versioned/storage/cassandratests/AbstractCassandraBackendTestFactory.java
+++ b/versioned/storage/cassandra-tests/src/main/java/org/projectnessie/versioned/storage/cassandratests/AbstractCassandraBackendTestFactory.java
@@ -16,7 +16,6 @@
 package org.projectnessie.versioned.storage.cassandratests;
 
 import static java.lang.String.format;
-import static org.testcontainers.containers.CassandraContainer.CQL_PORT;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.metadata.Metadata;
@@ -32,7 +31,7 @@ import org.projectnessie.versioned.storage.cassandra.CassandraBackendConfig;
 import org.projectnessie.versioned.storage.testextension.BackendTestFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.CassandraContainer;
+import org.testcontainers.cassandra.CassandraContainer;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
@@ -42,11 +41,12 @@ public abstract class AbstractCassandraBackendTestFactory implements BackendTest
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AbstractCassandraBackendTestFactory.class);
   public static final String KEYSPACE_FOR_TEST = "nessie";
+  public static final Integer CQL_PORT = 9042;
 
   private final String dbName;
   private final List<String> args;
 
-  private CassandraContainer<?> container;
+  private CassandraContainer container;
   private InetSocketAddress hostAndPort;
   private String localDc;
 
@@ -116,8 +116,8 @@ public abstract class AbstractCassandraBackendTestFactory implements BackendTest
             .asCompatibleSubstituteFor("cassandra");
 
     for (int retry = 0; ; retry++) {
-      CassandraContainer<?> c =
-          new CassandraContainer<>(dockerImageName)
+      CassandraContainer c =
+          new CassandraContainer(dockerImageName)
               .withLogConsumer(new Slf4jLogConsumer(LOGGER))
               .withCommand(args.toArray(new String[0]));
       configureContainer(c);
@@ -160,7 +160,7 @@ public abstract class AbstractCassandraBackendTestFactory implements BackendTest
     return localDc;
   }
 
-  protected abstract void configureContainer(CassandraContainer<?> c);
+  protected abstract void configureContainer(CassandraContainer c);
 
   @Override
   public void start() {

--- a/versioned/storage/cassandra-tests/src/main/java/org/projectnessie/versioned/storage/cassandratests/CassandraBackendTestFactory.java
+++ b/versioned/storage/cassandra-tests/src/main/java/org/projectnessie/versioned/storage/cassandratests/CassandraBackendTestFactory.java
@@ -18,7 +18,7 @@ package org.projectnessie.versioned.storage.cassandratests;
 import static java.util.Collections.emptyList;
 
 import org.projectnessie.versioned.storage.cassandra.CassandraBackendFactory;
-import org.testcontainers.containers.CassandraContainer;
+import org.testcontainers.cassandra.CassandraContainer;
 
 public class CassandraBackendTestFactory extends AbstractCassandraBackendTestFactory {
 
@@ -37,7 +37,7 @@ public class CassandraBackendTestFactory extends AbstractCassandraBackendTestFac
   }
 
   @Override
-  protected void configureContainer(CassandraContainer<?> c) {
+  protected void configureContainer(CassandraContainer c) {
     c.withEnv("JVM_OPTS", JVM_OPTS_TEST);
   }
 }

--- a/versioned/storage/cassandra-tests/src/main/java/org/projectnessie/versioned/storage/cassandratests/ScyllaDBBackendTestFactory.java
+++ b/versioned/storage/cassandra-tests/src/main/java/org/projectnessie/versioned/storage/cassandratests/ScyllaDBBackendTestFactory.java
@@ -21,7 +21,7 @@ import static java.lang.Runtime.getRuntime;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
-import org.testcontainers.containers.CassandraContainer;
+import org.testcontainers.cassandra.CassandraContainer;
 
 public class ScyllaDBBackendTestFactory extends AbstractCassandraBackendTestFactory {
 
@@ -47,5 +47,5 @@ public class ScyllaDBBackendTestFactory extends AbstractCassandraBackendTestFact
   }
 
   @Override
-  protected void configureContainer(CassandraContainer<?> c) {}
+  protected void configureContainer(CassandraContainer c) {}
 }

--- a/versioned/storage/cassandra2-tests/src/main/java/org/projectnessie/versioned/storage/cassandra2tests/AbstractCassandraBackendTestFactory.java
+++ b/versioned/storage/cassandra2-tests/src/main/java/org/projectnessie/versioned/storage/cassandra2tests/AbstractCassandraBackendTestFactory.java
@@ -16,7 +16,6 @@
 package org.projectnessie.versioned.storage.cassandra2tests;
 
 import static java.lang.String.format;
-import static org.testcontainers.containers.CassandraContainer.CQL_PORT;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.metadata.Metadata;
@@ -32,7 +31,7 @@ import org.projectnessie.versioned.storage.cassandra2.Cassandra2BackendConfig;
 import org.projectnessie.versioned.storage.testextension.BackendTestFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.CassandraContainer;
+import org.testcontainers.cassandra.CassandraContainer;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
@@ -42,11 +41,12 @@ public abstract class AbstractCassandraBackendTestFactory implements BackendTest
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AbstractCassandraBackendTestFactory.class);
   public static final String KEYSPACE_FOR_TEST = "nessie";
+  public static final Integer CQL_PORT = 9042;
 
   private final String dbName;
   private final List<String> args;
 
-  private CassandraContainer<?> container;
+  private CassandraContainer container;
   private InetSocketAddress hostAndPort;
   private String localDc;
 
@@ -117,8 +117,8 @@ public abstract class AbstractCassandraBackendTestFactory implements BackendTest
             .asCompatibleSubstituteFor("cassandra");
 
     for (int retry = 0; ; retry++) {
-      CassandraContainer<?> c =
-          new CassandraContainer<>(dockerImageName)
+      CassandraContainer c =
+          new CassandraContainer(dockerImageName)
               .withLogConsumer(new Slf4jLogConsumer(LOGGER))
               .withCommand(args.toArray(new String[0]));
       configureContainer(c);
@@ -161,7 +161,7 @@ public abstract class AbstractCassandraBackendTestFactory implements BackendTest
     return localDc;
   }
 
-  protected abstract void configureContainer(CassandraContainer<?> c);
+  protected abstract void configureContainer(CassandraContainer c);
 
   @Override
   public void start() {

--- a/versioned/storage/cassandra2-tests/src/main/java/org/projectnessie/versioned/storage/cassandra2tests/CassandraBackendTestFactory.java
+++ b/versioned/storage/cassandra2-tests/src/main/java/org/projectnessie/versioned/storage/cassandra2tests/CassandraBackendTestFactory.java
@@ -18,7 +18,7 @@ package org.projectnessie.versioned.storage.cassandra2tests;
 import static java.util.Collections.emptyList;
 
 import org.projectnessie.versioned.storage.cassandra2.Cassandra2BackendFactory;
-import org.testcontainers.containers.CassandraContainer;
+import org.testcontainers.cassandra.CassandraContainer;
 
 public class CassandraBackendTestFactory extends AbstractCassandraBackendTestFactory {
 
@@ -37,7 +37,7 @@ public class CassandraBackendTestFactory extends AbstractCassandraBackendTestFac
   }
 
   @Override
-  protected void configureContainer(CassandraContainer<?> c) {
+  protected void configureContainer(CassandraContainer c) {
     c.withEnv("JVM_OPTS", JVM_OPTS_TEST);
   }
 }

--- a/versioned/storage/cassandra2-tests/src/main/java/org/projectnessie/versioned/storage/cassandra2tests/ScyllaDBBackendTestFactory.java
+++ b/versioned/storage/cassandra2-tests/src/main/java/org/projectnessie/versioned/storage/cassandra2tests/ScyllaDBBackendTestFactory.java
@@ -21,7 +21,7 @@ import static java.lang.Runtime.getRuntime;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
-import org.testcontainers.containers.CassandraContainer;
+import org.testcontainers.cassandra.CassandraContainer;
 
 public class ScyllaDBBackendTestFactory extends AbstractCassandraBackendTestFactory {
 
@@ -47,5 +47,5 @@ public class ScyllaDBBackendTestFactory extends AbstractCassandraBackendTestFact
   }
 
   @Override
-  protected void configureContainer(CassandraContainer<?> c) {}
+  protected void configureContainer(CassandraContainer c) {}
 }


### PR DESCRIPTION
... in favor of `org.testcontainers.cassandra.CassandraContainer` and `org.testcontainers.kafka.KafkaContainer`. It seems that has been introduced by the testcontainers bump in #9675.
