### PR TITLE
Build/internal/NesQuEIT: enforce no colon `:` for `nessieProject()`

### DIFF
--- a/build-logic/src/main/kotlin/Utilities.kt
+++ b/build-logic/src/main/kotlin/Utilities.kt
@@ -195,6 +195,9 @@ fun DependencyHandlerScope.nessieProject(
   artifactId: String,
   configuration: String? = null
 ): ModuleDependency {
+  if (artifactId.startsWith(":")) {
+    throw IllegalArgumentException("artifactId for nessieProject() must not start with ':'")
+  }
   return if (!isIncludedInNesQuEIT(project(":").dependencyProject.gradle)) {
     project(":$artifactId", configuration)
   } else {

--- a/integrations/spark-extensions/build.gradle.kts
+++ b/integrations/spark-extensions/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
   // picks the right dependencies for scala compilation
   forScala(sparkScala.scalaVersion)
 
-  implementation(nessieProject(":nessie-cli-grammar"))
+  implementation(nessieProject("nessie-cli-grammar"))
   implementation(project(":nessie-spark-extensions-base_${sparkScala.scalaMajorVersion}"))
   compileOnly("org.apache.spark:spark-sql_${sparkScala.scalaMajorVersion}") { forSpark(sparkScala.sparkVersion) }
   compileOnly("org.apache.spark:spark-core_${sparkScala.scalaMajorVersion}") { forSpark(sparkScala.sparkVersion) }


### PR DESCRIPTION
... otherwise leads to invalid `:buildName::moduleName` Gradle project references.