### PR TITLE
Remove `@Nested` from a Quarkus test (Quarkus 3.16 prep)

### DIFF
--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieRest.java
@@ -46,7 +46,6 @@ import java.util.stream.Stream;
 import org.assertj.core.data.MapEntry;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -824,14 +823,6 @@ public abstract class BaseTestNessieRest extends BaseTestNessieApi {
         .containsExactly(400, ErrorCode.BAD_REQUEST);
     soft.assertThat(nessieError.getMessage())
         .contains("Hashes are not allowed when fetching a reference by name");
-  }
-
-  @Nested
-  @NessieApiVersions(versions = NessieApiVersion.V2)
-  public class RelativeReferences extends AbstractRelativeReferences {
-    protected RelativeReferences() {
-      super(BaseTestNessieRest.this);
-    }
   }
 
   @NessieApiVersions(versions = {NessieApiVersion.V2})

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieRestWithRelRef.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieRestWithRelRef.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.jaxrs.tests;
+
+import org.junit.jupiter.api.Nested;
+import org.projectnessie.client.ext.NessieApiVersion;
+import org.projectnessie.client.ext.NessieApiVersions;
+
+public abstract class BaseTestNessieRestWithRelRef extends BaseTestNessieRest {
+
+  @Nested
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public class RelativeReferences extends AbstractRelativeReferences {
+    protected RelativeReferences() {
+      super(BaseTestNessieRestWithRelRef.this);
+    }
+  }
+}

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/AbstractTestRestApiPersist.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/AbstractTestRestApiPersist.java
@@ -25,7 +25,7 @@ import org.projectnessie.versioned.storage.testextension.NessiePersist;
 import org.projectnessie.versioned.storage.testextension.PersistExtension;
 
 @ExtendWith(PersistExtension.class)
-abstract class AbstractTestRestApiPersist extends BaseTestNessieRest {
+abstract class AbstractTestRestApiPersist extends BaseTestNessieRestWithRelRef {
 
   @NessiePersist protected static Persist persist;
 


### PR DESCRIPTION
Quarkus tests often don't work with nested test classes. Quarkus test classes that extend `BaseTestNessieRest` started to fail with Quarkus 3.16.1, complaining that there are multiple instances that implement `BaseTestNessieRest`. The tests have been moved to the non-Quarkus tests only.