### PR TITLE
fix/keycloak-v26-deprecated-vars

### DIFF
--- a/docker/all-in-one/docker-compose.yml
+++ b/docker/all-in-one/docker-compose.yml
@@ -226,8 +226,8 @@ services:
       - "8080:8080"
       - "9001:9000"
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://postgres:5432/catalog
       KC_DB_USERNAME: postgres

--- a/docker/authn-keycloak/docker-compose.yml
+++ b/docker/authn-keycloak/docker-compose.yml
@@ -52,8 +52,8 @@ services:
       - "8080:8080"
       - "9001:9000"
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
     volumes:
       - ./config/iceberg-realm.json:/opt/keycloak/data/import/iceberg-realm.json
     command: [

--- a/docker/catalog-auth-s3-otel/docker-compose.yml
+++ b/docker/catalog-auth-s3-otel/docker-compose.yml
@@ -213,8 +213,8 @@ services:
       - "8080:8080"
       - "9001:9000"
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
     volumes:
       - ../authn-keycloak/config/iceberg-realm.json:/opt/keycloak/data/import/iceberg-realm.json
     command: [

--- a/docker/catalog-auth-s3/docker-compose.yml
+++ b/docker/catalog-auth-s3/docker-compose.yml
@@ -160,8 +160,8 @@ services:
       - "8080:8080"
       - "9001:9000"
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
     volumes:
       - ../authn-keycloak/config/iceberg-realm.json:/opt/keycloak/data/import/iceberg-realm.json
     command: [

--- a/servers/quarkus-server/README.md
+++ b/servers/quarkus-server/README.md
@@ -6,7 +6,7 @@ It is meant to be used for testing purposes only.
 
 1. Start a local Keycloak server
     ```shell
-    docker run -p 8080:8080 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin --name keycloak quay.io/keycloak/keycloak:latest start-dev
+    docker run -p 8080:8080 -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin --name keycloak quay.io/keycloak/keycloak:latest start-dev
     ```
 1. Log into Keycloak Admin Console at http://localhost:8080/auth/
 1. Create user `nessie` with password `nessie` (under the `master` realm)

--- a/site/docs/guides/keycloak.md
+++ b/site/docs/guides/keycloak.md
@@ -11,7 +11,7 @@ demonstrate how OpenID authentication works in Nessie servers.
 First, start a Keycloak container using its latest Docker image.
 
 ```shell
-docker run -p 8080:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin \
+docker run -p 8080:8080 -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
   --name keycloak quay.io/keycloak/keycloak:latest start-dev
 ```
 


### PR DESCRIPTION
The major Keycloak update to version 26, introduced through this PR [1], rendered all Keycloak containers unusable at startup due to the use of deprecated Admin Bootstrapping environment variables [2][3][4][5].

Closes: https://github.com/projectnessie/nessie/issues/9777

***

[1] https://github.com/projectnessie/nessie/pull/9702
[2] https://www.keycloak.org/docs/latest/upgrading/index.html#admin-bootstrapping-and-recovery
[3] https://github.com/keycloak/keycloak/blob/946798aa0133c1bdd32d5d66bdbb3c00d244ebc8/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc?plain=1#L150
[4] https://www.keycloak.org/getting-started/getting-started-docker
[5] https://github.com/keycloak/keycloak/blob/946798aa0133c1bdd32d5d66bdbb3c00d244ebc8/docs/guides/getting-started/templates/start-keycloak-container.adoc?plain=1#L7

***