### PR TITLE
Make the composite `TransferRelatedObjects` accessible to other projects

### DIFF
--- a/versioned/transfer-related/src/main/java/org/projectnessie/versioned/transfer/related/CompositeTransferRelatedObjects.java
+++ b/versioned/transfer-related/src/main/java/org/projectnessie/versioned/transfer/related/CompositeTransferRelatedObjects.java
@@ -13,35 +13,40 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.versioned.transfer;
+package org.projectnessie.versioned.transfer.related;
 
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.agrona.collections.ObjectHashSet;
 import org.projectnessie.model.Content;
-import org.projectnessie.versioned.storage.common.logic.IdentifyHeadsAndForkPoints;
 import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 import org.projectnessie.versioned.storage.common.persist.Reference;
-import org.projectnessie.versioned.transfer.related.TransferRelatedObjects;
 
-final class CompositeTransferRelatedObjects implements TransferRelatedObjects {
+public final class CompositeTransferRelatedObjects implements TransferRelatedObjects {
 
   private final List<TransferRelatedObjects> transferRelatedObjectsImpls;
+  private final Predicate<ObjId> filter;
 
-  /**
-   * One "related" object might be referenced by multiple content objects or commits or references.
-   * This implementation avoid exporting the same "related" object more than once. This set of
-   * {@link ObjId}s is unbounded, like the collections in {@link IdentifyHeadsAndForkPoints}.
-   */
-  private final ObjectHashSet<ObjId> seen = new ObjectHashSet<>();
+  public static TransferRelatedObjects createCompositeTransferRelatedObjects() {
+    return createCompositeTransferRelatedObjects(List.of(), x -> true);
+  }
 
-  public CompositeTransferRelatedObjects(List<URL> jarUrls) {
+  public static TransferRelatedObjects createCompositeTransferRelatedObjects(List<URL> jarUrls) {
+    return createCompositeTransferRelatedObjects(jarUrls, x -> true);
+  }
+
+  public static TransferRelatedObjects createCompositeTransferRelatedObjects(
+      List<URL> jarUrls, Predicate<ObjId> filter) {
+    return new CompositeTransferRelatedObjects(jarUrls, filter);
+  }
+
+  private CompositeTransferRelatedObjects(List<URL> jarUrls, Predicate<ObjId> filter) {
     // Exporter runs as a Quarkus CLI application, so "just adding additional jars via `java
     // -classpath`" doesn't work here. The artifacts that implement TransferRelatedObjects are
     // rather lightweight and only depend on code that's present in Nessie's server-admin-tool (in
@@ -54,35 +59,36 @@ final class CompositeTransferRelatedObjects implements TransferRelatedObjects {
         ServiceLoader.load(TransferRelatedObjects.class, cl).stream()
             .map(ServiceLoader.Provider::get)
             .collect(Collectors.toList());
+    this.filter = filter;
   }
 
-  private Set<ObjId> filterSeen(Stream<ObjId> src) {
-    return src.filter(seen::add).collect(Collectors.toSet());
+  private Set<ObjId> filter(Stream<ObjId> src) {
+    return src.filter(filter).collect(Collectors.toSet());
   }
 
   @Override
   public Set<ObjId> repositoryRelatedObjects() {
-    return filterSeen(
+    return filter(
         transferRelatedObjectsImpls.stream().flatMap(i -> i.repositoryRelatedObjects().stream()));
   }
 
   @Override
   public Set<ObjId> commitRelatedObjects(CommitObj commitObj) {
-    return filterSeen(
+    return filter(
         transferRelatedObjectsImpls.stream()
             .flatMap(i -> i.commitRelatedObjects(commitObj).stream()));
   }
 
   @Override
   public Set<ObjId> contentRelatedObjects(Content content) {
-    return filterSeen(
+    return filter(
         transferRelatedObjectsImpls.stream()
             .flatMap(i -> i.contentRelatedObjects(content).stream()));
   }
 
   @Override
   public Set<ObjId> referenceRelatedObjects(Reference reference) {
-    return filterSeen(
+    return filter(
         transferRelatedObjectsImpls.stream()
             .flatMap(i -> i.referenceRelatedObjects(reference).stream()));
   }


### PR DESCRIPTION
no functional change