### PR TITLE
Revert "Prevent tracing initialization race (Quarkus 3.16 prep) (#9866)"

### DIFF
--- a/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/QuarkusTestProfilePersistBigTable.java
+++ b/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/QuarkusTestProfilePersistBigTable.java
@@ -29,9 +29,6 @@ public class QuarkusTestProfilePersistBigTable extends BaseConfigProfile {
     return ImmutableMap.<String, String>builder()
         .putAll(super.getConfigOverrides())
         .put("nessie.version.store.type", BIGTABLE.name())
-        // Disable telemetry to prevent test execution errors due to collision of
-        // `AutoConfiguredOpenTelemetrySdkBuilder` and Google's tracing code.
-        .put("nessie.version.store.persist.bigtable.enable-telemetry", "false")
         .build();
   }
 


### PR DESCRIPTION
The attempt with PR #9866 did not properly work as expected, reverting.