### PR TITLE
Prevent tracing initialization race (Quarkus 3.16 prep)

### DIFF
--- a/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/QuarkusTestProfilePersistBigTable.java
+++ b/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/QuarkusTestProfilePersistBigTable.java
@@ -29,6 +29,9 @@ public class QuarkusTestProfilePersistBigTable extends BaseConfigProfile {
     return ImmutableMap.<String, String>builder()
         .putAll(super.getConfigOverrides())
         .put("nessie.version.store.type", BIGTABLE.name())
+        // Disable telemetry to prevent test execution errors due to collision of
+        // `AutoConfiguredOpenTelemetrySdkBuilder` and Google's tracing code.
+        .put("nessie.version.store.persist.bigtable.enable-telemetry", "false")
         .build();
   }
 


### PR DESCRIPTION
OTel's SDK initialization and the "fallback" no-op global-tracer race and cause an initialization error.

The global-tracer is configured first (`Throwable` stack trace), but later the OTel auto-configured SDK tracer is being configured as well, triggering the ISE.

```
...
Unhandled exception returned as HTTP/500 to client:
jakarta.enterprise.inject.CreationException: Error creating synthetic
bean ... io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException: Unexpected configuration error
...
Caused by: io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException: Unexpected configuration error
...
Caused by: java.lang.IllegalStateException: GlobalOpenTelemetry.set has already been called. GlobalOpenTelemetry.set must be called only once before any calls to GlobalOpenTelemetry.get. If you are using the OpenTelemetrySdk, use OpenTelemetrySdkBuilder.buildAndRegisterGlobal instead. Previous invocation set to cause of this exception.
	at io.opentelemetry.api.GlobalOpenTelemetry.set(GlobalOpenTelemetry.java:107)
	at io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder.maybeSetAsGlobal(AutoConfiguredOpenTelemetrySdkBuilder.java:589)
	at io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder.build(AutoConfiguredOpenTelemetrySdkBuilder.java:506)
	... 104 more
Caused by: java.lang.Throwable
	at io.opentelemetry.api.GlobalOpenTelemetry.set(GlobalOpenTelemetry.java:115)
	at io.opentelemetry.api.GlobalOpenTelemetry.get(GlobalOpenTelemetry.java:85)
	at io.opentelemetry.api.GlobalOpenTelemetry.getTracer(GlobalOpenTelemetry.java:151)
	at io.opentelemetry.opencensusshim.OpenTelemetrySpanBuilderImpl.<clinit>(OpenTelemetrySpanBuilderImpl.java:54)
	at io.opentelemetry.opencensusshim.OpenTelemetryTracerImpl.spanBuilderWithExplicitParent(OpenTelemetryTracerImpl.java:42)
	at io.opencensus.trace.Tracer.spanBuilder(Tracer.java:308)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:865)
...
```