### PR TITLE
Convenience for pyiceberg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ as necessary. Empty sections will not end in the release notes.
   accessed cached objects. The default cache capacity fraction has been reduced from 70% of the
   heap size to 60% of the heap size. However, extreme heap pressure may let Java GC clear all
   `SoftReference`s.
+- Sends the following default options, which are convenient when using pyiceberg:
+  * `py-io-impl=pyiceberg.io.fsspec.FsspecFileIO`
+  * `s3.signer=S3V4RestSigner` when S3 signing is being used
+
 
 ### Deprecations
 

--- a/catalog/files/api/src/main/java/org/projectnessie/catalog/files/api/ObjectIO.java
+++ b/catalog/files/api/src/main/java/org/projectnessie/catalog/files/api/ObjectIO.java
@@ -27,6 +27,7 @@ import org.projectnessie.storage.uri.StorageUri;
 
 public interface ObjectIO {
   String ICEBERG_FILE_IO_IMPL = "io-impl";
+  String PYICEBERG_FILE_IO_IMPL = "py-io-impl";
 
   void ping(StorageUri uri) throws IOException;
 

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsObjectIO.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsObjectIO.java
@@ -215,6 +215,7 @@ public class AdlsObjectIO implements ObjectIO {
   }
 
   void icebergConfigDefaults(BiConsumer<String, String> config) {
+    config.accept(PYICEBERG_FILE_IO_IMPL, "pyiceberg.io.fsspec.FsspecFileIO");
     config.accept(ICEBERG_FILE_IO_IMPL, "org.apache.iceberg.azure.adlsv2.ADLSFileIO");
   }
 }

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsObjectIO.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsObjectIO.java
@@ -268,6 +268,7 @@ public class GcsObjectIO implements ObjectIO {
   }
 
   void icebergConfigDefaults(BiConsumer<String, String> config) {
+    config.accept(PYICEBERG_FILE_IO_IMPL, "pyiceberg.io.fsspec.FsspecFileIO");
     config.accept(ICEBERG_FILE_IO_IMPL, "org.apache.iceberg.gcp.gcs.GCSFileIO");
   }
 }

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3ObjectIO.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3ObjectIO.java
@@ -54,6 +54,7 @@ public class S3ObjectIO implements ObjectIO {
   static final String S3_PATH_STYLE_ACCESS = "s3.path-style-access";
   static final String S3_USE_ARN_REGION_ENABLED = "s3.use-arn-region-enabled";
   static final String S3_REMOTE_SIGNING_ENABLED = "s3.remote-signing-enabled";
+  static final String S3_SIGNER = "s3.signer";
 
   private final S3ClientSupplier s3clientSupplier;
   private final S3CredentialsResolver s3CredentialsResolver;
@@ -199,6 +200,7 @@ public class S3ObjectIO implements ObjectIO {
       requestSigning = enableRequestSigning.getAsBoolean();
     }
     config.accept(S3_REMOTE_SIGNING_ENABLED, Boolean.toString(requestSigning));
+    config.accept(S3_SIGNER, "S3V4RestSigner"); // Needed for pyiceberg
 
     // Note: 'accessDelegationPredicate' returns 'true', if the client did not send the
     // 'X-Iceberg-Access-Delegation' header (or if the header contains the appropriate value).
@@ -262,6 +264,7 @@ public class S3ObjectIO implements ObjectIO {
   void icebergConfigDefaults(StorageUri warehouse, BiConsumer<String, String> config) {
     S3BucketOptions bucketOptions = s3clientSupplier.s3options().resolveOptionsForUri(warehouse);
     bucketOptions.region().ifPresent(x -> config.accept(S3_CLIENT_REGION, x));
+    config.accept(PYICEBERG_FILE_IO_IMPL, "pyiceberg.io.fsspec.FsspecFileIO");
     config.accept(ICEBERG_FILE_IO_IMPL, "org.apache.iceberg.aws.s3.S3FileIO");
   }
 }


### PR DESCRIPTION
* Add sending `py-io-impl=pyiceberg.io.fsspec.FsspecFileIO` a config-default.
* Add sending `s3.signer=S3V4RestSigner` when S3 signing is being used.

Fixes #9318