### PR TITLE
Catalog: Allow passing -1 for new schema/partition-spec/sort-order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Fixes
 
+- Nessie re-assigns IDs for new schemas/partition-specs/sort-orders. The check that the provided ID for
+  those must be valid (>= 0) is therefore superfluous, it can actually unnecessarily lead to problems. This
+  change also fixes an issue that the last-added schema/spec/sort ID is set to -1, if the schema/spec/sort
+  already existed. This lets the set-current-schema/set-default-partition-spec/set-default-sort-order
+  updates with `-1` for the last-added one fail, but it should return the ID of the schema/spec/sort ID that
+  already existed.
+
 ### Commits
 
 ## [0.102.1] Release (2025-01-22)

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/NessieModelIceberg.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/NessieModelIceberg.java
@@ -1197,7 +1197,7 @@ public class NessieModelIceberg {
   public static void addSchema(AddSchema u, IcebergTableMetadataUpdateState state) {
     IcebergSchema schema = u.schema();
 
-    checkArgument(schema.schemaId() >= 0, "Invalid schema-ID %s", u.schema().schemaId());
+    checkArgument(schema.schemaId() >= -1, "Invalid schema-ID %s", u.schema().schemaId());
     NessieTableSnapshot snapshot = state.snapshot();
 
     // TODO check again, carefully, how exactly and when Iceberg does the the following ID
@@ -1209,17 +1209,19 @@ public class NessieModelIceberg {
       schema = icebergInitialSchema(schema, remappedFieldIds);
     }
 
-    checkArgument(
-        !snapshot.schemaByIcebergId(schema.schemaId()).isPresent(),
-        "A schema with ID %s already exists",
-        schema.schemaId());
+    if (schema.schemaId() != -1) {
+      checkArgument(
+          !snapshot.schemaByIcebergId(schema.schemaId()).isPresent(),
+          "A schema with ID %s already exists",
+          schema.schemaId());
+    }
 
     // Check if a similar schema exists, and if so then update the "last added schema ID"
     // accordingly for a following "set-current-schema -1".
     ReuseOrCreate<IcebergSchema> reuseOrCreate = reuseOrCreateNewSchemaId(schema, snapshot);
     schema = schema.withSchemaId(reuseOrCreate.id());
     if (reuseOrCreate.value().isPresent()) {
-      state.schemaAdded(state.isAddedSchema(schema.schemaId()) ? schema.schemaId() : -1);
+      state.schemaAdded(schema.schemaId());
       return;
     }
 
@@ -1356,20 +1358,22 @@ public class NessieModelIceberg {
   public static void addSchema(AddSchema u, IcebergViewMetadataUpdateState state) {
     IcebergSchema schema = u.schema();
 
-    checkArgument(schema.schemaId() >= 0, "Invalid schema-ID %s", u.schema().schemaId());
+    checkArgument(schema.schemaId() >= -1, "Invalid schema-ID %s", u.schema().schemaId());
     NessieViewSnapshot snapshot = state.snapshot();
 
-    checkArgument(
-        !snapshot.schemaByIcebergId(schema.schemaId()).isPresent(),
-        "A schema with ID %s already exists",
-        schema.schemaId());
+    if (schema.schemaId() != -1) {
+      checkArgument(
+          !snapshot.schemaByIcebergId(schema.schemaId()).isPresent(),
+          "A schema with ID %s already exists",
+          schema.schemaId());
+    }
 
     // Check if a similar schema exists, and if so then update the "last added schema ID"
     // accordingly for a following "set-current-schema -1".
     ReuseOrCreate<IcebergSchema> reuseOrCreate = reuseOrCreateNewSchemaId(schema, snapshot);
     schema = schema.withSchemaId(reuseOrCreate.id());
     if (reuseOrCreate.value().isPresent()) {
-      state.schemaAdded(state.isAddedSchema(schema.schemaId()) ? schema.schemaId() : -1);
+      state.schemaAdded(schema.schemaId());
       return;
     }
 
@@ -1425,7 +1429,7 @@ public class NessieModelIceberg {
 
   public static void addPartitionSpec(AddPartitionSpec u, IcebergTableMetadataUpdateState state) {
     IcebergPartitionSpec spec = u.spec();
-    checkArgument(spec.specId() >= 0, "Invalid spec-ID %s", spec.specId());
+    checkArgument(spec.specId() >= -1, "Invalid spec-ID %s", spec.specId());
     NessieTableSnapshot snapshot = state.snapshot();
 
     // TODO re-check this ID-re-assignment block
@@ -1458,7 +1462,7 @@ public class NessieModelIceberg {
     ReuseOrCreate<IcebergPartitionSpec> reuseOrCreate = reuseOrCreateNewSpecId(spec, snapshot);
     spec = spec.withSpecId(reuseOrCreate.id());
     if (reuseOrCreate.value().isPresent()) {
-      state.specAdded(state.isAddedSpec(spec.specId()) ? spec.specId() : -1);
+      state.specAdded(spec.specId());
       return;
     }
 
@@ -1480,7 +1484,7 @@ public class NessieModelIceberg {
         "No Iceberg-ID for NessiePartitionDefinition, retrieved via spec-ID %s",
         u.spec().specId());
     state.builder().addPartitionDefinition(def).icebergLastPartitionId(lastNewFieldId);
-    state.specAdded(u.spec().specId());
+    state.specAdded(spec.specId());
   }
 
   public static void removePartitionSpecs(
@@ -1542,7 +1546,7 @@ public class NessieModelIceberg {
 
   public static void addSortOrder(AddSortOrder u, IcebergTableMetadataUpdateState state) {
     IcebergSortOrder sortOrder = u.sortOrder();
-    checkArgument(sortOrder.orderId() >= 0, "Invalid order-ID %s", u.sortOrder().orderId());
+    checkArgument(sortOrder.orderId() >= -1, "Invalid order-ID %s", u.sortOrder().orderId());
     NessieTableSnapshot snapshot = state.snapshot();
 
     // TODO re-check this ID-re-assignment block
@@ -1564,7 +1568,7 @@ public class NessieModelIceberg {
         reuseOrCreateNewSortOrderId(sortOrder, snapshot);
     sortOrder = sortOrder.withOrderId(reuseOrCreate.id());
     if (reuseOrCreate.value().isPresent()) {
-      state.sortOrderAdded(state.isAddedOrder(sortOrder.orderId()) ? sortOrder.orderId() : -1);
+      state.sortOrderAdded(sortOrder.orderId());
       return;
     }
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergMetadataUpdate.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergMetadataUpdate.java
@@ -412,7 +412,7 @@ public interface IcebergMetadataUpdate {
     @Value.Check
     default void check() {
       int id = spec().specId();
-      checkState(id >= 0, "Illegal spec-ID %s for %s", id);
+      checkState(id >= -1, "Illegal spec-ID %s", id);
     }
 
     static AddPartitionSpec addPartitionSpec(IcebergPartitionSpec spec) {
@@ -435,7 +435,7 @@ public interface IcebergMetadataUpdate {
     @Value.Check
     default void check() {
       for (Integer specId : specIds()) {
-        checkState(specId != null && specId >= 0, "Illegal spec-ID %s for %s", specId);
+        checkState(specId != null && specId >= 0, "Illegal spec-ID %s", specId);
       }
     }
 
@@ -580,7 +580,7 @@ public interface IcebergMetadataUpdate {
       int id = sortOrder().orderId();
       boolean unsorted = sortOrder().isUnsorted();
       checkState(
-          id > 0 || (unsorted && id == 0),
+          id == -1 || id > 0 || (unsorted && id == 0),
           "Illegal order-ID %s for %s",
           id,
           unsorted ? "unsorted" : "sort order");


### PR DESCRIPTION
Nessie re-assigns IDs for new schemas/partition-specs/sort-orders. The check that the provided ID for those must be valid (>= 0) is therefore superfluous, it can actually unnecessarily lead to problems.

This change also fixes an issue that the last-added schema/spec/sort ID is set to -1, if the schema/spec/sort already existed. This lets the set-current-schema/set-default-partition-spec/set-default-sort-order updates with `-1` for the last-added one fail, but it should return the ID of the schema/spec/sort ID that already existed.

Also fixing the related checks in IcebergMetadataUpdate.

Added tests for the relevant add*-updates to TestNessieModelIceberg.