### PR TITLE
Cache: add option to disable soft references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ as necessary. Empty sections will not end in the release notes.
   by the standard OAuth 2.0 specification. See the [Nessie
   documentation](https://projectnessie.org/tools/client_config/#authentication-settings) for
   details.
+- Add a configuration option `nessie.version.store.persist.cache-enable-soft-references` (defaults to 
+  `true`) to optionally disable the additional caching the constructed Java objects via soft references.
+  Having the already constructed Java object is faster when getting object from the cache, but a Java object
+  tree implies a rather unpredictable heap pressure, hence these object are referenced via Java soft
+  references. This optimization however can cause heap issues in rare scenarios, and disabling this
+  optimization can help there.
 
 ### Changes
 

--- a/servers/quarkus-config/src/main/java/org/projectnessie/quarkus/config/QuarkusStoreConfig.java
+++ b/servers/quarkus-config/src/main/java/org/projectnessie/quarkus/config/QuarkusStoreConfig.java
@@ -116,6 +116,8 @@ public interface QuarkusStoreConfig extends StoreConfig {
 
   String CONFIG_CACHE_CAPACITY_MB = "cache-capacity-mb";
 
+  boolean DEFAULT_CONFIG_CACHE_ENABLE_SOFT_REFERENCES = true;
+
   /**
    * Fixed amount of heap used to cache objects, set to 0 to disable the cache entirely. Must not be
    * used with fractional cache sizing. See description for {@code cache-capacity-fraction-of-heap}
@@ -124,7 +126,19 @@ public interface QuarkusStoreConfig extends StoreConfig {
   @WithName(CONFIG_CACHE_CAPACITY_MB)
   OptionalInt cacheCapacityMB();
 
+  /**
+   * Nessie keeps so called soft-references of the cached Java objects in addition to the serialized
+   * representation around.
+   *
+   * <p>This toggle optionally enables this behavior.
+   */
+  @WithName(CONFIG_CACHE_ENABLE_SOFT_REFERENCES)
+  @WithDefault("" + DEFAULT_CONFIG_CACHE_ENABLE_SOFT_REFERENCES)
+  Optional<Boolean> cacheEnableSoftReferences();
+
   String CONFIG_CACHE_CAPACITY_FRACTION_MIN_SIZE_MB = "cache-capacity-fraction-min-size-mb";
+
+  String CONFIG_CACHE_ENABLE_SOFT_REFERENCES = "cache-enable-soft-references";
 
   /** When using fractional cache sizing, this amount in MB is the minimum cache size. */
   @WithName(CONFIG_CACHE_CAPACITY_FRACTION_MIN_SIZE_MB)

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CacheConfig.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CacheConfig.java
@@ -39,6 +39,8 @@ public interface CacheConfig {
 
   Optional<Duration> referenceNegativeTtl();
 
+  Optional<Boolean> enableSoftReferences();
+
   @Value.Default
   default LongSupplier clockNanos() {
     return System::nanoTime;
@@ -75,6 +77,9 @@ public interface CacheConfig {
 
     @CanIgnoreReturnValue
     Builder clockNanos(LongSupplier clockNanos);
+
+    @CanIgnoreReturnValue
+    Builder enableSoftReferences(boolean enableSoftReferences);
 
     CacheConfig build();
   }

--- a/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCachingNoSoftReferencesInmemoryPersist.java
+++ b/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCachingNoSoftReferencesInmemoryPersist.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.cache;
+
+import static org.projectnessie.versioned.storage.common.objtypes.ContentValueObj.contentValue;
+import static org.projectnessie.versioned.storage.common.persist.ObjId.randomObjId;
+import static org.projectnessie.versioned.storage.commontests.AbstractBasePersistTests.randomContentId;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.nessie.relocated.protobuf.ByteString;
+import org.projectnessie.versioned.storage.common.persist.Obj;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+import org.projectnessie.versioned.storage.commontests.AbstractPersistTests;
+import org.projectnessie.versioned.storage.testextension.NessiePersist;
+import org.projectnessie.versioned.storage.testextension.NessiePersistCache;
+import org.projectnessie.versioned.storage.testextension.PersistExtension;
+
+@NessiePersistCache(enableSoftReferences = false)
+public class TestCachingNoSoftReferencesInmemoryPersist extends AbstractPersistTests {
+
+  @Nested
+  @ExtendWith({PersistExtension.class, SoftAssertionsExtension.class})
+  public class CacheSpecific {
+    @InjectSoftAssertions protected SoftAssertions soft;
+
+    @NessiePersist protected Persist persist;
+
+    @Test
+    public void getImmediate() throws Exception {
+      Obj obj =
+          contentValue(randomObjId(), 420L, randomContentId(), 1, ByteString.copyFromUtf8("hello"));
+      soft.assertThat(persist.getImmediate(obj.id())).isNull();
+      persist.storeObj(obj);
+      soft.assertThat(persist.getImmediate(obj.id())).isEqualTo(obj);
+      persist.deleteObj(obj.id());
+      soft.assertThat(persist.getImmediate(obj.id())).isNull();
+      persist.storeObj(obj);
+      persist.fetchObj(obj.id());
+      soft.assertThat(persist.getImmediate(obj.id())).isEqualTo(obj);
+    }
+  }
+}

--- a/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestNegativeCaching.java
+++ b/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestNegativeCaching.java
@@ -26,8 +26,9 @@ import static org.projectnessie.versioned.storage.common.persist.ObjId.randomObj
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.projectnessie.versioned.storage.cache.CacheTestObjTypeBundle.NegativeCachingObj;
 import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
@@ -42,11 +43,16 @@ public class TestNegativeCaching {
 
   @NessiePersist protected Persist persist;
 
-  @Test
-  public void nonEffectiveNegativeCache() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void nonEffectiveNegativeCache(boolean enableSoftReferences) throws Exception {
     Persist backing = spy(persist);
     CacheBackend cacheBackend =
-        PersistCaches.newBackend(CacheConfig.builder().capacityMb(16).build());
+        PersistCaches.newBackend(
+            CacheConfig.builder()
+                .capacityMb(16)
+                .enableSoftReferences(enableSoftReferences)
+                .build());
     Persist cachedPersist = spy(cacheBackend.wrap(backing));
 
     verify(backing).config();
@@ -72,11 +78,16 @@ public class TestNegativeCaching {
     reset(backing, cachedPersist);
   }
 
-  @Test
-  public void negativeCacheFetchTypedObj() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void negativeCacheFetchTypedObj(boolean enableSoftReferences) throws Exception {
     Persist backing = spy(persist);
     CacheBackend cacheBackend =
-        PersistCaches.newBackend(CacheConfig.builder().capacityMb(16).build());
+        PersistCaches.newBackend(
+            CacheConfig.builder()
+                .capacityMb(16)
+                .enableSoftReferences(enableSoftReferences)
+                .build());
     Persist cachedPersist = spy(cacheBackend.wrap(backing));
 
     verify(backing).config();
@@ -158,11 +169,16 @@ public class TestNegativeCaching {
     reset(backing, cachedPersist);
   }
 
-  @Test
-  public void negativeCacheFetchTypedObjs() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void negativeCacheFetchTypedObjs(boolean enableSoftReferences) throws Exception {
     Persist backing = spy(persist);
     CacheBackend cacheBackend =
-        PersistCaches.newBackend(CacheConfig.builder().capacityMb(16).build());
+        PersistCaches.newBackend(
+            CacheConfig.builder()
+                .capacityMb(16)
+                .enableSoftReferences(enableSoftReferences)
+                .build());
     Persist cachedPersist = spy(cacheBackend.wrap(backing));
 
     verify(backing).config();
@@ -185,11 +201,16 @@ public class TestNegativeCaching {
     negativeCacheFetchRepeat(cachedPersist, backing, id);
   }
 
-  @Test
-  public void negativeCacheFetchTypedObjsIfExist() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void negativeCacheFetchTypedObjsIfExist(boolean enableSoftReferences) throws Exception {
     Persist backing = spy(persist);
     CacheBackend cacheBackend =
-        PersistCaches.newBackend(CacheConfig.builder().capacityMb(16).build());
+        PersistCaches.newBackend(
+            CacheConfig.builder()
+                .capacityMb(16)
+                .enableSoftReferences(enableSoftReferences)
+                .build());
     Persist cachedPersist = spy(cacheBackend.wrap(backing));
 
     verify(backing).config();

--- a/versioned/storage/testextension/src/main/java/org/projectnessie/versioned/storage/testextension/ClassPersistInstances.java
+++ b/versioned/storage/testextension/src/main/java/org/projectnessie/versioned/storage/testextension/ClassPersistInstances.java
@@ -60,6 +60,7 @@ final class ClassPersistInstances {
                     .capacityMb(nessiePersistCache.capacityMb())
                     .referenceTtl(Duration.ofMinutes(1))
                     .referenceNegativeTtl(Duration.ofMinutes(1))
+                    .enableSoftReferences(nessiePersistCache.enableSoftReferences())
                     .build())
             : null;
 

--- a/versioned/storage/testextension/src/main/java/org/projectnessie/versioned/storage/testextension/NessiePersistCache.java
+++ b/versioned/storage/testextension/src/main/java/org/projectnessie/versioned/storage/testextension/NessiePersistCache.java
@@ -33,4 +33,6 @@ public @interface NessiePersistCache {
 
   /** The maximum capacity of the cache in MB. Default is 1 MB. */
   long capacityMb() default 1;
+
+  boolean enableSoftReferences() default true;
 }


### PR DESCRIPTION
The change #9648 introduced a performance optimization to keep the already deserialized Java objects available via soft-references. This change adds an opt-out of that feature.