### PR TITLE
Add admin tool command to cut commit log as a certain point.

### DIFF
--- a/tools/server-admin/src/intTest/java/org/projectnessie/tools/admin/cli/AbstractContentTests.java
+++ b/tools/server-admin/src/intTest/java/org/projectnessie/tools/admin/cli/AbstractContentTests.java
@@ -98,17 +98,17 @@ abstract class AbstractContentTests<OutputType> {
     result = launcher.launch(cmdArgs.toArray(new String[0]));
   }
 
-  protected void commit(IcebergTable table) throws Exception {
-    commit(table, true);
+  protected CommitObj commit(IcebergTable table) throws Exception {
+    return commit(table, true);
   }
 
-  protected void commit(Content table, boolean add) throws Exception {
-    commit(table, ContentKey.of("test_namespace", "table_" + table.getId()), add);
+  protected CommitObj commit(Content table, boolean add) throws Exception {
+    return commit(table, ContentKey.of("test_namespace", "table_" + table.getId()), add);
   }
 
-  protected void commit(Content table, ContentKey key, boolean add) throws Exception {
+  protected CommitObj commit(Content table, ContentKey key, boolean add) throws Exception {
     ByteString serialized = DefaultStoreWorker.instance().toStoreOnReferenceState(table);
-    commit(
+    return commit(
         key,
         UUID.fromString(Objects.requireNonNull(table.getId())),
         (byte) payloadForContent(table),
@@ -127,7 +127,7 @@ abstract class AbstractContentTests<OutputType> {
         true);
   }
 
-  protected void commit(
+  protected CommitObj commit(
       ContentKey key,
       UUID contentId,
       byte payload,
@@ -177,6 +177,7 @@ abstract class AbstractContentTests<OutputType> {
         Objects.requireNonNull(commitLogic.doCommit(builder.build(), Collections.emptyList()));
 
     referenceLogic(persist).assignReference(refMain, commit.id());
+    return commit;
   }
 
   protected Hash getMainHead() {

--- a/tools/server-admin/src/intTest/java/org/projectnessie/tools/admin/cli/ITCutHistory.java
+++ b/tools/server-admin/src/intTest/java/org/projectnessie/tools/admin/cli/ITCutHistory.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.admin.cli;
+
+import static java.util.Objects.requireNonNull;
+import static org.projectnessie.versioned.storage.common.logic.Logics.commitLogic;
+import static org.projectnessie.versioned.storage.versionstore.TypeMapping.hashToObjId;
+import static org.projectnessie.versioned.storage.versionstore.TypeMapping.objIdToHash;
+
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.quarkus.tests.profiles.BaseConfigProfile;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.VersionStore;
+import org.projectnessie.versioned.storage.common.logic.CommitLogic;
+import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+import org.projectnessie.versioned.storage.versionstore.VersionStoreImpl;
+
+@QuarkusMainTest
+@TestProfile(BaseConfigProfile.class)
+@ExtendWith({NessieServerAdminTestExtension.class, SoftAssertionsExtension.class})
+class ITCutHistory extends AbstractContentTests<CheckContentEntry> {
+
+  @InjectSoftAssertions private SoftAssertions soft;
+
+  ITCutHistory(Persist persist) {
+    super(persist, CheckContentEntry.class);
+  }
+
+  @Test
+  public void testEmptyRepo(QuarkusMainLauncher launcher) {
+    var launchResult = launcher.launch("cut-history", "--depth", "1");
+    soft.assertThat(launchResult.exitCode()).isEqualTo(0);
+    soft.assertThat(launchResult.getOutputStream()).contains("Updated 0 commits.");
+  }
+
+  @Test
+  public void testShallowRepo(QuarkusMainLauncher launcher) throws Exception {
+    commit(IcebergTable.of("111", 1, 2, 3, 4, UUID.randomUUID().toString()));
+    commit(IcebergTable.of("222", 1, 2, 3, 4, UUID.randomUUID().toString()));
+    var launchResult = launcher.launch("cut-history", "--ref", "main", "--depth", "10");
+    soft.assertThat(launchResult.exitCode()).isEqualTo(0);
+    soft.assertThat(launchResult.getOutputStream()).contains("Updated 0 commits.");
+  }
+
+  @Test
+  public void testCutMain(QuarkusMainLauncher launcher) throws Exception {
+    Set<Object> locations = new HashSet<>();
+    List<Hash> commitHashes = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      String location = "loc-" + i;
+      locations.add(location);
+      CommitObj commit =
+          commit(IcebergTable.of(location, i, 1, 1, 1, UUID.randomUUID().toString()));
+      commitHashes.addFirst(objIdToHash(commit.id()));
+    }
+
+    var launchResult = launcher.launch("cut-history", "--depth", "5");
+    soft.assertThat(launchResult.exitCode()).isEqualTo(0);
+    // 20 commits need rewriting because of the default 20 entries in the commit "tail".
+    soft.assertThat(launchResult.getOutputStream()).contains("Updated 20 commits.");
+
+    VersionStoreImpl store = new VersionStoreImpl(persist());
+
+    // 5 preserved commits plus 20 in the commit tail
+    int histDepth = 25;
+    for (int i = 0; i < histDepth; i++) {
+      Hash start = commitHashes.get(i);
+      List<Hash> log = new ArrayList<>();
+      store.getCommits(start, false).forEachRemaining(c -> log.add(c.getHash()));
+      soft.assertThat(log).containsExactlyElementsOf(commitHashes.subList(i, histDepth));
+    }
+
+    Set<String> collectedLocations = new HashSet<>();
+    store
+        .getKeys(getMainHead(), null, true, VersionStore.KeyRestrictions.NO_KEY_RESTRICTIONS)
+        .forEachRemaining(
+            e -> {
+              if (e.getContent() instanceof IcebergTable) {
+                collectedLocations.add(((IcebergTable) e.getContent()).getMetadataLocation());
+              }
+            });
+    soft.assertThat(collectedLocations).isEqualTo(locations);
+  }
+
+  @Test
+  public void testCutAcrossMerge(QuarkusMainLauncher launcher) throws Exception {
+    CommitLogic commitLogic = commitLogic(persist());
+    commit(IcebergTable.of("111", 1, 2, 3, 4, UUID.randomUUID().toString()));
+    CommitObj commit1 = requireNonNull(commitLogic.fetchCommit(hashToObjId(getMainHead())));
+    commit(IcebergTable.of("222", 1, 2, 3, 4, UUID.randomUUID().toString()));
+    commit(IcebergTable.of("333", 1, 2, 3, 4, UUID.randomUUID().toString()));
+    CommitObj commit3 = requireNonNull(commitLogic.fetchCommit(hashToObjId(getMainHead())));
+    commit(IcebergTable.of("444", 1, 2, 3, 4, UUID.randomUUID().toString()));
+
+    persist()
+        .upsertObj(
+            CommitObj.commitBuilder().from(commit3).addSecondaryParents(commit1.id()).build());
+
+    var launchResult = launcher.launch("cut-history", "--depth", "1");
+    soft.assertThat(launchResult.exitCode()).isEqualTo(1);
+    soft.assertThat(launchResult.getErrorOutput())
+        .contains(String.format("Unable to reset parents in merge commit '%s'", commit3.id()));
+  }
+
+  @Test
+  public void testCutAcrossRoot(QuarkusMainLauncher launcher) throws Exception {
+    commit(IcebergTable.of("111", 1, 2, 3, 4, UUID.randomUUID().toString()));
+    commit(IcebergTable.of("222", 1, 2, 3, 4, UUID.randomUUID().toString()));
+    var launchResult = launcher.launch("cut-history", "--ref", "main", "--depth", "1");
+    soft.assertThat(launchResult.exitCode()).isEqualTo(0);
+    soft.assertThat(launchResult.getErrorOutput()).contains("Encountered root commit");
+  }
+}

--- a/tools/server-admin/src/main/java/org/projectnessie/tools/admin/cli/CutHistory.java
+++ b/tools/server-admin/src/main/java/org/projectnessie/tools/admin/cli/CutHistory.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.admin.cli;
+
+import static org.projectnessie.versioned.storage.common.logic.CommitLogQuery.commitLogQuery;
+import static org.projectnessie.versioned.storage.common.logic.Logics.repositoryLogic;
+import static org.projectnessie.versioned.storage.common.persist.ObjId.EMPTY_OBJ_ID;
+import static org.projectnessie.versioned.storage.versionstore.TypeMapping.hashToObjId;
+import static org.projectnessie.versioned.storage.versionstore.TypeMapping.objIdToHash;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.ReferenceNotFoundException;
+import org.projectnessie.versioned.storage.common.logic.CommitLogic;
+import org.projectnessie.versioned.storage.common.logic.Logics;
+import org.projectnessie.versioned.storage.common.logic.PagedResult;
+import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
+import org.projectnessie.versioned.storage.common.persist.Obj;
+import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.versionstore.RefMapping;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "cut-history",
+    mixinStandardHelpOptions = true,
+    description = {
+      "Advanced commit log manipulation command that detaches a number of most recent "
+          + "commits from their parent commit trail. Use with extreme caution. See also the 'cleanup-repository' "
+          + "command."
+    })
+public class CutHistory extends BaseCommand {
+  @CommandLine.Option(
+      names = {"-r", "--ref"},
+      description = "Reference name to use (default branch, if not set).")
+  private String ref;
+
+  @CommandLine.Option(
+      names = {"--depth", "-D"},
+      required = true,
+      description = "The number of commits to preserve intact starting from the ref HEAD.")
+  private int depth;
+
+  @Override
+  public Integer call() throws Exception {
+    if (!repositoryLogic(persist).repositoryExists()) {
+      spec.commandLine().getErr().println("Nessie repository does not exist");
+      return EXIT_CODE_REPO_DOES_NOT_EXIST;
+    }
+
+    CommitLogic commitLogic = Logics.commitLogic(persist);
+
+    Hash head = resolveRefHead();
+    List<CommitObj> toStore = new ArrayList<>();
+    Set<ObjId> danglingTail = new HashSet<>(); // commit IDs referenced from direct children
+    int count = depth;
+    PagedResult<CommitObj, ObjId> it = commitLogic.commitLog(commitLogQuery(hashToObjId(head)));
+    while (it.hasNext()) {
+      CommitObj commitObj = it.next();
+
+      if (count > 0) { // Processing a preserved commit
+        danglingTail.addAll(commitObj.tail());
+        danglingTail.remove(commitObj.id());
+        danglingTail.remove(EMPTY_OBJ_ID);
+
+        count--;
+        continue;
+      }
+
+      if (!commitObj.secondaryParents().isEmpty()) {
+        spec.commandLine()
+            .getErr()
+            .printf("ERROR: Unable to reset parents in merge commit '%s'%n", commitObj.id());
+        return EXIT_CODE_GENERIC_ERROR;
+      }
+
+      if (EMPTY_OBJ_ID.equals(commitObj.directParent())) {
+        spec.commandLine()
+            .getErr()
+            .printf(
+                "Encountered root commit '%s'. Full commit history is reserved.%n", commitObj.id());
+        return 0;
+      }
+
+      // Rewriting commit to fixup parents
+      danglingTail.remove(commitObj.id());
+      CommitObj.Builder builder = CommitObj.commitBuilder().from(commitObj);
+      if (danglingTail.isEmpty()) {
+        spec.commandLine().getOut().printf("New root commit '%s'%n", commitObj.id());
+        builder.tail(List.of());
+      } else {
+        spec.commandLine().getOut().printf("Resetting tail in commit '%s'%n", commitObj.id());
+        builder.tail(commitObj.tail().subList(0, 1)); // one direct parent for simplicity
+      }
+
+      toStore.add(builder.build());
+
+      if (danglingTail.isEmpty()) {
+        break;
+      }
+    }
+
+    persist.upsertObjs(toStore.toArray(new Obj[0]));
+
+    spec.commandLine().getOut().printf("Updated %d commits.%n", toStore.size());
+    return 0;
+  }
+
+  private Hash resolveRefHead() throws ReferenceNotFoundException {
+    String effectiveRef = ref == null ? serverConfig.getDefaultBranch() : ref;
+    return objIdToHash(new RefMapping(persist).resolveNamedRef(effectiveRef).pointer());
+  }
+}

--- a/tools/server-admin/src/main/java/org/projectnessie/tools/admin/cli/NessieServerAdminTool.java
+++ b/tools/server-admin/src/main/java/org/projectnessie/tools/admin/cli/NessieServerAdminTool.java
@@ -30,6 +30,7 @@ import picocli.CommandLine.HelpCommand;
       NessieInfo.class,
       HelpCommand.class,
       CleanupRepository.class,
+      CutHistory.class,
       CheckContent.class,
       DeleteCatalogTasks.class,
       EraseRepository.class,


### PR DESCRIPTION
The tool is intended for advanced use cases when commit log needs to be shortened.

Cuts across branch points are not detected, but may lead to errors. This is left to the end user to avoid.

Some child commits of the new history root are rewritten to prevent their tails from referencing deeper parents.