### PR TITLE
Fix update-requirement check to handle "no current snapshot" requirement properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Fixes
 
+- Fix handling of Iceberg update-requirement "no current snapshot"
+
 ### Commits
 
 ## [0.101.0] Release (2024-12-06)

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergMetadataUpdate.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergMetadataUpdate.java
@@ -702,6 +702,15 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      checkState(
+          "main".equals(refName()) && "branch".equals(type()),
+          "Nessie only supports the current snapshot-ref 'main', use Nessie's branches instead");
+      var currentSnapshotId = state.snapshot().icebergSnapshotId();
+      checkState(
+          Objects.equals(snapshotId(), state.snapshot().icebergSnapshotId()),
+          "Snapshot ID mismatch, must be %s, but is %s",
+          currentSnapshotId,
+          snapshotId());
       state.addCatalogOp(CatalogOps.META_SET_SNAPSHOT_REF);
       // NOP - This class is used for JSON deserialization only.
       // Nessie has catalog-level branches and tags.
@@ -718,6 +727,9 @@ public interface IcebergMetadataUpdate {
 
     @Override
     default void applyToTable(IcebergTableMetadataUpdateState state) {
+      checkState(
+          "main".equals(refName()),
+          "Nessie only supports the Iceberg snapshot-ref 'main', use Nessie's branches instead");
       state.addCatalogOp(CatalogOps.META_REMOVE_SNAPSHOT_REF);
       // NOP - This class is used for JSON deserialization only.
       // Nessie has catalog-level branches and tags.


### PR DESCRIPTION
The current implementation of the `assert-ref-snapshot-id` update requirement neglects the `null` requirement case, which means "there must be no current snapshot". The fix is simple. Also added a check that the ref-name in that requirement-check is `main`.

Also updated a few cases to eliminate IDE warnings in the same class.

Fixes #10062