### PR TITLE
Make `cache-enable-soft-references` default to `false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Highlights
 
+* Configuration option `nessie.version.store.persist.cache-enable-soft-references` defaults to 
+  `false` now. Some feedback suggests that using soft references in the Nessie cache may not be
+  optimal with respect to GC overhead in some environments, so defaulting to `false` is safer.
+
 ### Upgrade notes
 
 ### Breaking changes

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
@@ -60,7 +60,7 @@ class CaffeineCacheBackend implements CacheBackend {
 
     refCacheTtlNanos = config.referenceTtl().orElse(Duration.ZERO).toNanos();
     refCacheNegativeTtlNanos = config.referenceNegativeTtl().orElse(Duration.ZERO).toNanos();
-    enableSoftReferences = config.enableSoftReferences().orElse(true);
+    enableSoftReferences = config.enableSoftReferences().orElse(false);
 
     Caffeine<CacheKeyValue, CacheKeyValue> cacheBuilder =
         Caffeine.newBuilder()


### PR DESCRIPTION
Following up on #10217.

Using soft references in the Nessie cache may cause heavy GC overhead in some environments. While it may be used for fine-tuning Nessie caches to improve performance, enabling it by default seems risky for less advanced users and smaller environments.