### PR TITLE
Renovate: Update config for trino-client

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,12 +23,41 @@
       labels: [],
     },
 
+    // Schedule npm + pip on weekends
+    {
+      matchManagers: ["pip_requirements", "pip_setup"],
+      extends: ["schedule:weekends"],
+    },
+
+    //
+    // General update-type rules
+    //
+
+    // Check for updates, merge automatically
+    {
+      matchManagers: ["maven", "gradle", "gradle-wrapper", "pip_requirements", "pip_setup", "dockerfile", "devcontainer", "docker-compose"],
+      matchUpdateTypes: ["minor", "patch"],
+      automerge: true,
+      platformAutomerge: true,
+    },
+
+    // Check for major updates, but do not merge automatically
+    {
+      matchManagers: ["maven", "gradle", "gradle-wrapper", "pip_requirements", "pip_setup"],
+      matchUpdateTypes: ["major"],
+      automerge: false,
+    },
+
     {
       matchManagers: ["github-actions"],
       matchUpdateTypes: ["major", "minor", "patch", "digest"],
       automerge: true,
       platformAutomerge: true,
     },
+
+    //
+    // Specific rules
+    //
 
     // Dockerfile for google-cloud-cli, basically no minor/patch version, daily major version updates
     {
@@ -51,27 +80,6 @@
       ],
       automerge: true,
       platformAutomerge: true
-    },
-
-    // Check for updates, merge automatically
-    {
-      matchManagers: ["maven", "gradle", "gradle-wrapper", "pip_requirements", "pip_setup", "dockerfile", "devcontainer", "docker-compose"],
-      matchUpdateTypes: ["minor", "patch"],
-      automerge: true,
-      platformAutomerge: true,
-    },
-
-    // Schedule npm + pip on weekends
-    {
-      matchManagers: ["pip_requirements", "pip_setup"],
-      extends: ["schedule:weekends"],
-    },
-
-    // Check for major updates, but do not merge automatically
-    {
-      matchManagers: ["maven", "gradle", "gradle-wrapper", "pip_requirements", "pip_setup"],
-      matchUpdateTypes: ["major"],
-      automerge: false,
     },
 
     // Jandex special


### PR DESCRIPTION
While the Trino Docker image is merged automatically, the trino-cliend artifact is not. Feels like it's due to the order of the rules, changing those in this PR.