### PR TITLE
Fix backwards compatibility issues with Obj.referenced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Fixes
 
+- Fix an issue that prevents the Nessie Server Admin tool to purge unreferenced data in the backend
+  database, for data being written before Nessie version 0.101.0.
+
 ### Commits
 
 ## [0.101.3] Release (2024-12-18)

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
@@ -568,14 +568,13 @@ public class BigTablePersist implements Persist {
 
   @Override
   public boolean deleteWithReferenced(@Nonnull Obj obj) {
-    Filter exactReferencedFilter =
-        FILTERS
-            .chain()
-            .filter(FILTERS.qualifier().exactMatch(QUALIFIER_OBJ_REFERENCED))
-            .filter(FILTERS.value().exactMatch(copyFromUtf8(Long.toString(obj.referenced()))));
     Filter condition;
     if (obj.referenced() != -1L) {
-      condition = exactReferencedFilter;
+      condition =
+          FILTERS
+              .chain()
+              .filter(FILTERS.qualifier().exactMatch(QUALIFIER_OBJ_REFERENCED))
+              .filter(FILTERS.value().exactMatch(copyFromUtf8(Long.toString(obj.referenced()))));
     } else {
       // We take a risk here in case the given object does _not_ have a referenced() value (old
       // object). It's sadly not possible to check for the _absence_ of a cell.

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
@@ -568,11 +568,19 @@ public class BigTablePersist implements Persist {
 
   @Override
   public boolean deleteWithReferenced(@Nonnull Obj obj) {
-    Filter condition =
+    Filter exactReferencedFilter =
         FILTERS
             .chain()
             .filter(FILTERS.qualifier().exactMatch(QUALIFIER_OBJ_REFERENCED))
             .filter(FILTERS.value().exactMatch(copyFromUtf8(Long.toString(obj.referenced()))));
+    Filter condition;
+    if (obj.referenced() != -1L) {
+      condition = exactReferencedFilter;
+    } else {
+      // We take a risk here in case the given object does _not_ have a referenced() value (old
+      // object). It's sadly not possible to check for the _absence_ of a cell.
+      condition = FILTERS.pass();
+    }
 
     ConditionalRowMutation conditionalRowMutation =
         conditionalRowMutation(obj, condition, Mutation.create().deleteRow());
@@ -653,12 +661,15 @@ public class BigTablePersist implements Persist {
     }
     mutation
         .setCell(FAMILY_OBJS, QUALIFIER_OBJS, CELL_TIMESTAMP, unsafeWrap(serialized))
-        .setCell(FAMILY_OBJS, QUALIFIER_OBJ_TYPE, CELL_TIMESTAMP, objTypeValue)
-        .setCell(
-            FAMILY_OBJS,
-            QUALIFIER_OBJ_REFERENCED,
-            CELL_TIMESTAMP,
-            copyFromUtf8(Long.toString(referenced)));
+        .setCell(FAMILY_OBJS, QUALIFIER_OBJ_TYPE, CELL_TIMESTAMP, objTypeValue);
+    if (obj.referenced() != -1L) {
+      // -1 is a sentinel for AbstractBasePersistTests.deleteWithReferenced()
+      mutation.setCell(
+          FAMILY_OBJS,
+          QUALIFIER_OBJ_REFERENCED,
+          CELL_TIMESTAMP,
+          copyFromUtf8(Long.toString(referenced)));
+    }
     UpdateableObj.extractVersionToken(obj)
         .map(ByteString::copyFromUtf8)
         .ifPresent(bs -> mutation.setCell(FAMILY_OBJS, QUALIFIER_OBJ_VERS, CELL_TIMESTAMP, bs));
@@ -756,7 +767,7 @@ public class BigTablePersist implements Persist {
     List<RowCell> objReferenced = row.getCells(FAMILY_OBJS, QUALIFIER_OBJ_REFERENCED);
     long referenced =
         objReferenced.isEmpty()
-            ? 0L
+            ? -1L
             : Long.parseLong(objReferenced.get(0).getValue().toStringUtf8());
     List<RowCell> objCells = row.getCells(FAMILY_OBJS, QUALIFIER_OBJS);
     ByteBuffer obj = objCells.get(0).getValue().asReadOnlyByteBuffer();

--- a/versioned/storage/cassandra2/src/main/java/org/projectnessie/versioned/storage/cassandra2/Cassandra2Persist.java
+++ b/versioned/storage/cassandra2/src/main/java/org/projectnessie/versioned/storage/cassandra2/Cassandra2Persist.java
@@ -348,25 +348,19 @@ public class Cassandra2Persist implements Persist {
   public boolean deleteWithReferenced(@Nonnull Obj obj) {
     var referenced = obj.referenced();
     BoundStatement stmt =
-        backend.buildStatement(
-            DELETE_OBJ_REFERENCED,
-            false,
-            config.repositoryId(),
-            serializeObjId(obj.id()),
-            referenced != -1L ? referenced : null);
-    //    var objIdSerialized = serializeObjId(obj.id());
-    //    var repoId = config.repositoryId();
-    //    BoundStatement stmt =
-    //        referenced != -1L
-    //            ? backend.buildStatement(
-    //                DELETE_OBJ_REFERENCED, false, repoId, objIdSerialized, referenced)
-    //            // We take a risk here in case the given object does _not_ have a referenced()
-    // value
-    //            // (old object).
-    //            // Cassandra's conditional DELETE ... IF doesn't allow us to use "IF col IS NULL"
-    // or "IF
-    //            // (col = 0 OR col IS NULL)".
-    //            : backend.buildStatement(DELETE_OBJ, false, repoId, objIdSerialized);
+        referenced != -1L
+            ? backend.buildStatement(
+                DELETE_OBJ_REFERENCED,
+                false,
+                config.repositoryId(),
+                serializeObjId(obj.id()),
+                referenced)
+            // We take a risk here in case the given object does _not_ have a referenced() value
+            // (old object).
+            // Cassandra's conditional DELETE ... IF doesn't allow us to use "IF col IS NULL" or "IF
+            // (col = 0 OR col IS NULL)".
+            : backend.buildStatement(
+                DELETE_OBJ, false, config.repositoryId(), serializeObjId(obj.id()));
     return backend.executeCas(stmt);
   }
 

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Obj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Obj.java
@@ -39,6 +39,18 @@ public interface Obj {
    * <p>The value of this attribute is generated exclusively by the {@link Persist} implementations.
    *
    * <p>This attribute is <em>not</em> consistent when using a caching {@link Persist}.
+   *
+   * <p>When <em>reading</em> an object, this value is either {@code 0}, which means that the object
+   * was written using a Nessie version that did not have this attribute, or a (positive) timestamp
+   * when the object was written.
+   *
+   * <p>When <em>storing</em> an object, this value <em>must</em> be {@code 0}. The only one
+   * exception is for tests that exercise the relevant code paths - those tests do also use {@code
+   * -1} as a sentinel to write "NULL".
+   *
+   * <p>In any case it is <em>illegal</em> to refer to and/or interpret this attribute from code
+   * that does not have to deal explicitly with this value, only code that runs maintenance
+   * operations shall use this value.
    */
   @JsonIgnore
   @JacksonInject(OBJ_REFERENCED_KEY)

--- a/versioned/storage/dynamodb2/src/main/java/org/projectnessie/versioned/storage/dynamodb2/DynamoDB2Persist.java
+++ b/versioned/storage/dynamodb2/src/main/java/org/projectnessie/versioned/storage/dynamodb2/DynamoDB2Persist.java
@@ -92,6 +92,7 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValueUpdate;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.Condition;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import software.amazon.awssdk.services.dynamodb.model.ExpectedAttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
@@ -550,16 +551,21 @@ public class DynamoDB2Persist implements Persist {
   public boolean deleteWithReferenced(@Nonnull Obj obj) {
     ObjId id = obj.id();
 
-    Map<String, ExpectedAttributeValue> expectedValues =
-        Map.of(
-            COL_OBJ_REFERENCED,
-            ExpectedAttributeValue.builder().value(fromS(Long.toString(obj.referenced()))).build());
+    var deleteItemRequest =
+        DeleteItemRequest.builder().tableName(backend.tableObjs).key(objKeyMap(id));
+    if (obj.referenced() != -1L) {
+      // We take a risk here in case the given object does _not_ have a referenced() value
+      // (old object). It's not possible in DynamoDB to check for '== 0 OR IS ABSENT/NULL'.
+      deleteItemRequest.expected(
+          Map.of(
+              COL_OBJ_REFERENCED,
+              ExpectedAttributeValue.builder()
+                  .value(fromS(Long.toString(obj.referenced())))
+                  .build()));
+    }
 
     try {
-      backend
-          .client()
-          .deleteItem(
-              b -> b.tableName(backend.tableObjs).key(objKeyMap(id)).expected(expectedValues));
+      backend.client().deleteItem(deleteItemRequest.build());
       return true;
     } catch (ConditionalCheckFailedException checkFailedException) {
       return false;
@@ -663,7 +669,7 @@ public class DynamoDB2Persist implements Persist {
     ByteBuffer bin = item.get(COL_OBJ_VALUE).b().asByteBuffer();
     String versionToken = attributeToString(item, COL_OBJ_VERS);
     String referencedString = attributeToString(item, COL_OBJ_REFERENCED);
-    long referenced = referencedString != null ? Long.parseLong(referencedString) : 0L;
+    long referenced = referencedString != null ? Long.parseLong(referencedString) : -1L;
     Obj obj = deserializeObj(id, referenced, bin, versionToken);
     return typeClass.cast(obj);
   }
@@ -677,7 +683,10 @@ public class DynamoDB2Persist implements Persist {
     Map<String, AttributeValue> item = new HashMap<>();
     item.put(KEY_NAME, objKey(id));
     item.put(COL_OBJ_TYPE, fromS(type.shortName()));
-    item.put(COL_OBJ_REFERENCED, fromS(Long.toString(referenced)));
+    if (obj.referenced() != -1) {
+      // -1 is a sentinel for AbstractBasePersistTests.deleteWithReferenced()
+      item.put(COL_OBJ_REFERENCED, fromS(Long.toString(referenced)));
+    }
     UpdateableObj.extractVersionToken(obj).ifPresent(token -> item.put(COL_OBJ_VERS, fromS(token)));
     int incrementalIndexSizeLimit =
         ignoreSoftSizeRestrictions ? Integer.MAX_VALUE : effectiveIncrementalIndexSizeLimit();

--- a/versioned/storage/inmemory/src/main/java/org/projectnessie/versioned/storage/inmemory/InmemoryPersist.java
+++ b/versioned/storage/inmemory/src/main/java/org/projectnessie/versioned/storage/inmemory/InmemoryPersist.java
@@ -229,7 +229,8 @@ class InmemoryPersist implements ValidatingPersist {
       verifySoftRestrictions(obj);
     }
 
-    long referenced = config.currentTimeMicros();
+    // -1 is a sentinel for AbstractBasePersistTests.deleteWithReferenced()
+    long referenced = obj.referenced() != -1L ? config.currentTimeMicros() : -1L;
     Obj withReferenced = obj.withReferenced(referenced);
 
     AtomicBoolean r = new AtomicBoolean(false);
@@ -296,7 +297,8 @@ class InmemoryPersist implements ValidatingPersist {
           if (v == null) {
             // not present
             return null;
-          } else if (v.referenced() != obj.referenced()) {
+          }
+          if (v.referenced() != obj.referenced()) {
             return v;
           }
           result.set(true);

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
@@ -449,7 +449,7 @@ abstract class AbstractJdbcPersist implements Persist {
 
   protected final boolean deleteWithReferenced(@Nonnull Connection conn, @Nonnull Obj obj) {
     var referenced = obj.referenced();
-    var referencedPresent = referenced != -1L && referenced != 0L;
+    var referencedPresent = referenced != -1L;
     try (PreparedStatement ps =
         conn.prepareStatement(
             referencedPresent ? DELETE_OBJ_REFERENCED : DELETE_OBJ_REFERENCED_NULL)) {

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/SqlConstants.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/SqlConstants.java
@@ -73,6 +73,18 @@ final class SqlConstants {
           + "=? AND "
           + COL_OBJ_REFERENCED
           + "=?";
+  static final String DELETE_OBJ_REFERENCED_NULL =
+      "DELETE FROM "
+          + TABLE_OBJS
+          + " WHERE "
+          + COL_REPO_ID
+          + "=? AND "
+          + COL_OBJ_ID
+          + "=? AND ("
+          + COL_OBJ_REFERENCED
+          + " IS NULL OR "
+          + COL_OBJ_REFERENCED
+          + "=0)";
 
   static final String COL_REFS_NAME = "ref_name";
   static final String COL_REFS_POINTER = "pointer";

--- a/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/AbstractJdbc2Persist.java
+++ b/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/AbstractJdbc2Persist.java
@@ -412,7 +412,7 @@ abstract class AbstractJdbc2Persist implements Persist {
 
   protected final boolean deleteWithReferenced(@Nonnull Connection conn, @Nonnull Obj obj) {
     var referenced = obj.referenced();
-    var referencedPresent = referenced != -1L && referenced != 0L;
+    var referencedPresent = referenced != -1L;
     try (PreparedStatement ps =
         conn.prepareStatement(
             referencedPresent ? DELETE_OBJ_REFERENCED : DELETE_OBJ_REFERENCED_NULL)) {

--- a/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/AbstractJdbc2Persist.java
+++ b/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/AbstractJdbc2Persist.java
@@ -29,6 +29,7 @@ import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.COL_OBJ_VER
 import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.DELETE_OBJ;
 import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.DELETE_OBJ_CONDITIONAL;
 import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.DELETE_OBJ_REFERENCED;
+import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.DELETE_OBJ_REFERENCED_NULL;
 import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.FETCH_OBJ_TYPE;
 import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.FIND_OBJS;
 import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.FIND_OBJS_TYPED;
@@ -379,6 +380,9 @@ abstract class AbstractJdbc2Persist implements Persist {
     String versionToken = rs.getString(COL_OBJ_VERS);
     byte[] serialized = rs.getBytes(COL_OBJ_VALUE);
     long referenced = rs.getLong(COL_OBJ_REFERENCED);
+    if (rs.wasNull()) {
+      referenced = -1;
+    }
     return ProtoSerialization.deserializeObj(id, referenced, serialized, versionToken);
   }
 
@@ -407,10 +411,16 @@ abstract class AbstractJdbc2Persist implements Persist {
   }
 
   protected final boolean deleteWithReferenced(@Nonnull Connection conn, @Nonnull Obj obj) {
-    try (PreparedStatement ps = conn.prepareStatement(DELETE_OBJ_REFERENCED)) {
+    var referenced = obj.referenced();
+    var referencedPresent = referenced != -1L && referenced != 0L;
+    try (PreparedStatement ps =
+        conn.prepareStatement(
+            referencedPresent ? DELETE_OBJ_REFERENCED : DELETE_OBJ_REFERENCED_NULL)) {
       ps.setString(1, config.repositoryId());
       serializeObjId(ps, 2, obj.id(), databaseSpecific);
-      ps.setLong(3, obj.referenced());
+      if (referencedPresent) {
+        ps.setLong(3, referenced);
+      }
       return ps.executeUpdate() == 1;
     } catch (SQLException e) {
       throw unhandledSQLException(e);
@@ -528,7 +538,12 @@ abstract class AbstractJdbc2Persist implements Persist {
         }
         byte[] serialized = serializeObj(obj, incrementalIndexSizeLimit, indexSizeLimit, false);
         ps.setBytes(5, serialized);
-        ps.setLong(6, referenced);
+        if (obj.referenced() == -1L) {
+          // -1 is a sentinel for AbstractBasePersistTests.deleteWithReferenced()
+          ps.setNull(6, Types.BIGINT);
+        } else {
+          ps.setLong(6, referenced);
+        }
 
         batchIndexToObjIndex.put(batchIndex++, i);
         ps.addBatch();

--- a/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/SqlConstants.java
+++ b/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/SqlConstants.java
@@ -67,6 +67,18 @@ final class SqlConstants {
           + "=? AND "
           + COL_OBJ_REFERENCED
           + "=?";
+  static final String DELETE_OBJ_REFERENCED_NULL =
+      "DELETE FROM "
+          + TABLE_OBJS
+          + " WHERE "
+          + COL_REPO_ID
+          + "=? AND "
+          + COL_OBJ_ID
+          + "=? AND ("
+          + COL_OBJ_REFERENCED
+          + " IS NULL OR "
+          + COL_OBJ_REFERENCED
+          + "=0)";
 
   static final String COL_REFS_NAME = "ref_name";
   static final String COL_REFS_POINTER = "pointer";

--- a/versioned/storage/mongodb2/src/main/java/org/projectnessie/versioned/storage/mongodb2/MongoDB2Persist.java
+++ b/versioned/storage/mongodb2/src/main/java/org/projectnessie/versioned/storage/mongodb2/MongoDB2Persist.java
@@ -65,6 +65,7 @@ import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.bulk.BulkWriteUpsert;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCursor;
+import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.InsertOneModel;
 import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.ReplaceOptions;
@@ -670,10 +671,14 @@ public class MongoDB2Persist implements Persist {
     ObjId id = obj.id();
 
     try {
+      var referencedBson =
+          obj.referenced() != -1L
+              ? eq(COL_OBJ_REFERENCED, obj.referenced())
+              : Filters.or(
+                  eq(COL_OBJ_REFERENCED, 0L), Filters.not(Filters.exists(COL_OBJ_REFERENCED)));
       return backend
               .objs()
-              .findOneAndDelete(
-                  and(eq(ID_PROPERTY_NAME, idObjDoc(id)), eq(COL_OBJ_REFERENCED, obj.referenced())))
+              .findOneAndDelete(and(eq(ID_PROPERTY_NAME, idObjDoc(id)), referencedBson))
           != null;
     } catch (RuntimeException e) {
       throw unhandledException(e);
@@ -764,7 +769,8 @@ public class MongoDB2Persist implements Persist {
     Binary bin = doc.get(COL_OBJ_VALUE, Binary.class);
     String versionToken = doc.getString(COL_OBJ_VERS);
     Long referenced = doc.getLong(COL_OBJ_REFERENCED);
-    Obj obj = deserializeObj(id, referenced != null ? referenced : 0L, bin.getData(), versionToken);
+    Obj obj =
+        deserializeObj(id, referenced != null ? referenced : -1L, bin.getData(), versionToken);
     @SuppressWarnings("unchecked")
     T r = (T) obj;
     return r;
@@ -780,7 +786,11 @@ public class MongoDB2Persist implements Persist {
     Document doc = new Document();
     doc.put(ID_PROPERTY_NAME, idObjDoc(id));
     doc.put(COL_OBJ_TYPE, type.shortName());
-    doc.put(COL_OBJ_REFERENCED, referenced);
+    var objReferenced = obj.referenced();
+    if (objReferenced != -1L) {
+      // -1 is a sentinel for AbstractBasePersistTests.deleteWithReferenced()
+      doc.put(COL_OBJ_REFERENCED, referenced);
+    }
     UpdateableObj.extractVersionToken(obj).ifPresent(token -> doc.put(COL_OBJ_VERS, token));
     int incrementalIndexSizeLimit =
         ignoreSoftSizeRestrictions ? Integer.MAX_VALUE : effectiveIncrementalIndexSizeLimit();

--- a/versioned/storage/rocksdb/src/main/java/org/projectnessie/versioned/storage/rocksdb/RocksDBPersist.java
+++ b/versioned/storage/rocksdb/src/main/java/org/projectnessie/versioned/storage/rocksdb/RocksDBPersist.java
@@ -349,7 +349,9 @@ class RocksDBPersist implements Persist {
         ignoreSoftSizeRestrictions = true;
         r = false;
       } else {
-        obj = obj.withReferenced(referenced);
+        var objReferenced = obj.referenced();
+        // -1 is a sentinel for AbstractBasePersistTests.deleteWithReferenced()
+        obj = obj.withReferenced(objReferenced != -1L ? referenced : -1L);
         r = true;
       }
 
@@ -461,7 +463,9 @@ class RocksDBPersist implements Persist {
       if (!existing.type().equals(obj.type())) {
         return false;
       }
-      if (existing.referenced() != obj.referenced()) {
+      var referenced = obj.referenced();
+      if (existing.referenced() != referenced && referenced != -1L) {
+        // -1 is a sentinel for AbstractBasePersistTests.deleteWithReferenced()
         return false;
       }
 


### PR DESCRIPTION
While this is a real bug fix, the underlying issue does not affect data correctness.

`Obj.referenced()` was introduced to track when a particular `Obj` was (last) written. This information is crucial when purging unreferenced data in Nessie's persistence backend database.

The current code uses the sentinel value `0` for `Obj.reference()` for accidentally _two_ scenarios: to indicate that the value is not set and needs to be written with the actual timestamp and it is also `0` when old rows that do not have the `referenced` column set (aka `NULL`).

This change updates the code to introduce `-1` for `referenced` as a sentinel for "absent" (NULL).

There is also a bug in the implementations that prevents the "purge unreferenced data" to actually work for rows that do not have a value in the `referenced` column. This change fixes this. Unfortunately not all databases properly (DynamoDB and BigTable) support checking for the absence of a value.