### PR TITLE
Transfer/related: make `CoreTransferRelatedObjects` generally accessible

### DIFF
--- a/versioned/transfer-related/build.gradle.kts
+++ b/versioned/transfer-related/build.gradle.kts
@@ -21,6 +21,7 @@ publishingHelper { mavenName = "Nessie - Import/Export - Related Objects" }
 dependencies {
   implementation(project(":nessie-model"))
   implementation(project(":nessie-versioned-storage-common"))
+  compileOnly(project(":nessie-versioned-transfer-proto"))
 
   compileOnly(libs.microprofile.openapi)
   compileOnly(libs.errorprone.annotations)

--- a/versioned/transfer-related/src/main/java/org/projectnessie/versioned/transfer/related/CoreTransferRelatedObjects.java
+++ b/versioned/transfer-related/src/main/java/org/projectnessie/versioned/transfer/related/CoreTransferRelatedObjects.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.versioned.transfer;
+package org.projectnessie.versioned.transfer.related;
 
 import static java.util.Collections.singleton;
 import static org.projectnessie.versioned.storage.common.objtypes.UniqueIdObj.uniqueId;
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.UUID;
 import org.projectnessie.model.Content;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
-import org.projectnessie.versioned.transfer.related.TransferRelatedObjects;
 
 public class CoreTransferRelatedObjects implements TransferRelatedObjects {
   @Override

--- a/versioned/transfer-related/src/main/resources/META-INF/services/org.projectnessie.versioned.transfer.related.TransferRelatedObjects
+++ b/versioned/transfer-related/src/main/resources/META-INF/services/org.projectnessie.versioned.transfer.related.TransferRelatedObjects
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-org.projectnessie.versioned.transfer.CoreTransferRelatedObjects
+org.projectnessie.versioned.transfer.related.CoreTransferRelatedObjects


### PR DESCRIPTION
... and not only for export/import.