### PR TITLE
JDBC: commit after DDL setup + more info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ as necessary. Empty sections will not end in the release notes.
 ### Fixes
 
 - GC: Consider referenced statistics (and partition statistics) files as 'live'.
+- JDBC: Perform JDBC commit when auto-creating tables to please transactional schema changes.
 
 ### Commits
 


### PR DESCRIPTION
Some databases like Postgres support transactional schema changes, which require a "commit" to happen.

This change adds this RDBMS commit and also some more information about the storage tables.