### PR TITLE
Enable Azure Key Vault IT

### DIFF
--- a/catalog/secrets/azure/build.gradle.kts
+++ b/catalog/secrets/azure/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
   intTestImplementation("org.testcontainers:testcontainers")
   intTestImplementation("org.testcontainers:junit-jupiter")
   intTestImplementation(libs.lowkey.vault.testcontainers)
+  intTestImplementation(libs.lowkey.vault.client)
   intTestImplementation(project(":nessie-container-spec-helper"))
   intTestRuntimeOnly(libs.logback.classic)
 }

--- a/catalog/secrets/azure/src/main/java/org/projectnessie/catalog/secrets/azure/AzureSecretsManager.java
+++ b/catalog/secrets/azure/src/main/java/org/projectnessie/catalog/secrets/azure/AzureSecretsManager.java
@@ -21,6 +21,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.security.keyvault.secrets.SecretAsyncClient;
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -57,7 +58,9 @@ public class AzureSecretsManager extends AbstractStringBasedSecretsManager {
                 });
 
     try {
-      return future.get(timeout, MILLISECONDS).getValue();
+      return Optional.ofNullable(future.get(timeout, MILLISECONDS))
+          .map(KeyVaultSecret::getValue)
+          .orElse(null);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       throw new RuntimeException(e);
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -103,6 +103,7 @@ junit-platform-reporting = { module = "org.junit.platform:junit-platform-reporti
 kafka-clients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafka" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 lowkey-vault-testcontainers = { module = "com.github.nagyesta.lowkey-vault:lowkey-vault-testcontainers", version = "2.6.0" }
+lowkey-vault-client = { module = "com.github.nagyesta.lowkey-vault:lowkey-vault-client", version = "2.6.0" }
 keycloak-admin-client = { module = "org.keycloak:keycloak-admin-client", version.ref = "keycloak" }
 mariadb-java-client = { module = "org.mariadb.jdbc:mariadb-java-client", version = "3.5.1" }
 maven-resolver-supplier = { module = "org.apache.maven.resolver:maven-resolver-supplier", version.ref = "mavenResolver" }


### PR DESCRIPTION
- Add Lowkey Vault Client dependency to be able to use custom HTTP client during tests
- Reconfigure SecretClient to use custom HTTP client and accept self-signed cert
- Enable previously disabled test

### Note
Hi,
I have noticed that you wanted to use Lowkey Vault in your ITs and they we disabled due to the SSL issues. I thought I would help with them... 
Please feel free to use this PR if it makes sense or let me know in case you disagree with the approach!
Either way, thank you very much for using Lowkey Vault and feel free to let me know in case further assistance is needed!