### PR TITLE
Fix NesQuEIT to pass against recent Iceberg changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -950,8 +950,11 @@ jobs:
       - name: Nessie Spark 3.4 / 2.13 Extensions test
         run: ./gradlew -DscalaVersion=2.13 :nessie:nessie-iceberg:nessie-spark-extensions-3.4_2.13:test :nessie:nessie-iceberg:nessie-spark-extensions-3.4_2.13:intTest --scan
 
-      - name: Nessie Spark 3.5 / 2.13 Extensions test
-        run: ./gradlew -DscalaVersion=2.13 :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:test :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:intTest --scan
+      - name: Nessie Spark 3.5 / 2.12 Extensions test
+        run: ./gradlew -DscalaVersion=2.12 :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.12:test :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.12:intTest --scan
+      # TODO Revert the change to Scala 2.12 after we have an Iceberg release with https://github.com/apache/iceberg/pull/11520 (Iceberg 1.8 probably)
+      #- name: Nessie Spark 3.5 / 2.13 Extensions test
+      #  run: ./gradlew -DscalaVersion=2.13 :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:test :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:intTest --scan
 
       #- name: Publish Nessie + Iceberg to local Maven repo
       #  run: ./gradlew publishLocal --scan

--- a/integrations/spark-extensions-basetests/src/main/java/org/projectnessie/spark/extensions/AbstractNessieSparkSqlExtensionTest.java
+++ b/integrations/spark-extensions-basetests/src/main/java/org/projectnessie/spark/extensions/AbstractNessieSparkSqlExtensionTest.java
@@ -755,8 +755,16 @@ public abstract class AbstractNessieSparkSqlExtensionTest extends SparkSqlTestBa
     String version = spark.version();
     if (version.startsWith("3.3.")) {
       soft.assertThat(rewriteResult.get(0)).startsWith(5, 1);
-    } else {
+    } else if (version.startsWith("3.4.")) {
       soft.assertThat(rewriteResult.get(0)).startsWith(11, 2);
+    } else {
+      // 3.5 onwards
+      soft.assertThat(rewriteResult.get(0))
+          .satisfiesAnyOf(
+              result -> assertThat(result).startsWith(11, 2),
+              // Since https://github.com/apache/iceberg/pull/11478 (Spark: Change Delete
+              // granularity to file for Spark 3.5)
+              result -> assertThat(result).startsWith(8, 2));
     }
 
     validateContentAfterMaintenance(branchName, tableName);


### PR DESCRIPTION
There are two Iceberg PRs that "broke" NesQuEIT:

* https://github.com/apache/iceberg/pull/11478 caused `testRewriteManifests` to fail due to the changed outcome of the `rewrite_manifests` procedure
* https://github.com/apache/iceberg/pull/11520 caused a class-path issue w/ Scala 2.13

Related PR: https://github.com/projectnessie/query-engine-integration-tests/pull/684