### PR TITLE
Remove "AWS Athena" from the index page

### DIFF
--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -5,7 +5,7 @@ template: "home.html"
 
 * Git-inspired data version control
 * Cross-table transactions and visibility
-* Open data lake approach, supporting Hive, Spark, Dremio, AWS Athena, etc.
+* Open data lake approach, supporting Hive, Spark, Dremio, Trino, etc.
 * Works with Apache Iceberg tables
 * Run as a Docker image or on Kubernetes
 * Fork it on GitHub


### PR DESCRIPTION
Athena apparently does not support external catalogs (which Nessie would be).

Quoting from https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html : "Only Iceberg tables created against the AWS Glue catalog based on specifications defined by the open source glue catalog implementation are supported from Athena."

Use plain "Trino" in its place in the list of example integrations.