### PR TITLE
Helm: Allow annotations on the configmap. 

### DIFF
--- a/helm/nessie/templates/configmap.yaml
+++ b/helm/nessie/templates/configmap.yaml
@@ -26,6 +26,10 @@ metadata:
     {{- if .Values.configMapLabels }}
     {{- toYaml .Values.configMapLabels | nindent 4 }}
     {{- end }}
+  annotations:
+    {{- if .Values.configMapAnnotations }}
+    {{- toYaml .Values.configMapAnnotations | nindent 4 }}
+    {{- end }}
 data:
   application.properties: |-
     {{- $map := dict -}}

--- a/helm/nessie/templates/configmap.yaml
+++ b/helm/nessie/templates/configmap.yaml
@@ -26,10 +26,10 @@ metadata:
     {{- if .Values.configMapLabels }}
     {{- toYaml .Values.configMapLabels | nindent 4 }}
     {{- end }}
+  {{- if .Values.configMapAnnotations }}
   annotations:
-    {{- if .Values.configMapAnnotations }}
-    {{- toYaml .Values.configMapAnnotations | nindent 4 }}
-    {{- end }}
+    {{- tpl (toYaml .Values.configMapAnnotations) . | nindent 4 }}
+  {{- end }}
 data:
   application.properties: |-
     {{- $map := dict -}}

--- a/helm/nessie/tests/configmap_test.yaml
+++ b/helm/nessie/tests/configmap_test.yaml
@@ -1,0 +1,46 @@
+##
+## Copyright (C) 2024 Dremio
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+release:
+  name: nessie
+  namespace: nessie-ns
+
+templates:
+  - configmap.yaml
+
+tests:
+  - it: should not create annotations by default
+    asserts:
+      - notExists:
+          path: metadata.annotations
+  - it: should create annotations if defined
+    set:
+      configMapAnnotations:
+        foo: bar
+    asserts:
+    - equal:
+        path: metadata.annotations
+        value:
+          foo: bar
+  - it: should create annotations with templates
+    set:
+      configMapAnnotations:
+        foo: configmap-{{ .Release.Name }}-{{ .Release.Namespace }}
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            foo: configmap-nessie-nessie-ns

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -740,6 +740,9 @@ podLabels: {}
 # -- Additional Labels to apply to nessie configmap.
 configMapLabels: {}
 
+# -- Additional Annotations to apply to nessie configmap.
+configMapAnnotations: {}
+
 # -- Security context for the nessie pod. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/.
 podSecurityContext:
   # GID 10001 is compatible with Nessie OSS default images starting with 0.95.1; change this if you


### PR DESCRIPTION

This pull request introduces enhancements to the Helm chart for Nessie by adding support for custom annotations in the ConfigMap. The changes ensure that users can define additional annotations through the `values.yaml` file, which will be applied to the ConfigMap.

This would allow us to set the argocd sync-wave, which ensures the CM syncs first, leading to a more stable Nessie deployment. 
i.e. 

```
  annotations:
    argocd.argoproj.io/sync-wave: "-1"
```

There may of course, be other use cases. 

Key changes include:

* [`helm/nessie/templates/configmap.yaml`](diffhunk://#diff-4dd7692ce974f0d9968339f65a8aad2db5dd16da0012dee981c6222566ca4191R29-R32): Added support for custom annotations by including a conditional block to insert annotations if they are defined in the `values.yaml` file.
* [`helm/nessie/values.yaml`](diffhunk://#diff-2ec11c0c74822e15c1da4fdd05297e86c7ebecfe975c5c1173454565571b9534R743-R745): Introduced a new field `configMapAnnotations` to allow users to specify additional annotations for the ConfigMap.