### PR TITLE
Fix using nested fields in partition-spec and sort-order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ as necessary. Empty sections will not end in the release notes.
   database, for data being written before Nessie version 0.101.0.
 - Fix an issue that prevents using nested fields in partition-spec and sort-order.
   Given a schema having a `struct < field_a, field_b >`, it was not possible to reference
-  `field_a` or `field_a` in a partition-spec or sort-order. There was no issue however using fields
+  `field_a` or `field_b` in a partition-spec or sort-order. There was no issue however using fields
   at the "top level" (a schema like `field_a, field_b`).
 
 ### Commits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ as necessary. Empty sections will not end in the release notes.
 
 - Fix an issue that prevents the Nessie Server Admin tool to purge unreferenced data in the backend
   database, for data being written before Nessie version 0.101.0.
+- Fix an issue that prevents using nested fields in partition-spec and sort-order.
+  Given a schema having a `struct < field_a, field_b >`, it was not possible to reference
+  `field_a` or `field_a` in a partition-spec or sort-order. There was no issue however using fields
+  at the "top level" (a schema like `field_a, field_b`).
 
 ### Commits
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/NessieModelIceberg.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/NessieModelIceberg.java
@@ -743,6 +743,9 @@ public class NessieModelIceberg {
   /**
    * Collects all fields, top-level and nested in structs, from the given struct into the given map.
    *
+   * <p>Does <em>not</em> return fields inside lists or maps, as those cannot be referred from
+   * partition-specs or sort-orders.
+   *
    * <p>Similar to {@link #collectFieldsByIcebergId(NessieStruct, Map)}.
    */
   public static void collectFieldsByNessieId(
@@ -756,6 +759,15 @@ public class NessieModelIceberg {
     }
   }
 
+  /**
+   * Collects all fields, top-level and nested in structs, from the given schemas into the given
+   * map.
+   *
+   * <p>Does <em>not</em> return fields inside lists or maps, as those cannot be referred from
+   * partition-specs or sort-orders.
+   *
+   * <p>Similar to {@link #collectFieldsByNessieId(NessieStruct, Map)}.
+   */
   @VisibleForTesting
   static Map<Integer, NessieField> collectFieldsByIcebergId(List<NessieSchema> schemas) {
     Map<Integer, NessieField> icebergFields = new HashMap<>();

--- a/catalog/model/src/main/java/org/projectnessie/catalog/model/snapshot/NessieTableSnapshot.java
+++ b/catalog/model/src/main/java/org/projectnessie/catalog/model/snapshot/NessieTableSnapshot.java
@@ -26,19 +26,15 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
 import org.projectnessie.catalog.model.NessieTable;
 import org.projectnessie.catalog.model.id.NessieId;
-import org.projectnessie.catalog.model.schema.NessieField;
 import org.projectnessie.catalog.model.schema.NessiePartitionDefinition;
-import org.projectnessie.catalog.model.schema.NessieSchema;
 import org.projectnessie.catalog.model.schema.NessieSortDefinition;
 import org.projectnessie.catalog.model.statistics.NessiePartitionStatisticsFile;
 import org.projectnessie.catalog.model.statistics.NessieStatisticsFile;
@@ -203,18 +199,6 @@ public interface NessieTableSnapshot extends NessieEntitySnapshot<NessieTable> {
 
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   List<NessiePartitionStatisticsFile> partitionStatisticsFiles();
-
-  @Value.Lazy
-  @JsonIgnore
-  default Map<UUID, NessieField> allFieldsById() {
-    Map<UUID, NessieField> allFields = new HashMap<>();
-    for (NessieSchema schema : schemas()) {
-      for (NessieField field : schema.struct().fields()) {
-        allFields.put(field.id(), field);
-      }
-    }
-    return allFields;
-  }
 
   @Value.Check
   default void check() {


### PR DESCRIPTION
Given a schema having a `struct < field_a, field_b >`, it was not possible to reference `field_a` or `field_b` in a partition-spec or sort-order. There was no issue however using fields at the "top level" (a schema like `field_a, field_b`).

Also:
* Enhance the checks to emit more useful information.
* Rename functions in `NessieModelIceberg` to (hopefully) improve the nomenclature.