### PR TITLE
Export: fix ZIP output after #9034

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Highlights
 
+- Export: ZIP file exports were broken in all Nessie versions from 0.92.1 until 0.100.0.
+  If you are using any of these versions, you must not use ZIP export mode, but use the
+  file (directory) based exporter (`--output-format=DIRECTORY`)!
+
 ### Upgrade notes
 
 ### Breaking changes
@@ -19,6 +23,8 @@ as necessary. Empty sections will not end in the release notes.
 ### Deprecations
 
 ### Fixes
+
+- Export: ZIP file exports are fixed with this Nessie version 0.100.1.
 
 ### Commits
 

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/SizeLimitedOutput.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/SizeLimitedOutput.java
@@ -44,7 +44,7 @@ final class SizeLimitedOutput {
       Consumer<String> newFileName,
       LongConsumer finalEntityCount) {
     this.exportFiles = exportFiles;
-    this.maxFileSize = exporter.maxFileSize();
+    this.maxFileSize = exportFiles.fixMaxFileSize(exporter.maxFileSize());
     this.outputBufferSize = exporter.outputBufferSize();
     this.fileNamePrefix = fileNamePrefix;
     this.newFileName = newFileName;

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/ExportFileSupplier.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/ExportFileSupplier.java
@@ -29,4 +29,6 @@ public interface ExportFileSupplier extends AutoCloseable {
 
   @Nonnull
   OutputStream newFileOutput(@Nonnull String fileName) throws IOException;
+
+  long fixMaxFileSize(long userProvidedMaxFileSize);
 }

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/FileExporter.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/FileExporter.java
@@ -48,6 +48,11 @@ public abstract class FileExporter implements ExportFileSupplier {
   abstract Path targetDirectory();
 
   @Override
+  public long fixMaxFileSize(long userProvidedMaxFileSize) {
+    return userProvidedMaxFileSize;
+  }
+
+  @Override
   @Nonnull
   public Path getTargetPath() {
     return targetDirectory();

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/ZipArchiveExporter.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/ZipArchiveExporter.java
@@ -25,9 +25,14 @@ import static java.nio.file.Files.newOutputStream;
 
 import jakarta.annotation.Nonnull;
 import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.immutables.value.Value;
@@ -64,6 +69,11 @@ public abstract class ZipArchiveExporter implements ExportFileSupplier {
   }
 
   @Override
+  public long fixMaxFileSize(long userProvidedMaxFileSize) {
+    return Math.max(64 * 1024, Math.min(10 * 1024 * 1024, userProvidedMaxFileSize));
+  }
+
+  @Override
   public void preValidate() {}
 
   @Override
@@ -72,6 +82,8 @@ public abstract class ZipArchiveExporter implements ExportFileSupplier {
     return outputFile();
   }
 
+  private final Set<DelayedOutputStream> activeOutputStreams = new HashSet<>();
+
   @Override
   @Nonnull
   public OutputStream newFileOutput(@Nonnull String fileName) throws IOException {
@@ -79,14 +91,24 @@ public abstract class ZipArchiveExporter implements ExportFileSupplier {
         fileName.indexOf('/') == -1 && fileName.indexOf('\\') == -1, "Directories not supported");
     checkArgument(!fileName.isEmpty(), "Invalid file name argument");
 
-    ZipOutputStream out = zipOutput();
-    out.putNextEntry(new ZipEntry(fileName));
-    return new NonClosingOutputStream(out);
+    var output = new DelayedOutputStream(fileName);
+    synchronized (activeOutputStreams) {
+      activeOutputStreams.add(output);
+    }
+    return output;
   }
 
   @Override
   public void close() throws Exception {
     try {
+      List<DelayedOutputStream> activeOutputs;
+      synchronized (activeOutputStreams) {
+        activeOutputs = new ArrayList<>(activeOutputStreams);
+      }
+      for (var active : activeOutputs) {
+        active.close();
+      }
+
       zipOutput().close();
     } finally {
       deleteIfExists(outputFile());
@@ -96,44 +118,50 @@ public abstract class ZipArchiveExporter implements ExportFileSupplier {
     }
   }
 
-  private static final class NonClosingOutputStream extends OutputStream {
-    private final ZipOutputStream out;
+  private void delayedFinished(DelayedOutputStream delayedOutputStream) {
+    synchronized (activeOutputStreams) {
+      activeOutputStreams.remove(delayedOutputStream);
+    }
+  }
+
+  private final class DelayedOutputStream extends OutputStream {
     private boolean open = true;
 
-    private NonClosingOutputStream(ZipOutputStream out) {
-      this.out = out;
+    private final String name;
+    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+    private DelayedOutputStream(String name) {
+      this.name = name;
     }
 
     @Override
-    public void write(byte[] b) throws IOException {
+    public void write(byte[] b, int off, int len) {
       checkState(open);
-      out.write(b);
+      buffer.write(b, off, len);
     }
 
     @Override
-    public void write(byte[] b, int off, int len) throws IOException {
+    public void write(int b) {
       checkState(open);
-      out.write(b, off, len);
-    }
-
-    @Override
-    public void write(int b) throws IOException {
-      checkState(open);
-      out.write(b);
+      buffer.write(b);
     }
 
     @Override
     public void flush() throws IOException {
       checkState(open);
-      out.flush();
+      buffer.flush();
     }
 
     @Override
     public void close() throws IOException {
       if (open) {
         try {
+          ZipOutputStream out = zipOutput();
+          out.putNextEntry(new ZipEntry(name));
+          buffer.writeTo(out);
           out.closeEntry();
         } finally {
+          delayedFinished(this);
           open = false;
         }
       }

--- a/versioned/transfer/src/test/java/org/projectnessie/versioned/transfer/TestSizeLimitedOutput.java
+++ b/versioned/transfer/src/test/java/org/projectnessie/versioned/transfer/TestSizeLimitedOutput.java
@@ -72,6 +72,11 @@ public class TestSizeLimitedOutput {
           }
 
           @Override
+          public long fixMaxFileSize(long userProvidedMaxFileSize) {
+            return userProvidedMaxFileSize;
+          }
+
+          @Override
           public void close() {}
         };
 

--- a/versioned/transfer/src/test/java/org/projectnessie/versioned/transfer/files/AbstractTestExporterImporter.java
+++ b/versioned/transfer/src/test/java/org/projectnessie/versioned/transfer/files/AbstractTestExporterImporter.java
@@ -70,7 +70,7 @@ public abstract class AbstractTestExporterImporter<
         out.write("a".getBytes(UTF_8));
       }
 
-      soft.assertThatThrownBy(() -> exporter.newFileOutput("foo-bar-file"))
+      soft.assertThatThrownBy(() -> exporter.newFileOutput("foo-bar-file").close())
           .hasMessageContaining("foo-bar-file");
     }
   }


### PR DESCRIPTION
The introduction of "generic object exports" introduced a race in ZIP file export, which manifested in (not really) "multiple active zip entry outputs".

The change in this PR is to buffer the outputs on the heap, up to 10MB.

Fixes #9944