### PR TITLE
Migrate to `org.apache.cassandra:java-driver-bom` and bump to latest version 4.18.1

### DIFF
--- a/build-logic/src/main/kotlin/Utilities.kt
+++ b/build-logic/src/main/kotlin/Utilities.kt
@@ -46,6 +46,20 @@ import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.withType
 import org.gradle.process.JavaForkOptions
 
+fun Project.cassandraDriverTweak() {
+  configurations.all {
+    resolutionStrategy {
+      eachDependency {
+        if (requested.module.toString() == "com.datastax.oss:java-driver-core") {
+          var libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+          val cstarVersion = libs.findLibrary("cassandra-driver-bom").get().get().version
+          useTarget("org.apache.cassandra:java-driver-core:$cstarVersion")
+        }
+      }
+    }
+  }
+}
+
 /**
  * dnsjava adds itself as the DNS resolver for the whole JVM, which is not something we want in
  * Nessie.

--- a/events/quarkus/build.gradle.kts
+++ b/events/quarkus/build.gradle.kts
@@ -21,6 +21,8 @@ plugins {
 
 publishingHelper { mavenName = "Nessie - Events - Quarkus" }
 
+cassandraDriverTweak()
+
 dependencies {
   implementation(project(":nessie-versioned-spi"))
   implementation(project(":nessie-events-api"))

--- a/events/ri/build.gradle.kts
+++ b/events/ri/build.gradle.kts
@@ -21,6 +21,8 @@ plugins {
 
 extra["maven.name"] = "Nessie - Events - SPI Reference Implementation"
 
+cassandraDriverTweak()
+
 dependencies {
   implementation(project(":nessie-model"))
   implementation(project(":nessie-events-api"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ awssdk-bom = { module = "software.amazon.awssdk:bom", version = "2.29.20" }
 azuresdk-bom = { module = "com.azure:azure-sdk-bom", version = "1.2.29" }
 bouncycastle-bcpkix = { module = "org.bouncycastle:bcpkix-jdk15on", version.ref = "bouncycastle" }
 bouncycastle-bcprov = { module = "org.bouncycastle:bcprov-jdk15on", version.ref = "bouncycastle" }
-cassandra-driver-bom = { module = "com.datastax.oss:java-driver-bom", version = "4.17.0" }
+cassandra-driver-bom = { module = "org.apache.cassandra:java-driver-bom", version = "4.18.1" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version = "3.1.8" }
 cel-bom = { module = "org.projectnessie.cel:cel-bom", version = "0.5.1" }
 checkstyle = { module = "com.puppycrawl.tools:checkstyle", version.ref = "checkstyle" }

--- a/servers/quarkus-common/build.gradle.kts
+++ b/servers/quarkus-common/build.gradle.kts
@@ -18,6 +18,8 @@ plugins { id("nessie-conventions-quarkus") }
 
 publishingHelper { mavenName = "Nessie - Quarkus Common" }
 
+cassandraDriverTweak()
+
 dependencies {
   implementation(project(":nessie-model"))
   implementation(project(":nessie-rest-common"))
@@ -67,6 +69,7 @@ dependencies {
   implementation(enforcedPlatform(libs.quarkus.google.cloud.services.bom))
   implementation("io.quarkiverse.googlecloudservices:quarkus-google-cloud-bigtable")
   implementation(enforcedPlatform(libs.quarkus.cassandra.bom))
+  implementation(enforcedPlatform(libs.cassandra.driver.bom))
   implementation("com.datastax.oss.quarkus:cassandra-quarkus-client") {
     // spotbugs-annotations has only a GPL license!
     exclude("com.github.spotbugs", "spotbugs-annotations")

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -37,6 +37,8 @@ val versionIceberg = libs.versions.iceberg.get()
 
 dnsjavaDowngrade()
 
+cassandraDriverTweak()
+
 dependencies {
   implementation(project(":nessie-client"))
   implementation(project(":nessie-model"))

--- a/tools/server-admin/build.gradle.kts
+++ b/tools/server-admin/build.gradle.kts
@@ -30,6 +30,8 @@ val quarkusRunner by
     description = "Used to reference the generated runner-jar (either fast-jar or uber-jar)"
   }
 
+cassandraDriverTweak()
+
 dependencies {
   implementation(project(":nessie-quarkus-common"))
   implementation(project(":nessie-quarkus-config"))

--- a/versioned/storage/cassandra-tests/build.gradle.kts
+++ b/versioned/storage/cassandra-tests/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
   annotationProcessor(libs.immutables.value.processor)
 
   implementation(platform(libs.cassandra.driver.bom))
-  implementation("com.datastax.oss:java-driver-core")
+  implementation("org.apache.cassandra:java-driver-core")
 
   implementation(platform(libs.testcontainers.bom))
   implementation("org.testcontainers:cassandra") {

--- a/versioned/storage/cassandra/build.gradle.kts
+++ b/versioned/storage/cassandra/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
   implementation(libs.slf4j.api)
 
   implementation(platform(libs.cassandra.driver.bom))
-  implementation("com.datastax.oss:java-driver-core") {
+  implementation("org.apache.cassandra:java-driver-core") {
     // spotbugs-annotations has only a GPL license!
     exclude("com.github.spotbugs", "spotbugs-annotations")
   }

--- a/versioned/storage/cassandra2-tests/build.gradle.kts
+++ b/versioned/storage/cassandra2-tests/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
   annotationProcessor(libs.immutables.value.processor)
 
   implementation(platform(libs.cassandra.driver.bom))
-  implementation("com.datastax.oss:java-driver-core")
+  implementation("org.apache.cassandra:java-driver-core")
 
   implementation(platform(libs.testcontainers.bom))
   implementation("org.testcontainers:cassandra") {

--- a/versioned/storage/cassandra2/build.gradle.kts
+++ b/versioned/storage/cassandra2/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
   implementation(libs.slf4j.api)
 
   implementation(platform(libs.cassandra.driver.bom))
-  implementation("com.datastax.oss:java-driver-core") {
+  implementation("org.apache.cassandra:java-driver-core") {
     // spotbugs-annotations has only a GPL license!
     exclude("com.github.spotbugs", "spotbugs-annotations")
   }


### PR DESCRIPTION
This change also adds build functionality to _replace_ the `java-driver-core` artifact with the Apache C* group ID and use that version. Also adds `org.apache.cassandra:java-driver-bom` as an `enforcedPlatform` to `:nessie-quarkus-common`, so we'd get notified (build errors), if other dependencies, like the shaded Guava, change.