### PR TITLE
Revert "Workaround for CI failures because of missing `vectorized/redpanda` images (#10074)"

### DIFF
--- a/events/ri/src/main/resources/application.properties
+++ b/events/ri/src/main/resources/application.properties
@@ -120,5 +120,3 @@ quarkus.log.category."com.github.dockerjava".level=INFO
 quarkus.kafka.devservices.topic-partitions.nessie-events-avro=1
 quarkus.kafka.devservices.topic-partitions.nessie-events-json=1
 quarkus.kafka.devservices.redpanda.transaction-enabled=false
-# Workaround, can be removed after a Quarkus release with https://github.com/quarkusio/quarkus/issues/45026 (> 3.17.3)
-quarkus.kafka.devservices.image-name=redpandadata/redpanda


### PR DESCRIPTION
This reverts commit 2edf17e346e106e6d5f46f81d60c267b0b3ae993.