### PR TITLE
Catalog: Return consistent metadata-location for Iceberg REST APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Fixes
 
+* Catalog: Return consistent metadata-location for Iceberg REST APIs
+
 ### Commits
 
 ## [0.103.0] Release (2025-02-18)

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ResourceBase.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ResourceBase.java
@@ -39,7 +39,6 @@ import static org.projectnessie.versioned.RequestMeta.API_WRITE;
 import com.google.common.base.Splitter;
 import io.smallrye.mutiny.Uni;
 import java.io.IOException;
-import java.net.URI;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.HashMap;
@@ -57,7 +56,6 @@ import org.projectnessie.catalog.formats.iceberg.rest.IcebergRenameTableRequest;
 import org.projectnessie.catalog.formats.iceberg.rest.IcebergUpdateEntityRequest;
 import org.projectnessie.catalog.service.api.CatalogCommit;
 import org.projectnessie.catalog.service.api.CatalogEntityAlreadyExistsException;
-import org.projectnessie.catalog.service.api.CatalogService;
 import org.projectnessie.catalog.service.api.SnapshotReqParams;
 import org.projectnessie.catalog.service.api.SnapshotResponse;
 import org.projectnessie.catalog.service.config.LakehouseConfig;
@@ -331,15 +329,6 @@ abstract class IcebergApiV1ResourceBase extends AbstractCatalogResource {
     checkArgument(
         reference instanceof Branch, "Can only commit against a branch, but got " + reference);
     return (Branch) reference;
-  }
-
-  protected String snapshotMetadataLocation(SnapshotResponse snap) {
-    // TODO the resolved metadataLocation is wrong !!
-    CatalogService.CatalogUriResolver catalogUriResolver = new CatalogUriResolverImpl(uriInfo);
-    URI metadataLocation =
-        catalogUriResolver.icebergSnapshot(
-            snap.effectiveReference(), snap.contentKey(), snap.nessieSnapshot());
-    return metadataLocation.toString();
   }
 
   static Map<String, String> createEntityProperties(Map<String, String> providedProperties) {

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1TableResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1TableResource.java
@@ -634,9 +634,10 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
                   (IcebergTableMetadata)
                       snap.entityObject()
                           .orElseThrow(() -> new IllegalStateException("entity object missing"));
+              IcebergTable content = (IcebergTable) snap.content();
               return IcebergCommitTableResponse.builder()
                   .metadata(tableMetadata)
-                  .metadataLocation(snapshotMetadataLocation(snap))
+                  .metadataLocation(content.getMetadataLocation())
                   .build();
             });
   }

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ViewResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1ViewResource.java
@@ -288,9 +288,10 @@ public class IcebergApiV1ViewResource extends IcebergApiV1ResourceBase {
                   (IcebergViewMetadata)
                       snap.entityObject()
                           .orElseThrow(() -> new IllegalStateException("entity object missing"));
+              IcebergView content = (IcebergView) snap.content();
               return IcebergLoadViewResponse.builder()
                   .metadata(viewMetadata)
-                  .metadataLocation(snapshotMetadataLocation(snap))
+                  .metadataLocation(content.getMetadataLocation())
                   .build();
             });
   }


### PR DESCRIPTION
# Problem

Different Nessie Iceberg REST APIs return metadata locations inconsistently:
- `loadTable` → a metadata location with a filesystem schema, e.g., `s3://bucket/table/metadata/xxx.metadata.json`.
- `updateTable` → a metadata location pointing to a Nessie API endpoint, e.g., `http://nessie-host:port/catalog/v1/trees/main%some-hash-value/snapshot/my.table?format=iceberg`.

This causes issues for clients like `iceberg-rust`, which doesn’t support HTTP metadata locations.

# Fix
Standardizes metadata location responses to always use the filesystem schema.