### PR TITLE
Build: Allow testing GC with Java 23

### DIFF
--- a/gc/gc-base/build.gradle.kts
+++ b/gc/gc-base/build.gradle.kts
@@ -61,3 +61,8 @@ dependencies {
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.bundles.junit.testing)
 }
+
+tasks.withType(Test::class.java).configureEach {
+  // Java 23 & Hadoop
+  systemProperty("java.security.manager", "allow")
+}

--- a/gc/gc-iceberg-files/build.gradle.kts
+++ b/gc/gc-iceberg-files/build.gradle.kts
@@ -86,6 +86,8 @@ dependencies {
 
 tasks.withType(Test::class.java).configureEach {
   systemProperty("aws.region", "us-east-1")
+  // Java 23 & Hadoop
+  systemProperty("java.security.manager", "allow")
   jvmArgumentProviders.add(
     CommandLineArgumentProvider {
       val tmpdir = project.layout.buildDirectory.get().asFile.resolve("tmpdir")

--- a/gc/gc-tool-inttest/build.gradle.kts
+++ b/gc/gc-tool-inttest/build.gradle.kts
@@ -118,7 +118,11 @@ dependencies {
 
 val intTest = tasks.named<Test>("intTest")
 
-intTest.configure { systemProperty("aws.region", "us-east-1") }
+intTest.configure {
+  systemProperty("aws.region", "us-east-1")
+  // Java 23 & Hadoop
+  systemProperty("java.security.manager", "allow")
+}
 
 nessieQuarkusApp {
   includeTask(intTest)

--- a/gc/gc-tool/build.gradle.kts
+++ b/gc/gc-tool/build.gradle.kts
@@ -111,7 +111,11 @@ dependencies {
   testImplementation(libs.bundles.junit.testing)
 }
 
-tasks.named<Test>("test").configure { systemProperty("expectedNessieVersion", project.version) }
+tasks.named<Test>("test").configure {
+  // Java 23 & Hadoop
+  systemProperty("java.security.manager", "allow")
+  systemProperty("expectedNessieVersion", project.version)
+}
 
 val mainClassName = "org.projectnessie.gc.tool.cli.CLI"
 


### PR DESCRIPTION
Nessie GC tests fail with Java 23 with the following exception:
```
getSubject is supported only if a security manager is allowed
java.lang.UnsupportedOperationException: getSubject is supported only if a security manager is allowed
	at java.base/javax.security.auth.Subject.getSubject(Subject.java:347)
	at org.apache.hadoop.security.UserGroupInformation.getCurrentUser(UserGroupInformation.java:588)
	at org.apache.hadoop.fs.FileSystem$Cache$Key.<init>(FileSystem.java:3888)
	at org.apache.hadoop.fs.FileSystem$Cache$Key.<init>(FileSystem.java:3878)
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:3666)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:557)
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:366)
	at org.projectnessie.gc.iceberg.files.IcebergFiles.listHadoop(IcebergFiles.java:160)
	at org.projectnessie.gc.iceberg.files.IcebergFiles.listRecursively(IcebergFiles.java:153)
	at org.projectnessie.gc.files.tests.AbstractFiles.walkSomeFiles(AbstractFiles.java:94)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
```

Workaround is to set the system property `java.security.manager=allow`

See [here](https://inside.java/2024/07/08/quality-heads-up/)