### PR TITLE
Fix a new failure in NesQuEIT, dependency issue w/ scala-collection-compat

### DIFF
--- a/build-logic/src/main/kotlin/Utilities.kt
+++ b/build-logic/src/main/kotlin/Utilities.kt
@@ -104,9 +104,8 @@ fun DependencyHandlerScope.forScala(scalaVersion: String) {
   add("implementation", "org.scala-lang:scala-reflect:$scalaVersion!!")
   if (scalaVersion.startsWith("2.12")) {
     // We only need this dependency for Scala 2.12, which does not have
-    // scala.jdk.CollectionConverters,
-    // but the deprecated JavaConverters.
-    add("implementation", "org.scala-lang.modules:scala-collection-compat_2.12:2.12.0!!")
+    // scala.jdk.CollectionConverters, but the deprecated JavaConverters.
+    add("implementation", "org.scala-lang.modules:scala-collection-compat_2.12:2.12.0")
   }
 }
 


### PR DESCRIPTION
Failure is:
```
Could not determine the dependencies of task ':nqeit-cross-engine-3.5-2.12-1.18:intTest'.
> Could not resolve all dependencies for configuration ':nqeit-cross-engine-3.5-2.12-1.18:testRuntimeClasspath'.
   > Could not resolve org.scala-lang.modules:scala-collection-compat_2.12:2.13.0.
     Required by:
         project :nqeit-cross-engine-3.5-2.12-1.18 > project :iceberg:iceberg-spark:iceberg-spark-3.5_2.12
         project :nqeit-cross-engine-3.5-2.12-1.18 > project :iceberg:iceberg-spark:iceberg-spark-extensions-3.5_2.12
      > Cannot find a version of 'org.scala-lang.modules:scala-collection-compat_2.12' that satisfies the version constraints:
           Dependency path 'org.projectnessie.integrations-tools-tests:nqeit-cross-engine-3.5-2.12-1.18:0.1-SNAPSHOT' --> 'org.apache.iceberg:iceberg-spark-3.5_2.12:1.8.0-SNAPSHOT' (runtimeElements) --> 'org.scala-lang.modules:scala-collection-compat_2.12:2.13.0'
           Dependency path 'org.projectnessie.integrations-tools-tests:nqeit-cross-engine-3.5-2.12-1.18:0.1-SNAPSHOT' --> 'org.apache.iceberg:iceberg-spark-extensions-3.5_2.12:1.8.0-SNAPSHOT' (runtimeElements) --> 'org.scala-lang.modules:scala-collection-compat_2.12:2.13.0'
           Dependency path 'org.projectnessie.integrations-tools-tests:nqeit-cross-engine-3.5-2.12-1.18:0.1-SNAPSHOT' --> 'org.projectnessie.nessie-integrations:nessie-spark-extensions-3.5_2.12:0.102.3-SNAPSHOT' (runtimeElements) --> 'org.scala-lang.modules:scala-collection-compat_2.12:{strictly 2.12.0}'
           Dependency path 'org.projectnessie.integrations-tools-tests:nqeit-cross-engine-3.5-2.12-1.18:0.1-SNAPSHOT' --> 'org.apache.spark:spark-core_2.12:3.5.3' (runtime) --> 'org.scala-lang.modules:scala-collection-compat_2.12:2.7.0'
           Dependency path 'org.projectnessie.integrations-tools-tests:nqeit-cross-engine-3.5-2.12-1.18:0.1-SNAPSHOT' --> 'org.projectnessie.nessie-integrations:nessie-spark-extensions-3.5_2.12:0.102.3-SNAPSHOT' (runtimeElements) --> 'org.projectnessie.nessie-integrations:nessie-spark-extensions-base_2.12:0.102.3-SNAPSHOT' (runtimeElements) --> 'org.scala-lang.modules:scala-collection-compat_2.12:{strictly 2.12.0}'
```

Change in Nessie is to not strictly require 2.12.0, but "just" 2.12.0 for that dependency.