### PR TITLE
Persist: introduce `deleteWithReferenced(Obj)`

### DIFF
--- a/versioned/storage/batching/src/main/java/org/projectnessie/versioned/storage/batching/BatchingPersistImpl.java
+++ b/versioned/storage/batching/src/main/java/org/projectnessie/versioned/storage/batching/BatchingPersistImpl.java
@@ -330,6 +330,11 @@ final class BatchingPersistImpl implements BatchingPersist, ValidatingPersist {
   }
 
   @Override
+  public boolean deleteWithReferenced(@Nonnull Obj obj) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public boolean deleteConditional(@Nonnull UpdateableObj obj) {
     throw new UnsupportedOperationException();
   }

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CachingPersistImpl.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CachingPersistImpl.java
@@ -303,6 +303,15 @@ class CachingPersistImpl implements Persist {
   }
 
   @Override
+  public boolean deleteWithReferenced(@Nonnull Obj obj) {
+    try {
+      return persist.deleteWithReferenced(obj);
+    } finally {
+      cache.remove(obj.id());
+    }
+  }
+
+  @Override
   public boolean deleteConditional(@Nonnull UpdateableObj obj) {
     try {
       return persist.deleteConditional(obj);

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraConstants.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraConstants.java
@@ -81,6 +81,17 @@ public final class CassandraConstants {
           + COL_OBJ_VERS
           + "=?";
 
+  static final String DELETE_OBJ_REFERENCED =
+      "DELETE FROM %s."
+          + TABLE_OBJS
+          + " WHERE "
+          + COL_REPO_ID
+          + "=? AND "
+          + COL_OBJ_ID
+          + "=? IF "
+          + COL_OBJ_REFERENCED
+          + "=?";
+
   public static final String INSERT_OBJ_PREFIX =
       "INSERT INTO %s."
           + TABLE_OBJS
@@ -124,7 +135,10 @@ public final class CassandraConstants {
           + " AND "
           + COL_OBJ_ID
           + "=:"
-          + COL_OBJ_ID;
+          + COL_OBJ_ID
+          // IF EXISTS is necessary to prevent writing just the referenced timestamp after an object
+          // has been deleted.
+          + " IF EXISTS";
 
   static final Set<CqlColumn> COLS_OBJS_ALL =
       Stream.concat(

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraPersist.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraPersist.java
@@ -28,6 +28,7 @@ import static org.projectnessie.versioned.storage.cassandra.CassandraConstants.C
 import static org.projectnessie.versioned.storage.cassandra.CassandraConstants.COL_REPO_ID;
 import static org.projectnessie.versioned.storage.cassandra.CassandraConstants.DELETE_OBJ;
 import static org.projectnessie.versioned.storage.cassandra.CassandraConstants.DELETE_OBJ_CONDITIONAL;
+import static org.projectnessie.versioned.storage.cassandra.CassandraConstants.DELETE_OBJ_REFERENCED;
 import static org.projectnessie.versioned.storage.cassandra.CassandraConstants.EXPECTED_SUFFIX;
 import static org.projectnessie.versioned.storage.cassandra.CassandraConstants.FETCH_OBJ_TYPE;
 import static org.projectnessie.versioned.storage.cassandra.CassandraConstants.FIND_OBJS;
@@ -340,6 +341,18 @@ public class CassandraPersist implements Persist {
   public void upsertObjs(@Nonnull Obj[] objs) throws ObjTooLargeException {
     long referenced = config.currentTimeMicros();
     persistObjs(objs, referenced, true);
+  }
+
+  @Override
+  public boolean deleteWithReferenced(@Nonnull Obj obj) {
+    BoundStatement stmt =
+        backend.buildStatement(
+            DELETE_OBJ_REFERENCED,
+            false,
+            config.repositoryId(),
+            serializeObjId(obj.id()),
+            obj.referenced());
+    return backend.executeCas(stmt);
   }
 
   @Override

--- a/versioned/storage/cassandra2/src/main/java/org/projectnessie/versioned/storage/cassandra2/Cassandra2Constants.java
+++ b/versioned/storage/cassandra2/src/main/java/org/projectnessie/versioned/storage/cassandra2/Cassandra2Constants.java
@@ -115,6 +115,17 @@ public final class Cassandra2Constants {
           + COL_OBJ_VERS
           + "=?";
 
+  static final String DELETE_OBJ_REFERENCED =
+      "DELETE FROM %s."
+          + TABLE_OBJS
+          + " WHERE "
+          + COL_REPO_ID
+          + "=? AND "
+          + COL_OBJ_ID
+          + "=? IF "
+          + COL_OBJ_REFERENCED
+          + "=?";
+
   static final String CREATE_TABLE_OBJS =
       "CREATE TABLE %s."
           + TABLE_OBJS
@@ -376,7 +387,10 @@ public final class Cassandra2Constants {
           + " AND "
           + COL_OBJ_ID
           + "=:"
-          + COL_OBJ_ID;
+          + COL_OBJ_ID
+          // IF EXISTS is necessary to prevent writing just the referenced timestamp after an object
+          // has been deleted.
+          + " IF EXISTS";
 
   private Cassandra2Constants() {}
 }

--- a/versioned/storage/cassandra2/src/main/java/org/projectnessie/versioned/storage/cassandra2/Cassandra2Persist.java
+++ b/versioned/storage/cassandra2/src/main/java/org/projectnessie/versioned/storage/cassandra2/Cassandra2Persist.java
@@ -29,6 +29,7 @@ import static org.projectnessie.versioned.storage.cassandra2.Cassandra2Constants
 import static org.projectnessie.versioned.storage.cassandra2.Cassandra2Constants.COL_REPO_ID;
 import static org.projectnessie.versioned.storage.cassandra2.Cassandra2Constants.DELETE_OBJ;
 import static org.projectnessie.versioned.storage.cassandra2.Cassandra2Constants.DELETE_OBJ_CONDITIONAL;
+import static org.projectnessie.versioned.storage.cassandra2.Cassandra2Constants.DELETE_OBJ_REFERENCED;
 import static org.projectnessie.versioned.storage.cassandra2.Cassandra2Constants.EXPECTED_SUFFIX;
 import static org.projectnessie.versioned.storage.cassandra2.Cassandra2Constants.FETCH_OBJ_TYPE;
 import static org.projectnessie.versioned.storage.cassandra2.Cassandra2Constants.FIND_OBJS;
@@ -340,6 +341,18 @@ public class Cassandra2Persist implements Persist {
   public void upsertObjs(@Nonnull Obj[] objs) throws ObjTooLargeException {
     long referenced = config.currentTimeMicros();
     persistObjs(objs, referenced, true);
+  }
+
+  @Override
+  public boolean deleteWithReferenced(@Nonnull Obj obj) {
+    BoundStatement stmt =
+        backend.buildStatement(
+            DELETE_OBJ_REFERENCED,
+            false,
+            config.repositoryId(),
+            serializeObjId(obj.id()),
+            obj.referenced());
+    return backend.executeCas(stmt);
   }
 
   @Override

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObservingPersist.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObservingPersist.java
@@ -275,6 +275,14 @@ public class ObservingPersist implements Persist {
   @Override
   @Counted(PREFIX)
   @Timed(value = PREFIX, histogram = true)
+  public boolean deleteWithReferenced(@Nonnull Obj obj) {
+    return delegate.deleteWithReferenced(obj);
+  }
+
+  @WithSpan
+  @Override
+  @Counted(PREFIX)
+  @Timed(value = PREFIX, histogram = true)
   public boolean deleteConditional(@Nonnull UpdateableObj obj) {
     return delegate.deleteConditional(obj);
   }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Persist.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Persist.java
@@ -379,6 +379,14 @@ public interface Persist {
   void deleteObjs(@Nonnull ObjId[] ids);
 
   /**
+   * Deletes the given object, if its {@link Obj#referenced()} value is equal to the persisted
+   * object's value. Since a caching {@link Persist} does not guarantee that the {@link
+   * Obj#referenced()} value is up-to-date, callers must ensure that they read the uncached object
+   * state, for example via a {@link #scanAllObjects(Set)}.
+   */
+  boolean deleteWithReferenced(@Nonnull Obj obj);
+
+  /**
    * Deletes the object, if the current state in the database is equal to the given state, comparing
    * the {@link UpdateableObj#versionToken()}.
    *

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBPersist.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBPersist.java
@@ -546,6 +546,28 @@ public class DynamoDBPersist implements Persist {
   }
 
   @Override
+  public boolean deleteWithReferenced(@Nonnull Obj obj) {
+    ObjId id = obj.id();
+
+    Map<String, ExpectedAttributeValue> expectedValues =
+        Map.of(
+            COL_OBJ_REFERENCED,
+            ExpectedAttributeValue.builder().value(fromS(Long.toString(obj.referenced()))).build());
+
+    try {
+      backend
+          .client()
+          .deleteItem(
+              b -> b.tableName(backend.tableObjs).key(objKeyMap(id)).expected(expectedValues));
+      return true;
+    } catch (ConditionalCheckFailedException checkFailedException) {
+      return false;
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
+  }
+
+  @Override
   public boolean deleteConditional(@Nonnull UpdateableObj obj) {
     ObjId id = obj.id();
 

--- a/versioned/storage/dynamodb2/src/main/java/org/projectnessie/versioned/storage/dynamodb2/DynamoDB2Persist.java
+++ b/versioned/storage/dynamodb2/src/main/java/org/projectnessie/versioned/storage/dynamodb2/DynamoDB2Persist.java
@@ -547,6 +547,28 @@ public class DynamoDB2Persist implements Persist {
   }
 
   @Override
+  public boolean deleteWithReferenced(@Nonnull Obj obj) {
+    ObjId id = obj.id();
+
+    Map<String, ExpectedAttributeValue> expectedValues =
+        Map.of(
+            COL_OBJ_REFERENCED,
+            ExpectedAttributeValue.builder().value(fromS(Long.toString(obj.referenced()))).build());
+
+    try {
+      backend
+          .client()
+          .deleteItem(
+              b -> b.tableName(backend.tableObjs).key(objKeyMap(id)).expected(expectedValues));
+      return true;
+    } catch (ConditionalCheckFailedException checkFailedException) {
+      return false;
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
+  }
+
+  @Override
   public boolean deleteConditional(@Nonnull UpdateableObj obj) {
     ObjId id = obj.id();
 

--- a/versioned/storage/inmemory/src/main/java/org/projectnessie/versioned/storage/inmemory/InmemoryPersist.java
+++ b/versioned/storage/inmemory/src/main/java/org/projectnessie/versioned/storage/inmemory/InmemoryPersist.java
@@ -288,6 +288,24 @@ class InmemoryPersist implements ValidatingPersist {
   }
 
   @Override
+  public boolean deleteWithReferenced(@Nonnull Obj obj) {
+    AtomicBoolean result = new AtomicBoolean();
+    inmemory.objects.compute(
+        compositeKey(obj.id()),
+        (k, v) -> {
+          if (v == null) {
+            // not present
+            return null;
+          } else if (v.referenced() != obj.referenced()) {
+            return v;
+          }
+          result.set(true);
+          return null;
+        });
+    return result.get();
+  }
+
+  @Override
   public boolean deleteConditional(@Nonnull UpdateableObj obj) {
     return updateDeleteConditional(obj, null);
   }

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
@@ -31,6 +31,7 @@ import static org.projectnessie.versioned.storage.jdbc.SqlConstants.COL_OBJ_VERS
 import static org.projectnessie.versioned.storage.jdbc.SqlConstants.COL_REPO_ID;
 import static org.projectnessie.versioned.storage.jdbc.SqlConstants.DELETE_OBJ;
 import static org.projectnessie.versioned.storage.jdbc.SqlConstants.DELETE_OBJ_CONDITIONAL;
+import static org.projectnessie.versioned.storage.jdbc.SqlConstants.DELETE_OBJ_REFERENCED;
 import static org.projectnessie.versioned.storage.jdbc.SqlConstants.FETCH_OBJ_TYPE;
 import static org.projectnessie.versioned.storage.jdbc.SqlConstants.FIND_OBJS;
 import static org.projectnessie.versioned.storage.jdbc.SqlConstants.FIND_OBJS_TYPED;
@@ -440,6 +441,17 @@ abstract class AbstractJdbcPersist implements Persist {
       throws ObjTooLargeException {
     upsertObjs(conn, objs, false, false);
     return null;
+  }
+
+  protected final boolean deleteWithReferenced(@Nonnull Connection conn, @Nonnull Obj obj) {
+    try (PreparedStatement ps = conn.prepareStatement(DELETE_OBJ_REFERENCED)) {
+      ps.setString(1, config.repositoryId());
+      serializeObjId(ps, 2, obj.id(), databaseSpecific);
+      ps.setLong(3, obj.referenced());
+      return ps.executeUpdate() == 1;
+    } catch (SQLException e) {
+      throw unhandledSQLException(e);
+    }
   }
 
   protected final boolean deleteConditional(@Nonnull Connection conn, @Nonnull UpdateableObj obj) {

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcPersist.java
@@ -211,6 +211,11 @@ class JdbcPersist extends AbstractJdbcPersist {
   }
 
   @Override
+  public boolean deleteWithReferenced(@Nonnull Obj obj) {
+    return withConnectionException(false, conn -> super.deleteWithReferenced(conn, obj));
+  }
+
+  @Override
   public boolean deleteConditional(@Nonnull UpdateableObj obj) {
     return withConnectionException(false, conn -> super.deleteConditional(conn, obj));
   }

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/SqlConstants.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/SqlConstants.java
@@ -63,6 +63,16 @@ final class SqlConstants {
           + "=? AND "
           + COL_OBJ_ID
           + "=?";
+  static final String DELETE_OBJ_REFERENCED =
+      "DELETE FROM "
+          + TABLE_OBJS
+          + " WHERE "
+          + COL_REPO_ID
+          + "=? AND "
+          + COL_OBJ_ID
+          + "=? AND "
+          + COL_OBJ_REFERENCED
+          + "=?";
 
   static final String COL_REFS_NAME = "ref_name";
   static final String COL_REFS_POINTER = "pointer";

--- a/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/Jdbc2Persist.java
+++ b/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/Jdbc2Persist.java
@@ -211,6 +211,11 @@ class Jdbc2Persist extends AbstractJdbc2Persist {
   }
 
   @Override
+  public boolean deleteWithReferenced(@Nonnull Obj obj) {
+    return withConnectionException(false, conn -> super.deleteWithReferenced(conn, obj));
+  }
+
+  @Override
   public boolean deleteConditional(@Nonnull UpdateableObj obj) {
     return withConnectionException(false, conn -> super.deleteConditional(conn, obj));
   }

--- a/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/SqlConstants.java
+++ b/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/SqlConstants.java
@@ -57,6 +57,16 @@ final class SqlConstants {
           + "=? AND "
           + COL_OBJ_ID
           + "=?";
+  static final String DELETE_OBJ_REFERENCED =
+      "DELETE FROM "
+          + TABLE_OBJS
+          + " WHERE "
+          + COL_REPO_ID
+          + "=? AND "
+          + COL_OBJ_ID
+          + "=? AND "
+          + COL_OBJ_REFERENCED
+          + "=?";
 
   static final String COL_REFS_NAME = "ref_name";
   static final String COL_REFS_POINTER = "pointer";

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
@@ -664,6 +664,21 @@ public class MongoDBPersist implements Persist {
   }
 
   @Override
+  public boolean deleteWithReferenced(@Nonnull Obj obj) {
+    ObjId id = obj.id();
+
+    try {
+      return backend
+              .objs()
+              .findOneAndDelete(
+                  and(eq(ID_PROPERTY_NAME, idObjDoc(id)), eq(COL_OBJ_REFERENCED, obj.referenced())))
+          != null;
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
+  }
+
+  @Override
   public boolean deleteConditional(@Nonnull UpdateableObj obj) {
     ObjId id = obj.id();
     ObjType type = obj.type();

--- a/versioned/storage/mongodb2/src/main/java/org/projectnessie/versioned/storage/mongodb2/MongoDB2Persist.java
+++ b/versioned/storage/mongodb2/src/main/java/org/projectnessie/versioned/storage/mongodb2/MongoDB2Persist.java
@@ -666,6 +666,21 @@ public class MongoDB2Persist implements Persist {
   }
 
   @Override
+  public boolean deleteWithReferenced(@Nonnull Obj obj) {
+    ObjId id = obj.id();
+
+    try {
+      return backend
+              .objs()
+              .findOneAndDelete(
+                  and(eq(ID_PROPERTY_NAME, idObjDoc(id)), eq(COL_OBJ_REFERENCED, obj.referenced())))
+          != null;
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
+  }
+
+  @Override
   public boolean deleteConditional(@Nonnull UpdateableObj obj) {
     ObjId id = obj.id();
     ObjType type = obj.type();

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/PersistDelegate.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/PersistDelegate.java
@@ -199,6 +199,11 @@ public class PersistDelegate implements Persist {
   }
 
   @Override
+  public boolean deleteWithReferenced(@Nonnull Obj obj) {
+    return delegate.deleteWithReferenced(obj);
+  }
+
+  @Override
   public boolean deleteConditional(@Nonnull UpdateableObj obj) {
     return delegate.deleteConditional(obj);
   }

--- a/versioned/transfer/src/testFixtures/java/org/projectnessie/versioned/transfer/AbstractExportImport.java
+++ b/versioned/transfer/src/testFixtures/java/org/projectnessie/versioned/transfer/AbstractExportImport.java
@@ -445,6 +445,11 @@ public abstract class AbstractExportImport {
           }
 
           @Override
+          public boolean deleteWithReferenced(@Nonnull Obj obj) {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
           public boolean deleteConditional(@Nonnull UpdateableObj obj) {
             throw new UnsupportedOperationException();
           }


### PR DESCRIPTION
... to delete an `Obj` only if its `referenced()` timestamp has the expected value.