### PR TITLE
Adopt Object Storage Mock to respect S3 chunked input trailing headers

### DIFF
--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/AwsChunkedInputStream.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/AwsChunkedInputStream.java
@@ -125,7 +125,6 @@ final class AwsChunkedInputStream extends InputStream {
           throw new EOFException("Unexpected end of metadata line");
         }
         checkArgument(c == 10, "Illegal CR-LF sequence");
-        System.err.println("readLine: " + line);
         return line.toString();
       }
       line.append((char) c);

--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/AwsChunkedInputStream.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/AwsChunkedInputStream.java
@@ -80,13 +80,17 @@ final class AwsChunkedInputStream extends InputStream {
           chunkLen -= rd;
           return rd;
         case EXPECT_SEPARATOR:
-          String sep = readLine();
-          if (sep == null) {
+          String line = readLine();
+          if (line == null) {
             state = AwsChunkedState.EOF;
             throw new EOFException("Expecting empty separator line, but got EOF");
           }
-          checkArgument(sep.isEmpty(), "Expecting empty separator line, but got '%s'", sep);
-          state = AwsChunkedState.EXPECT_METADATA;
+          if (line.isEmpty()) {
+            // If the line's not empty, it's a trailing header - we ignore it for the
+            // object-storage-mock. Headers can be for example: x-amz-checksum-crc32 or
+            // x-amz-trailer-signature
+            state = AwsChunkedState.EXPECT_METADATA;
+          }
           break;
         default:
           throw new IllegalStateException();
@@ -121,6 +125,7 @@ final class AwsChunkedInputStream extends InputStream {
           throw new EOFException("Unexpected end of metadata line");
         }
         checkArgument(c == 10, "Illegal CR-LF sequence");
+        System.err.println("readLine: " + line);
         return line.toString();
       }
       line.append((char) c);

--- a/testing/object-storage-mock/src/test/java/org/projectnessie/objectstoragemock/TestAwsChunkedInputStream.java
+++ b/testing/object-storage-mock/src/test/java/org/projectnessie/objectstoragemock/TestAwsChunkedInputStream.java
@@ -140,10 +140,6 @@ public class TestAwsChunkedInputStream {
             IllegalArgumentException.class,
             "Illegal CR-LF sequence"),
         arguments(
-            "5;chunk-signature=F00\r\nHello5;chunk-signature=F00\r\n".getBytes(UTF_8),
-            IllegalArgumentException.class,
-            "Expecting empty separator line, but got '5;chunk-signature=F00'"),
-        arguments(
             "FOO;chunk-signature=F00\r\nHello\r\n0;chunk-signature=F00\r\n\r\n".getBytes(UTF_8),
             NumberFormatException.class,
             ""));


### PR DESCRIPTION
This is required for #10227