### PR TITLE
Force dnsjava downgrade to 3.5.3

### DIFF
--- a/build-logic/src/main/kotlin/Utilities.kt
+++ b/build-logic/src/main/kotlin/Utilities.kt
@@ -46,6 +46,22 @@ import org.gradle.kotlin.dsl.withType
 import org.gradle.process.JavaForkOptions
 
 /**
+ * dnsjava adds itself as the DNS resolver for the whole JVM, which is not something we want in
+ * Nessie.
+ */
+fun Project.dnsjavaDowngrade() {
+  configurations.all {
+    resolutionStrategy {
+      eachDependency {
+        when (requested.module.toString()) {
+          "dnsjava:dnsjava" -> useVersion("3.5.3")
+        }
+      }
+    }
+  }
+}
+
+/**
  * Apply the given `sparkVersion` as a `strictly` version constraint and [withSparkExcludes] on the
  * current [Dependency].
  */

--- a/gc/gc-iceberg-files/build.gradle.kts
+++ b/gc/gc-iceberg-files/build.gradle.kts
@@ -22,6 +22,8 @@ description =
   "Nessie GC integration tests with Spark, Iceberg and S3 as a separate project " +
     "due to the hugely different set of dependencies"
 
+dnsjavaDowngrade()
+
 dependencies {
 
   // hadoop-common brings Jackson in ancient versions, pulling in the Jackson BOM to avoid that

--- a/gc/gc-tool-inttest/build.gradle.kts
+++ b/gc/gc-tool-inttest/build.gradle.kts
@@ -23,6 +23,8 @@ publishingHelper { mavenName = "Nessie - GC - CLI integration test" }
 
 val sparkScala = useSparkScalaVersionsForProject("3.4", "2.12")
 
+dnsjavaDowngrade()
+
 dependencies {
   implementation(nessieProject("nessie-gc-tool", "shadow"))
 

--- a/gc/gc-tool/build.gradle.kts
+++ b/gc/gc-tool/build.gradle.kts
@@ -25,6 +25,8 @@ plugins {
 
 publishingHelper { mavenName = "Nessie - GC - Standalone command line tool" }
 
+dnsjavaDowngrade()
+
 dependencies {
   implementation(nessieProject("nessie-client"))
   implementation(nessieProject("nessie-gc-base"))

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -35,6 +35,8 @@ val openapiSource by
 
 val versionIceberg = libs.versions.iceberg.get()
 
+dnsjavaDowngrade()
+
 dependencies {
   implementation(project(":nessie-client"))
   implementation(project(":nessie-model"))
@@ -173,7 +175,20 @@ dependencies {
   testFixturesApi("org.apache.iceberg:iceberg-azure")
   testFixturesApi("org.apache.iceberg:iceberg-api:$versionIceberg:tests")
   testFixturesApi("org.apache.iceberg:iceberg-core:$versionIceberg:tests")
-  testFixturesApi(libs.hadoop.common) { hadoopExcludes() }
+  testFixturesApi(libs.hadoop.common) {
+    exclude("ch.qos.reload4j", "reload4j")
+    exclude("com.sun.jersey")
+    exclude("commons-cli", "commons-cli")
+    exclude("jakarta.activation", "jakarta.activation-api")
+    exclude("javax.servlet", "javax.servlet-api")
+    exclude("javax.servlet.jsp", "jsp-api")
+    exclude("javax.ws.rs", "javax.ws.rs-api")
+    exclude("log4j", "log4j")
+    exclude("org.slf4j", "slf4j-log4j12")
+    exclude("org.slf4j", "slf4j-reload4j")
+    exclude("org.eclipse.jetty")
+    exclude("org.apache.zookeeper")
+  }
 
   // These two testFixturesRuntimeOnly are here to avoid the 'Failed to index javax...: Class does
   // not exist in ClassLoader' warnings
@@ -293,19 +308,4 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
 // Issue w/ testcontainers/podman in GH workflows :(
 if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
   tasks.named<Test>("intTest").configure { this.enabled = false }
-}
-
-fun ModuleDependency.hadoopExcludes() {
-  exclude("ch.qos.reload4j", "reload4j")
-  exclude("com.sun.jersey")
-  exclude("commons-cli", "commons-cli")
-  exclude("jakarta.activation", "jakarta.activation-api")
-  exclude("javax.servlet", "javax.servlet-api")
-  exclude("javax.servlet.jsp", "jsp-api")
-  exclude("javax.ws.rs", "javax.ws.rs-api")
-  exclude("log4j", "log4j")
-  exclude("org.slf4j", "slf4j-log4j12")
-  exclude("org.slf4j", "slf4j-reload4j")
-  exclude("org.eclipse.jetty")
-  exclude("org.apache.zookeeper")
 }


### PR DESCRIPTION
dnsjava 3.6.1 came in via hadoop-common 3.4.1 with Nessie 0.100.0. Nessie 0.90.0 had hadoop-common 3.4.0, which depends on dnsjava 3.4.0, which doesn't hijack the whole JVM's DNS resolution.

dnsjava since 3.6.0 provides a `java.net.spi.InetAddressResolverProvider` implementation, JVM-globally registered via Java's service loader mechanism. This does _not_ effectively replace Java's DNS resolution, setting the system property `org.dnsjava.spi.enable=true` is required.

However, the implementation/releases of dnsjava seem to cause issues, which break e.g. Nessie GC. See #9943 and the linked issues.

Fixes #9943