### PR TITLE
REST Catalog: Apply warehouse property overrides to tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ as necessary. Empty sections will not end in the release notes.
 
 ### New Features
 
+- Catalog: Warehouse configuration overrides can now be applied to tables.
+
 ### Changes
 
 ### Deprecations

--- a/catalog/service/config/src/main/java/org/projectnessie/catalog/service/config/WarehouseConfig.java
+++ b/catalog/service/config/src/main/java/org/projectnessie/catalog/service/config/WarehouseConfig.java
@@ -20,6 +20,7 @@ import static org.projectnessie.catalog.service.config.CatalogConfig.removeTrail
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.smallrye.config.WithConverter;
+import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 import java.util.Map;
 import org.immutables.value.Value;
@@ -47,6 +48,29 @@ public interface WarehouseConfig {
   @ConfigPropertyName("iceberg-property")
   @WithName("iceberg-config-overrides")
   Map<String, String> icebergConfigOverrides();
+
+  /**
+   * Instructs the server to override generated table properties with {@link
+   * #icebergConfigOverrides()}, whenever the same property is present in table properties and
+   * overrides.
+   */
+  @WithName("apply-overrides-to-table-config")
+  @WithDefault("false")
+  @Value.Default
+  default boolean applyOverridesToTableConfig() {
+    return false;
+  }
+
+  /**
+   * Instructs the server to forward all entries from {@link #icebergConfigOverrides()} into table
+   * properties for all tables, overriding any other table properties with matching keys.
+   */
+  @WithName("force-overrides-into-table-config")
+  @WithDefault("false")
+  @Value.Default
+  default boolean forceOverridesIntoTableConfig() {
+    return false;
+  }
 
   /** Location of the warehouse. Used to determine the base location of a table. */
   @WithConverter(TrimTrailingSlash.class)

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1TableResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1TableResource.java
@@ -205,7 +205,7 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
                 loadTableResultFromSnapshotResponse(
                     snap,
                     IcebergLoadTableResponse.builder(),
-                    warehouse.location(),
+                    warehouse,
                     prefix,
                     key,
                     dataAccess,
@@ -216,7 +216,7 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
       R loadTableResultFromSnapshotResponse(
           SnapshotResponse snap,
           B builder,
-          String warehouseLocation,
+          WarehouseConfig warehouse,
           String prefix,
           ContentKey contentKey,
           String dataAccess,
@@ -252,7 +252,7 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
     return loadTableResult(
         content.getMetadataLocation(),
         snap.nessieSnapshot(),
-        warehouseLocation,
+        warehouse,
         tableMetadata,
         builder,
         prefix,
@@ -265,7 +265,7 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
       R loadTableResult(
           String metadataLocation,
           NessieEntitySnapshot<?> nessieSnapshot,
-          String warehouseLocation,
+          WarehouseConfig warehouse,
           IcebergTableMetadata tableMetadata,
           B builder,
           String prefix,
@@ -276,7 +276,7 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
     IcebergTableConfig config =
         icebergConfigurer.icebergConfigPerTable(
             nessieSnapshot,
-            warehouseLocation,
+            warehouse,
             tableMetadata,
             prefix,
             contentKey,
@@ -362,7 +362,7 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
               this.loadTableResult(
                   null,
                   snapshot,
-                  warehouse.location(),
+                  warehouse,
                   stagedTableMetadata,
                   IcebergCreateTableResponse.builder(),
                   prefix,
@@ -384,7 +384,7 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
                 this.loadTableResultFromSnapshotResponse(
                     snap,
                     IcebergCreateTableResponse.builder(),
-                    warehouse.location(),
+                    warehouse,
                     prefix,
                     tableRef.contentKey(),
                     dataAccess,


### PR DESCRIPTION
* Add two new warehouse config flags to control the propagation of config overrides from the warehouse level to table level.

* By default old logic applies, which means warehouse config overrides do not affect table properties.