### PR TITLE
Fix clean-up of reference index objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Fixes
 
+- Fix large index processing in the `cleanup-repository` admin command.
+
 ### Commits
 
 ## [0.100.3] Release (2024-12-02)


### PR DESCRIPTION
Consider index objects and index stripes "referenced"

This is a follow-up to #9688 and a pre-requisite to #10048.