### PR TITLE
nessie-gc truncate table to avoid increasing storage of DB

### DIFF
--- a/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/JdbcHelper.java
+++ b/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/JdbcHelper.java
@@ -55,6 +55,20 @@ public final class JdbcHelper {
     }
   }
 
+  public static int truncateTable(Connection connection) throws SQLException {
+    int numOfTruncatedTables = 0;
+    try (Statement st = connection.createStatement()) {
+      for (String tableName : SqlDmlDdl.ALL_CREATES.keySet()) {
+        if (tableExists(connection, tableName)) {
+          st.executeUpdate("TRUNCATE TABLE " + tableName);
+          numOfTruncatedTables++;
+        }
+      }
+      connection.commit();
+    }
+    return numOfTruncatedTables;
+  }
+
   private static boolean tableExists(Connection connection, String tableName) throws SQLException {
     DatabaseMetaData meta = connection.getMetaData();
     if (meta.storesUpperCaseIdentifiers()) {

--- a/gc/gc-repository-jdbc/src/test/java/org/projectnessie/gc/contents/jdbc/TestJdbcHelper.java
+++ b/gc/gc-repository-jdbc/src/test/java/org/projectnessie/gc/contents/jdbc/TestJdbcHelper.java
@@ -68,4 +68,24 @@ public class TestJdbcHelper extends AbstractJdbcHelper {
         .as("dropping tables again should not throw")
         .doesNotThrowAnyException();
   }
+
+  @Test
+  @Order(2)
+  void truncateTables() {
+    assertThatCode(
+            () -> {
+              try (Connection conn = dataSource.getConnection()) {
+                JdbcHelper.truncateTable(conn);
+              }
+            })
+        .doesNotThrowAnyException();
+    assertThatCode(
+            () -> {
+              try (Connection conn = dataSource.getConnection()) {
+                JdbcHelper.truncateTable(conn);
+              }
+            })
+        .as("truncating tables again should not throw")
+        .doesNotThrowAnyException();
+  }
 }

--- a/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/CLI.java
+++ b/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/CLI.java
@@ -26,6 +26,7 @@ import org.projectnessie.gc.tool.cli.commands.DeferredDeleteFiles;
 import org.projectnessie.gc.tool.cli.commands.DeleteLiveSets;
 import org.projectnessie.gc.tool.cli.commands.JdbcCreateSchema;
 import org.projectnessie.gc.tool.cli.commands.JdbcDumpSchema;
+import org.projectnessie.gc.tool.cli.commands.JdbcTruncateTables;
 import org.projectnessie.gc.tool.cli.commands.ListDeferredDeletions;
 import org.projectnessie.gc.tool.cli.commands.ListLiveSets;
 import org.projectnessie.gc.tool.cli.commands.MarkAndSweep;
@@ -57,7 +58,8 @@ import picocli.CommandLine.HelpCommand;
       JdbcDumpSchema.class,
       JdbcCreateSchema.class,
       CompletionScript.class,
-      ThirdPartyLicenses.class
+      ThirdPartyLicenses.class,
+      JdbcTruncateTables.class
     })
 public class CLI {
 

--- a/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/commands/JdbcTruncateTables.java
+++ b/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/commands/JdbcTruncateTables.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.tool.cli.commands;
+
+import static java.lang.System.out;
+
+import java.sql.Connection;
+import javax.sql.DataSource;
+import org.projectnessie.gc.contents.jdbc.JdbcHelper;
+import org.projectnessie.gc.tool.cli.Closeables;
+import org.projectnessie.gc.tool.cli.options.EnvironmentDefaultProvider;
+import org.projectnessie.gc.tool.cli.options.JdbcOptions;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "truncate",
+    aliases = {"clean-tables"},
+    mixinStandardHelpOptions = true,
+    defaultValueProvider = EnvironmentDefaultProvider.class,
+    description =
+        "Truncate nessie-gc tables to avoid increasing storage of DB, "
+            + "must not be used with the in-memory contents-storage.")
+public class JdbcTruncateTables extends BaseCommand {
+  @CommandLine.ArgGroup(multiplicity = "1", exclusive = false)
+  JdbcOptions jdbc;
+
+  @Override
+  protected Integer call(Closeables closeables) throws Exception {
+    DataSource dataSource = closeables.maybeAdd(jdbc.createDataSource());
+    int truncateTableCount;
+    try (Connection conn = dataSource.getConnection()) {
+      truncateTableCount = JdbcHelper.truncateTable(conn);
+    }
+    out.printf("number of `%s` tables truncated", truncateTableCount);
+    return truncateTableCount > 0 ? 0 : 1;
+  }
+}

--- a/gc/gc-tool/src/test/java/org/projectnessie/gc/tool/TestCLI.java
+++ b/gc/gc-tool/src/test/java/org/projectnessie/gc/tool/TestCLI.java
@@ -128,6 +128,9 @@ public class TestCLI {
         arguments(
             asList("list-deferred", "--live-set-id=00000000-0000-0000-0000-000000000000"),
             "Error: Missing required argument (specify one of these): ([--inmemory] | [[--jdbc]"),
+        arguments(
+            singletonList("truncate"),
+            "Error: Missing required argument(s): ([--jdbc] --jdbc-url=<url>"),
         // No live-set-id
         arguments(
             asList("sweep", "--jdbc-url", "jdbc:foo//bar"),
@@ -469,5 +472,12 @@ public class TestCLI {
     run = RunCLI.run("completion-script", "--output-file", file.toString());
     soft.assertThat(run.getExitCode()).as(run::getErr).isEqualTo(1);
     soft.assertThat(run.getErr()).contains("File already exists.");
+  }
+
+  @Test
+  @Order(10)
+  public void truncateTables() throws Exception {
+    RunCLI run = RunCLI.run("truncate", "--jdbc-url", JDBC_URL);
+    soft.assertThat(run.getExitCode()).as(run::getErr).isEqualTo(0);
   }
 }


### PR DESCRIPTION
In case of using relational database for nessie-gc, nessie-gc keeps data of older runs inside tables and after some runs that cause storage problem(which is caused by data and index storage). 
That truncate step will help us to delete these data from these tables:

-          "gc_live_sets"
-          "gc_live_set_contents"
-         "gc_live_set_content_locations"
-         "gc_file_deletions"

