### PR TITLE
Build/release: Fix Git info after #9965

### DIFF
--- a/build-logic/src/main/kotlin/nessie-common-src.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-common-src.gradle.kts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import java.io.ByteArrayOutputStream
-import java.nio.charset.StandardCharsets
 import java.util.Properties
 import net.ltgt.gradle.errorprone.CheckSeverity
 import net.ltgt.gradle.errorprone.errorprone
@@ -177,13 +175,16 @@ if (project.hasProperty("release")) {
 class MemoizedGitInfo {
   companion object {
     private fun execProc(rootProject: Project, cmd: String, vararg args: Any): String {
-      val buf = ByteArrayOutputStream()
-      rootProject.providers.exec {
-        executable = cmd
-        args(args.toList())
-        standardOutput = buf
-      }
-      return buf.toString(StandardCharsets.UTF_8).trim()
+      var out =
+        rootProject.providers
+          .exec {
+            executable = cmd
+            args(args.toList())
+          }
+          .standardOutput
+          .asText
+          .get()
+      return out.trim()
     }
 
     fun gitInfo(rootProject: Project, attribs: Attributes) {


### PR DESCRIPTION
Getting Git information in `nessie-common-src.gradle.kts` fails after #9965 with a `java.lang.UnsupportedOperationException: Standard streams cannot be configured for exec output provider`. The fix is rather simple.