### PR TITLE
Testing: disable looking up GCP credentials

### DIFF
--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusBigTableConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusBigTableConfig.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.quarkus.config;
 
+import com.google.api.gax.core.CredentialsProvider;
 import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
@@ -46,4 +47,13 @@ public interface QuarkusBigTableConfig extends BigTableClientsConfig {
 
   @WithDefault("false")
   boolean noTableAdminClient();
+
+  /**
+   * Prevent looking up {@link CredentialsProvider} to prevent "global tracer field race" in tests.
+   * This undocumented setting is ONLY for tests!
+   *
+   * @hidden
+   */
+  @WithDefault("false")
+  boolean disableCredentialsLookupForTests();
 }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/BigTableBackendBuilder.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/BigTableBackendBuilder.java
@@ -50,10 +50,14 @@ public class BigTableBackendBuilder implements BackendBuilder {
   public Backend buildBackend() {
     CredentialsProvider credentialsProvider = null;
     Exception googleCredentialsException = null;
-    try {
-      credentialsProvider = credentialsProviderInstance.get();
-    } catch (Exception e) {
-      googleCredentialsException = e;
+    // The disableCredentialsLookupForTests() is only used for tests and only to prevent the
+    // OpenTelemetry/global-tracer static-field initialization race described in #9866
+    if (!bigTableConfig.disableCredentialsLookupForTests()) {
+      try {
+        credentialsProvider = credentialsProviderInstance.get();
+      } catch (Exception e) {
+        googleCredentialsException = e;
+      }
     }
     GcpConfigHolder gcpConfigHolder = gcpConfigHolderInstance.get();
 

--- a/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/QuarkusTestProfilePersistBigTable.java
+++ b/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/QuarkusTestProfilePersistBigTable.java
@@ -29,6 +29,10 @@ public class QuarkusTestProfilePersistBigTable extends BaseConfigProfile {
     return ImmutableMap.<String, String>builder()
         .putAll(super.getConfigOverrides())
         .put("nessie.version.store.type", BIGTABLE.name())
+        // Disable credentials lookup to prevent Google's code to implicitly initialize
+        // OpenCensus->OpenTelemetry causing test execution errors due to collision of
+        // `AutoConfiguredOpenTelemetrySdkBuilder` and Google's tracing code.
+        .put("nessie.version.store.persist.bigtable.disable-credentials-lookup-for-tests", "true")
         .build();
   }
 


### PR DESCRIPTION
This is a follow-up of #9866 (and it's revert #9899). The stack traces indicate that the global-tracer field init race happens when `BigTableBackendBuilder` tries to fetch the GCP credentials via `Instance<CredentialsProvider>`, which eventually lets the Google client try to find the default app-credentials, which then implicitly initializes OpenCensus->OpenTelemetry.

The workaround here is to add a new undocumented configuration option to disable GCP credentials lookup, which is also not necessary when using the BT emulator.