### PR TITLE
Support metrics relabelings in service monitor

### DIFF
--- a/helm/nessie/templates/servicemonitor.yaml
+++ b/helm/nessie/templates/servicemonitor.yaml
@@ -35,6 +35,10 @@ spec:
       interval: {{ .Values.serviceMonitor.interval }}
       {{- end }}
       path: /q/metrics
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/helm/nessie/tests/service_monitor_test.yaml
+++ b/helm/nessie/tests/service_monitor_test.yaml
@@ -1,0 +1,55 @@
+##
+## Copyright (C) 2024 Dremio
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+release:
+  name: nessie
+  namespace: nessie-ns
+
+capabilities:
+  apiVersions:
+    - monitoring.coreos.com/v1
+
+templates:
+  - servicemonitor.yaml
+
+tests:
+  - it: should create ServiceMonitor if enabled
+    set: { serviceMonitor: { enabled: true } }
+    asserts: [ { containsDocument: { kind: ServiceMonitor, apiVersion: monitoring.coreos.com/v1, name: nessie, namespace: nessie-ns } } ]
+  - it: should not create ServiceMonitor if disabled
+    set: { serviceMonitor: { enabled: false } }
+    asserts: [ { containsDocument: { kind: ServiceMonitor, apiVersion: monitoring.coreos.com/v1, name: nessie, namespace: nessie-ns }, not: true } ]
+  - it: should add metrics relabelings
+    set:
+      serviceMonitor:
+        enabled: true
+        metricRelabelings:
+          - source_labels: [ __meta_kubernetes_namespace ]
+            separator: ;
+            regex: (.*)
+            target_label: namespace
+            replacement: $1
+            action: replace
+    asserts:
+      - equal:
+          path: spec.endpoints[ 0].metricRelabelings
+          value:
+            - source_labels: [ __meta_kubernetes_namespace ]
+              separator: ;
+              regex: (.*)
+              target_label: namespace
+              replacement: $1
+              action: replace

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -715,6 +715,12 @@ serviceMonitor:
     # release: prometheus
   # -- Relabeling rules to apply to metrics. Ref https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config.
   metricRelabelings: []
+    # - source_labels: [ __meta_kubernetes_namespace ]
+    #   separator: ;
+    #   regex: (.*)
+    #   target_label: namespace
+    #   replacement: $1
+    #   action: replace
 
 serviceAccount:
   # -- Specifies whether a service account should be created.

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -713,6 +713,8 @@ serviceMonitor:
   labels:
     {}
     # release: prometheus
+  # -- Relabeling rules to apply to metrics. Ref https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config.
+  metricRelabelings: []
 
 serviceAccount:
   # -- Specifies whether a service account should be created.


### PR DESCRIPTION
The service monitor CRD allows configuring metric relabeling rules which are applied when the metrics are scraped. Support configuring metric relabeling configs in the helm chart.