### PR TITLE
OAuth client: add support for custom request parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ as necessary. Empty sections will not end in the release notes.
 
 ### New Features
 
+- When using OAuth authentication, the Nessie client now supports including extra parameters in
+  requests to the token endpoint. This is useful for passing custom parameters that are not covered
+  by the standard OAuth 2.0 specification. See the [Nessie
+  documentation](https://projectnessie.org/tools/client_config/#authentication-settings) for
+  details.
+
 ### Changes
 
 ### Deprecations

--- a/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2ClientAuthelia.java
+++ b/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2ClientAuthelia.java
@@ -22,6 +22,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URI;
 import java.security.cert.X509Certificate;
+import java.util.Map;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManager;
@@ -153,6 +154,8 @@ public class ITOAuth2ClientAuthelia {
         .addScope(clientId.equals("nessie-private-cc") ? "profile" : "offline_access")
         .authorizationCodeFlowWebServerPort(NESSIE_CALLBACK_PORT)
         .issuerUrl(issuerUrl)
+        // Should be ignored
+        .extraRequestParameters(Map.of("param1", "value1", "custom param 2", "custom value 2"))
         .sslContext(insecureSslContext());
   }
 

--- a/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2ClientKeycloak.java
+++ b/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2ClientKeycloak.java
@@ -543,6 +543,8 @@ public class ITOAuth2ClientKeycloak {
             .password("s3cr3t")
             // Otherwise Keycloak complains about missing scope, but still issues tokens
             .addScope("openid")
+            // Should be ignored
+            .extraRequestParameters(Map.of("param1", "value1", "custom param 2", "custom value 2"))
             .defaultAccessTokenLifespan(Duration.ofSeconds(10))
             .defaultRefreshTokenLifespan(Duration.ofSeconds(15))
             .refreshSafetyWindow(Duration.ofSeconds(5))

--- a/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -161,6 +161,13 @@ public final class NessieConfigConstants {
    * <pre>{@code
    * nessie.authentication.oauth2.extra-params = "custom_param1=custom_value1,custom_param2=custom_value2"
    * }</pre>
+   *
+   * For example, Auth0 requires the {@code audience} parameter to be set to the API identifier.
+   * This can be done by setting the following configuration:
+   *
+   * <pre>{@code
+   * nessie.authentication.oauth2.extra-params = "audience=https://nessie-catalog/api"
+   * }</pre>
    */
   @ConfigItem(section = "OAuth2 Authentication")
   public static final String CONF_NESSIE_OAUTH2_EXTRA_PARAMS =

--- a/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -151,6 +151,22 @@ public final class NessieConfigConstants {
       "nessie.authentication.oauth2.client-secret";
 
   /**
+   * Extra parameters to include in each request to the token endpoint. This is useful for custom
+   * parameters that are not covered by the standard OAuth2.0 specification. Optional, defaults to
+   * empty.
+   *
+   * <p>The format of this field is a comma-separated list of key-value pairs, separated by an equal
+   * sign. The values must NOT be URL-encoded. Example:
+   *
+   * <pre>{@code
+   * nessie.authentication.oauth2.extra-params = "custom_param1=custom_value1,custom_param2=custom_value2"
+   * }</pre>
+   */
+  @ConfigItem(section = "OAuth2 Authentication")
+  public static final String CONF_NESSIE_OAUTH2_EXTRA_PARAMS =
+      "nessie.authentication.oauth2.extra-params";
+
+  /**
    * Username to use when authenticating against the OAuth2 server. Required if using OAuth2
    * authentication and "password" grant type, ignored otherwise.
    */

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AbstractFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AbstractFlow.java
@@ -55,6 +55,7 @@ abstract class AbstractFlow implements Flow {
 
   <REQ extends TokenRequestBase, RESP extends TokenResponseBase> Tokens invokeTokenEndpoint(
       TokenRequestBase.Builder<REQ> request, Class<? extends RESP> responseClass) {
+    request.extraParameters(config.getExtraRequestParameters());
     getScope().ifPresent(request::scope);
     maybeAddClientId(request);
     return invokeEndpoint(getResolvedTokenEndpoint(), request.build(), responseClass)

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
@@ -421,7 +421,7 @@ abstract class OAuth2ClientConfig implements OAuth2AuthenticatorConfig {
         CONF_NESSIE_OAUTH2_GRANT_TYPE_TOKEN_EXCHANGE);
     if (!violations.isEmpty()) {
       throw new IllegalArgumentException(
-          "OAuth2 authentication is missing some parameters and could not be initialized: "
+          "OAuth2 authentication has configuration errors and could not be initialized: "
               + join(", ", violations));
     }
   }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
@@ -51,6 +51,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
@@ -497,6 +498,9 @@ abstract class OAuth2ClientConfig implements OAuth2AuthenticatorConfig {
 
     @Override
     Builder scopes(Iterable<String> scopes);
+
+    @CanIgnoreReturnValue
+    Builder extraRequestParameters(Map<String, ? extends String> extraRequestParameters);
 
     @Override
     Builder tokenExchangeConfig(TokenExchangeConfig tokenExchangeConfig);

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokenRequestBase.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokenRequestBase.java
@@ -15,10 +15,12 @@
  */
 package org.projectnessie.client.auth.oauth2;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -63,10 +65,20 @@ interface TokenRequestBase {
   @JsonProperty("scope")
   String getScope();
 
+  /**
+   * Additional parameters to be included in the request. This is useful for custom parameters that
+   * are not covered by the standard OAuth2.0 specification.
+   */
+  @JsonAnyGetter
+  Map<String, String> extraParameters();
+
   interface Builder<T extends TokenRequestBase> {
 
     @CanIgnoreReturnValue
     Builder<T> scope(String scope);
+
+    @CanIgnoreReturnValue
+    Builder<T> extraParameters(Map<String, ? extends String> extraParameters);
 
     T build();
   }

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
@@ -33,6 +33,7 @@ import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_DEVICE_AUTH_ENDPOINT;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_DEVICE_CODE_FLOW_POLL_INTERVAL;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_DEVICE_CODE_FLOW_TIMEOUT;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_EXTRA_PARAMS;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_GRANT_TYPE;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_IMPERSONATION_CLIENT_ID;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_IMPERSONATION_CLIENT_SECRET;
@@ -357,6 +358,9 @@ class TestOAuth2ClientConfig {
                 .put(
                     CONF_NESSIE_OAUTH2_TOKEN_EXCHANGE_ACTOR_TOKEN_TYPE,
                     TypedToken.URN_JWT.toString())
+                .put(
+                    CONF_NESSIE_OAUTH2_EXTRA_PARAMS,
+                    " extra1 = param1 , extra2=param 2 , extra3= , = ")
                 .build(),
             OAuth2ClientConfig.builder()
                 .issuerUrl(URI.create("https://example.com/"))
@@ -369,6 +373,8 @@ class TestOAuth2ClientConfig {
                 .username("Alice")
                 .password("s3cr3t")
                 .addScope("test")
+                .extraRequestParameters(
+                    ImmutableMap.of("extra1", "param1", "extra2", "param 2", "extra3", "", "", ""))
                 .defaultAccessTokenLifespan(Duration.ofSeconds(30))
                 .defaultRefreshTokenLifespan(Duration.ofSeconds(30))
                 .refreshSafetyWindow(Duration.ofSeconds(10))

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
@@ -77,7 +77,7 @@ class TestOAuth2ClientConfig {
     assertThatIllegalArgumentException()
         .isThrownBy(config::build)
         .withMessage(
-            "OAuth2 authentication is missing some parameters and could not be initialized: "
+            "OAuth2 authentication has configuration errors and could not be initialized: "
                 + join(", ", expected));
   }
 
@@ -313,12 +313,12 @@ class TestOAuth2ClientConfig {
             ImmutableMap.of(
                 CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT, "https://example.com/token",
                 CONF_NESSIE_OAUTH2_CLIENT_SECRET, "s3cr3t",
-                CONF_NESSIE_OAUTH2_REFRESH_SAFETY_WINDOW, "PT10S",
-                CONF_NESSIE_OAUTH2_DEFAULT_ACCESS_TOKEN_LIFESPAN, "PT30S",
-                CONF_NESSIE_OAUTH2_CLIENT_SCOPES, "test"),
+                CONF_NESSIE_OAUTH2_CLIENT_ID, "client1",
+                CONF_NESSIE_OAUTH2_EXTRA_PARAMS, "key1=value1,key1=value2"),
             null,
             new IllegalArgumentException(
-                "OAuth2 authentication is missing some parameters and could not be initialized: client ID must not be empty (nessie.authentication.oauth2.client-id)")),
+                "OAuth2 authentication has configuration errors and could not be initialized: "
+                    + "extra parameter 'key1' is defined multiple times (nessie.authentication.oauth2.extra-params)")),
         Arguments.of(
             ImmutableMap.builder()
                 .put(CONF_NESSIE_OAUTH2_ISSUER_URL, "https://example.com/")


### PR DESCRIPTION
For context, this change is motivated by the fact that Auth0 requires an `audience` field to be included in `client_credentials` requests to the token endpoint:

https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-credentials-flow/call-your-api-using-the-client-credentials-flow#request-tokens

The audience value must correspond to a declared "API identifier", and is mandatory.

This deviates from standard OAuth 2.0 specs and have annoyed other client implementors, e.g. [this one](https://github.com/usebruno/bruno/issues/2002). 

Rather than creating a specific `audience` field just for Auth0, I chose instead to open up for arbitrary custom parameters to be passed.

Ironically, Iceberg REST client is not affected by this issue, because if the `audience` field is present, it is (mistakenly) included in all requests (and ignored by the auth server).