### PR TITLE
Let `Persist.scanAllObjects()` accept an empty set to return all object types

### DIFF
--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraPersist.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraPersist.java
@@ -59,6 +59,7 @@ import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.projectnessie.versioned.storage.cassandra.CassandraBackend.BatchedQuery;
 import org.projectnessie.versioned.storage.cassandra.serializers.ObjSerializer;
@@ -569,10 +570,10 @@ public class CassandraPersist implements Persist {
       implements CloseableIterator<Obj> {
 
     private final Iterator<Row> rs;
-    private final Set<ObjType> returnedObjTypes;
+    private final Predicate<ObjType> returnedObjTypes;
 
     ScanAllObjectsIterator(Set<ObjType> returnedObjTypes) {
-      this.returnedObjTypes = returnedObjTypes;
+      this.returnedObjTypes = returnedObjTypes.isEmpty() ? x -> true : returnedObjTypes::contains;
       BoundStatement stmt = backend.buildStatement(SCAN_OBJS, true, config.repositoryId());
       rs = backend.execute(stmt).iterator();
     }
@@ -590,7 +591,7 @@ public class CassandraPersist implements Persist {
 
         Row row = rs.next();
         ObjType type = objTypeByName(requireNonNull(row.getString(COL_OBJ_TYPE.name())));
-        if (!returnedObjTypes.contains(type)) {
+        if (!returnedObjTypes.test(type)) {
           continue;
         }
 

--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBackendRepositoryTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBackendRepositoryTests.java
@@ -21,6 +21,7 @@ import static org.projectnessie.versioned.storage.versionstore.RefMapping.REFS_H
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -42,7 +43,6 @@ import org.projectnessie.versioned.storage.common.persist.Backend;
 import org.projectnessie.versioned.storage.common.persist.CloseableIterator;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
-import org.projectnessie.versioned.storage.common.persist.ObjTypes;
 import org.projectnessie.versioned.storage.common.persist.Persist;
 import org.projectnessie.versioned.storage.common.persist.PersistFactory;
 import org.projectnessie.versioned.storage.common.persist.Reference;
@@ -80,7 +80,7 @@ public class AbstractBackendRepositoryTests {
                     .toArray(Obj[]::new)))
         .hasSize(objs)
         .doesNotContain(false);
-    try (CloseableIterator<Obj> scan = repo1.scanAllObjects(ObjTypes.allObjTypes())) {
+    try (CloseableIterator<Obj> scan = repo1.scanAllObjects(Set.of())) {
       soft.assertThat(scan)
           .toIterable()
           .filteredOn(
@@ -90,7 +90,7 @@ public class AbstractBackendRepositoryTests {
 
     repo1.erase();
     soft.assertThat(repositoryLogic.repositoryExists()).isFalse();
-    try (CloseableIterator<Obj> scan = repo1.scanAllObjects(ObjTypes.allObjTypes())) {
+    try (CloseableIterator<Obj> scan = repo1.scanAllObjects(Set.of())) {
       soft.assertThat(scan).isExhausted();
     }
   }
@@ -109,7 +109,7 @@ public class AbstractBackendRepositoryTests {
     soft.assertThat(repos)
         .noneMatch(
             r -> {
-              try (CloseableIterator<Obj> scan = r.scanAllObjects(ObjTypes.allObjTypes())) {
+              try (CloseableIterator<Obj> scan = r.scanAllObjects(Set.of())) {
                 return scan.hasNext();
               }
             });
@@ -152,7 +152,7 @@ public class AbstractBackendRepositoryTests {
     soft.assertThat(toDelete)
         .noneMatch(
             r -> {
-              try (CloseableIterator<Obj> scan = r.scanAllObjects(ObjTypes.allObjTypes())) {
+              try (CloseableIterator<Obj> scan = r.scanAllObjects(Set.of())) {
                 return scan.hasNext();
               }
             });
@@ -162,7 +162,7 @@ public class AbstractBackendRepositoryTests {
       for (int i = 0; i < refs; i++) {
         soft.assertThat(repo.fetchReference(REFS_HEADS + "reference-" + i)).isNotNull();
       }
-      try (CloseableIterator<Obj> scan = repo.scanAllObjects(ObjTypes.allObjTypes())) {
+      try (CloseableIterator<Obj> scan = repo.scanAllObjects(Set.of())) {
         soft.assertThat(scan)
             .toIterable()
             .filteredOn(

--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBasePersistTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBasePersistTests.java
@@ -1121,6 +1121,17 @@ public class AbstractBasePersistTests {
     soft.assertThat(list1).isNotEmpty().doesNotContainAnyElementsOf(list2);
     soft.assertThat(list2).isNotEmpty().doesNotContainAnyElementsOf(list1);
 
+    ArrayList<Obj> list1b;
+    try (CloseableIterator<Obj> iter = persist.scanAllObjects(Set.of())) {
+      list1b = newArrayList(iter);
+    }
+    ArrayList<Obj> list2b;
+    try (CloseableIterator<Obj> iter = otherRepo.scanAllObjects(Set.of())) {
+      list2b = newArrayList(iter);
+    }
+    soft.assertThat(list1b).isEqualTo(list1);
+    soft.assertThat(list2b).isEqualTo(list2);
+
     try (CloseableIterator<Obj> iter = otherRepo.scanAllObjects(Set.of(COMMIT))) {
       soft.assertThat(newArrayList(iter)).isNotEmpty().allMatch(o -> o.type() == COMMIT);
     }
@@ -1376,6 +1387,13 @@ public class AbstractBasePersistTests {
           .contains(strings)
           .contains(commits);
     }
+    try (CloseableIterator<Obj> scan = persist.scanAllObjects(Set.of())) {
+      soft.assertThat(Lists.newArrayList(scan))
+          .hasSize(3 * numObjs)
+          .contains(values)
+          .contains(strings)
+          .contains(commits);
+    }
     try (CloseableIterator<Obj> scan = persist.scanAllObjects(Set.of(VALUE, STRING))) {
       soft.assertThat(Lists.newArrayList(scan))
           .hasSize(2 * numObjs)
@@ -1426,6 +1444,9 @@ public class AbstractBasePersistTests {
         .containsExactly(objs);
 
     try (CloseableIterator<Obj> scan = persist.scanAllObjects(ObjTypes.allObjTypes())) {
+      soft.assertThat(Lists.newArrayList(scan)).containsExactlyInAnyOrder(objs);
+    }
+    try (CloseableIterator<Obj> scan = persist.scanAllObjects(Set.of())) {
       soft.assertThat(Lists.newArrayList(scan)).containsExactlyInAnyOrder(objs);
     }
     try (CloseableIterator<Obj> scan =

--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractRepositoryLogicTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractRepositoryLogicTests.java
@@ -57,7 +57,6 @@ import org.projectnessie.versioned.storage.common.objtypes.CommitType;
 import org.projectnessie.versioned.storage.common.persist.CloseableIterator;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
-import org.projectnessie.versioned.storage.common.persist.ObjTypes;
 import org.projectnessie.versioned.storage.common.persist.Persist;
 import org.projectnessie.versioned.storage.common.persist.Reference;
 import org.projectnessie.versioned.storage.testextension.NessiePersist;
@@ -82,7 +81,7 @@ public class AbstractRepositoryLogicTests {
     persist.erase();
     soft.assertThat(repositoryLogic.repositoryExists()).isFalse();
 
-    try (CloseableIterator<Obj> iter = persist.scanAllObjects(ObjTypes.allObjTypes())) {
+    try (CloseableIterator<Obj> iter = persist.scanAllObjects(Set.of())) {
       soft.assertThat(iter).isExhausted();
     }
   }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Persist.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Persist.java
@@ -427,6 +427,8 @@ public interface Persist {
    * <p>It is possible that databases have to scan all rows/items in the tables/collections, which
    * can lead to a <em>very</em> long runtime of this method.
    *
+   * @param returnedObjTypes if empty, all object types are returned, otherwise only the given
+   *     object types will be returned
    * @return iterator over all objects, must be closed
    */
   @Nonnull

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBPersist.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBPersist.java
@@ -762,14 +762,17 @@ public class DynamoDBPersist implements Persist {
 
     public ScanAllObjectsIterator(Set<ObjType> returnedObjTypes) {
 
-      AttributeValue[] objTypes =
-          returnedObjTypes.stream()
-              .map(ObjType::shortName)
-              .map(AttributeValue::fromS)
-              .toArray(AttributeValue[]::new);
       Map<String, Condition> scanFilter = new HashMap<>();
       scanFilter.put(KEY_NAME, condition(BEGINS_WITH, fromS(keyPrefix)));
-      scanFilter.put(COL_OBJ_TYPE, condition(IN, objTypes));
+
+      if (!returnedObjTypes.isEmpty()) {
+        AttributeValue[] objTypes =
+            returnedObjTypes.stream()
+                .map(ObjType::shortName)
+                .map(AttributeValue::fromS)
+                .toArray(AttributeValue[]::new);
+        scanFilter.put(COL_OBJ_TYPE, condition(IN, objTypes));
+      }
 
       try {
         iter =

--- a/versioned/storage/dynamodb2/src/main/java/org/projectnessie/versioned/storage/dynamodb2/DynamoDB2Persist.java
+++ b/versioned/storage/dynamodb2/src/main/java/org/projectnessie/versioned/storage/dynamodb2/DynamoDB2Persist.java
@@ -760,14 +760,17 @@ public class DynamoDB2Persist implements Persist {
 
     public ScanAllObjectsIterator(Set<ObjType> returnedObjTypes) {
 
-      AttributeValue[] objTypes =
-          returnedObjTypes.stream()
-              .map(ObjType::shortName)
-              .map(AttributeValue::fromS)
-              .toArray(AttributeValue[]::new);
       Map<String, Condition> scanFilter = new HashMap<>();
       scanFilter.put(KEY_NAME, condition(BEGINS_WITH, fromS(keyPrefix)));
-      scanFilter.put(COL_OBJ_TYPE, condition(IN, objTypes));
+
+      if (!returnedObjTypes.isEmpty()) {
+        AttributeValue[] objTypes =
+            returnedObjTypes.stream()
+                .map(ObjType::shortName)
+                .map(AttributeValue::fromS)
+                .toArray(AttributeValue[]::new);
+        scanFilter.put(COL_OBJ_TYPE, condition(IN, objTypes));
+      }
 
       try {
         iter =

--- a/versioned/storage/inmemory/src/main/java/org/projectnessie/versioned/storage/inmemory/InmemoryPersist.java
+++ b/versioned/storage/inmemory/src/main/java/org/projectnessie/versioned/storage/inmemory/InmemoryPersist.java
@@ -339,7 +339,8 @@ class InmemoryPersist implements ValidatingPersist {
   @Nonnull
   @Override
   public CloseableIterator<Obj> scanAllObjects(@Nonnull Set<ObjType> returnedObjTypes) {
-    return new ScanAllObjectsIterator(returnedObjTypes::contains);
+    return new ScanAllObjectsIterator(
+        returnedObjTypes.isEmpty() ? x -> true : returnedObjTypes::contains);
   }
 
   private class ScanAllObjectsIterator extends AbstractIterator<Obj>

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/SqlConstants.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/SqlConstants.java
@@ -204,16 +204,16 @@ final class SqlConstants {
 
   static final String FIND_OBJS_TYPED = FIND_OBJS + " AND " + COL_OBJ_TYPE + "=?";
 
-  static final String SCAN_OBJS =
+  static final String SCAN_OBJS_ALL =
       "SELECT "
           + String.join(", ", COLS_OBJS_ALL.keySet())
           + " FROM "
           + TABLE_OBJS
           + " WHERE "
           + COL_REPO_ID
-          + "=? AND "
-          + COL_OBJ_TYPE
-          + " IN (?)";
+          + "=?";
+
+  static final String SCAN_OBJS = SCAN_OBJS_ALL + " AND " + COL_OBJ_TYPE + " IN (?)";
 
   private SqlConstants() {}
 }

--- a/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/SqlConstants.java
+++ b/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/SqlConstants.java
@@ -206,16 +206,10 @@ final class SqlConstants {
 
   static final String FIND_OBJS_TYPED = FIND_OBJS + " AND " + COL_OBJ_TYPE + "=?";
 
-  static final String SCAN_OBJS =
-      "SELECT "
-          + COLS_OBJS_ALL_NAMES
-          + " FROM "
-          + TABLE_OBJS
-          + " WHERE "
-          + COL_REPO_ID
-          + "=? AND "
-          + COL_OBJ_TYPE
-          + " IN (?)";
+  static final String SCAN_OBJS_ALL =
+      "SELECT " + COLS_OBJS_ALL_NAMES + " FROM " + TABLE_OBJS + " WHERE " + COL_REPO_ID + "=?";
+
+  static final String SCAN_OBJS = SCAN_OBJS_ALL + " AND " + COL_OBJ_TYPE + " IN (?)";
 
   private SqlConstants() {}
 }

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
@@ -781,17 +781,14 @@ public class MongoDBPersist implements Persist {
     private final MongoCursor<Document> result;
 
     public ScanAllObjectsIterator(Set<ObjType> returnedObjTypes) {
-      List<String> objTypeShortNames =
-          returnedObjTypes.stream().map(ObjType::shortName).collect(toList());
+      Bson condition = eq(ID_REPO_PATH, config.repositoryId());
+      if (!returnedObjTypes.isEmpty()) {
+        List<String> objTypeShortNames =
+            returnedObjTypes.stream().map(ObjType::shortName).collect(toList());
+        condition = and(condition, in(COL_OBJ_TYPE, objTypeShortNames));
+      }
       try {
-        result =
-            backend
-                .objs()
-                .find(
-                    and(
-                        eq(ID_REPO_PATH, config.repositoryId()),
-                        in(COL_OBJ_TYPE, objTypeShortNames)))
-                .iterator();
+        result = backend.objs().find(condition).iterator();
       } catch (RuntimeException e) {
         throw unhandledException(e);
       }

--- a/versioned/storage/mongodb2/src/main/java/org/projectnessie/versioned/storage/mongodb2/MongoDB2Persist.java
+++ b/versioned/storage/mongodb2/src/main/java/org/projectnessie/versioned/storage/mongodb2/MongoDB2Persist.java
@@ -782,17 +782,15 @@ public class MongoDB2Persist implements Persist {
     private final MongoCursor<Document> result;
 
     public ScanAllObjectsIterator(Set<ObjType> returnedObjTypes) {
-      List<String> objTypeShortNames =
-          returnedObjTypes.stream().map(ObjType::shortName).collect(toList());
+      Bson condition = eq(ID_REPO_PATH, config.repositoryId());
+      if (!returnedObjTypes.isEmpty()) {
+        List<String> objTypeShortNames =
+            returnedObjTypes.stream().map(ObjType::shortName).collect(toList());
+        condition = and(condition, in(COL_OBJ_TYPE, objTypeShortNames));
+      }
+
       try {
-        result =
-            backend
-                .objs()
-                .find(
-                    and(
-                        eq(ID_REPO_PATH, config.repositoryId()),
-                        in(COL_OBJ_TYPE, objTypeShortNames)))
-                .iterator();
+        result = backend.objs().find(condition).iterator();
       } catch (RuntimeException e) {
         throw unhandledException(e);
       }

--- a/versioned/storage/rocksdb/src/main/java/org/projectnessie/versioned/storage/rocksdb/RocksDBPersist.java
+++ b/versioned/storage/rocksdb/src/main/java/org/projectnessie/versioned/storage/rocksdb/RocksDBPersist.java
@@ -529,7 +529,8 @@ class RocksDBPersist implements Persist {
   @Nonnull
   @Override
   public CloseableIterator<Obj> scanAllObjects(@Nonnull Set<ObjType> returnedObjTypes) {
-    return new ScanAllObjectsIterator(returnedObjTypes::contains);
+    return new ScanAllObjectsIterator(
+        returnedObjTypes.isEmpty() ? x -> true : returnedObjTypes::contains);
   }
 
   private class ScanAllObjectsIterator extends AbstractIterator<Obj>


### PR DESCRIPTION
The current behavior for an empty set of expected object types is to return nothing (but do a lot), which doesn't make sense. This change updates the give an empty set the meaning to return all object types, and skip object-type filtering.