### PR TITLE
Adopt to next guava version

### DIFF
--- a/api/client/build.gradle.kts
+++ b/api/client/build.gradle.kts
@@ -44,9 +44,8 @@ dependencies {
 
   compileOnly(project(":nessie-doc-generator-annotations"))
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testFixturesApi(libs.guava)
   testFixturesApi(libs.bouncycastle.bcprov)
@@ -64,6 +63,7 @@ dependencies {
 
   // javax/jakarta
   testFixturesApi(libs.jakarta.annotation.api)
+  testFixturesApi(libs.findbugs.jsr305)
 
   testFixturesApi(platform(libs.opentelemetry.bom.alpha))
   testFixturesApi("io.opentelemetry:opentelemetry-api")
@@ -84,9 +84,8 @@ dependencies {
 
   testRuntimeOnly(libs.logback.classic)
 
-  testCompileOnly(libs.immutables.builder)
-  testCompileOnly(libs.immutables.value.annotations)
-  testAnnotationProcessor(libs.immutables.value.processor)
+  testCompileOnly(project(":nessie-immutables-std"))
+  testAnnotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   intTestImplementation(platform(libs.testcontainers.bom))
   intTestImplementation("org.testcontainers:testcontainers")
@@ -96,7 +95,7 @@ dependencies {
     exclude(group = "org.slf4j") // uses SLF4J 2.x, we are not ready yet
   }
   intTestImplementation(project(":nessie-container-spec-helper"))
-  intTestCompileOnly(libs.immutables.value.annotations)
+  intTestCompileOnly(project(":nessie-immutables-std"))
 }
 
 jandex { skipDefaultProcessing() }

--- a/api/model/build.gradle.kts
+++ b/api/model/build.gradle.kts
@@ -41,13 +41,12 @@ dependencies {
 
   compileOnly(libs.microprofile.openapi)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testCompileOnly(libs.microprofile.openapi)
-  testCompileOnly(libs.immutables.value.annotations)
-  testAnnotationProcessor(libs.immutables.value.processor)
+  testCompileOnly(project(":nessie-immutables-std"))
+  testAnnotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
   testCompileOnly(libs.jakarta.ws.rs.api)
   testCompileOnly(libs.javax.ws.rs)
   testCompileOnly(libs.jakarta.validation.api)
@@ -62,7 +61,7 @@ dependencies {
   intTestImplementation("org.testcontainers:testcontainers")
   intTestImplementation(libs.awaitility)
   intTestImplementation(project(":nessie-container-spec-helper"))
-  intTestCompileOnly(libs.immutables.value.annotations)
+  intTestCompileOnly(project(":nessie-immutables-std"))
 }
 
 extensions.configure<SmallryeOpenApiExtension> {

--- a/catalog/format/iceberg/build.gradle.kts
+++ b/catalog/format/iceberg/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
 
   implementation(libs.jakarta.annotation.api) // 'implementation' for smallrye-config
   compileOnly(libs.jakarta.validation.api)
+  compileOnly(libs.findbugs.jsr305)
 
   compileOnly(libs.errorprone.annotations)
   compileOnly(libs.microprofile.openapi)

--- a/catalog/model/build.gradle.kts
+++ b/catalog/model/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
   compileOnly(libs.jakarta.ws.rs.api)
   compileOnly(libs.jakarta.enterprise.cdi.api)
   compileOnly(libs.jakarta.validation.api)
+  compileOnly(libs.findbugs.jsr305)
 
   compileOnly(libs.errorprone.annotations)
   compileOnly(libs.microprofile.openapi)

--- a/catalog/secrets/cache/src/main/java/org/projectnessie/catalog/secrets/cache/CachingSecretsBackend.java
+++ b/catalog/secrets/cache/src/main/java/org/projectnessie/catalog/secrets/cache/CachingSecretsBackend.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongSupplier;
-import org.checkerframework.checker.index.qual.NonNegative;
 import org.projectnessie.catalog.secrets.Secret;
 import org.projectnessie.catalog.secrets.SecretType;
 import org.projectnessie.catalog.secrets.SecretsProvider;
@@ -70,7 +69,7 @@ public class CachingSecretsBackend {
                       CacheKeyValue key,
                       Secret value,
                       long currentTimeNanos,
-                      @NonNegative long currentDurationNanos) {
+                      long currentDurationNanos) {
                     return currentDurationNanos;
                   }
 
@@ -79,7 +78,7 @@ public class CachingSecretsBackend {
                       CacheKeyValue key,
                       Secret value,
                       long currentTimeNanos,
-                      @NonNegative long currentDurationNanos) {
+                      long currentDurationNanos) {
                     return currentDurationNanos;
                   }
                 })

--- a/cli/cli/build.gradle.kts
+++ b/cli/cli/build.gradle.kts
@@ -56,8 +56,8 @@ dependencies {
   runtimeOnly(platform(libs.azuresdk.bom))
   runtimeOnly("com.azure:azure-storage-file-datalake")
 
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   compileOnly(libs.jakarta.annotation.api)
   compileOnly(libs.microprofile.openapi)
@@ -65,9 +65,8 @@ dependencies {
   implementation(platform(libs.jackson.bom))
   implementation("com.fasterxml.jackson.core:jackson-databind")
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   runtimeOnly(libs.logback.classic)
 
@@ -83,7 +82,7 @@ dependencies {
 
   testImplementation(project(":nessie-versioned-storage-inmemory-tests"))
 
-  testCompileOnly(libs.immutables.value.annotations)
+  testCompileOnly(project(":nessie-immutables-std"))
 
   intTestImplementation(project(":nessie-object-storage-mock"))
   intTestImplementation(project(":nessie-catalog-format-iceberg"))

--- a/cli/grammar/build.gradle.kts
+++ b/cli/grammar/build.gradle.kts
@@ -28,8 +28,8 @@ configurations.testFixturesApi { extendsFrom(syntaxGen) }
 
 dependencies {
   compileOnly(libs.jakarta.annotation.api)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   implementation(libs.guava)
   implementation(libs.slf4j.api)
@@ -42,7 +42,7 @@ dependencies {
   testFixturesApi(platform(libs.junit.bom))
   testFixturesApi(libs.bundles.junit.testing)
   testFixturesApi(libs.jakarta.annotation.api)
-  testFixturesApi(libs.immutables.value.annotations)
+  testFixturesApi(project(":nessie-immutables-std"))
 
   testFixturesRuntimeOnly(libs.logback.classic)
 

--- a/events/api/build.gradle.kts
+++ b/events/api/build.gradle.kts
@@ -22,9 +22,8 @@ dependencies {
   api(project(":nessie-model"))
 
   // Immutables
-  implementation(libs.immutables.builder)
-  implementation(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  implementation(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   // Jackson
   implementation(platform(libs.jackson.bom))

--- a/events/service/build.gradle.kts
+++ b/events/service/build.gradle.kts
@@ -33,9 +33,8 @@ dependencies {
   compileOnly(libs.microprofile.openapi)
   compileOnly(libs.jakarta.annotation.api)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.bundles.junit.testing)
@@ -43,6 +42,7 @@ dependencies {
   testRuntimeOnly(libs.logback.classic)
 
   testCompileOnly(libs.microprofile.openapi)
+  testCompileOnly(libs.jakarta.annotation.api)
 }
 
 tasks.withType(Test::class).configureEach {

--- a/events/spi/build.gradle.kts
+++ b/events/spi/build.gradle.kts
@@ -22,9 +22,8 @@ dependencies {
   api(project(":nessie-events-api"))
 
   // Immutables
-  implementation(libs.immutables.builder)
-  implementation(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  implementation(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   // Jackson
   compileOnly(platform(libs.jackson.bom))

--- a/gc/gc-base/build.gradle.kts
+++ b/gc/gc-base/build.gradle.kts
@@ -23,8 +23,8 @@ description =
 
 dependencies {
   compileOnly(libs.errorprone.annotations)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   api(project(":nessie-storage-uri"))
   implementation(project(":nessie-client"))
@@ -52,8 +52,8 @@ dependencies {
 
   testCompileOnly(libs.jakarta.validation.api)
 
-  testCompileOnly(libs.immutables.value.annotations)
-  testAnnotationProcessor(libs.immutables.value.processor)
+  testCompileOnly(project(":nessie-immutables-std"))
+  testAnnotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testCompileOnly(platform(libs.jackson.bom))
   testCompileOnly("com.fasterxml.jackson.core:jackson-annotations")

--- a/gc/gc-iceberg-files/build.gradle.kts
+++ b/gc/gc-iceberg-files/build.gradle.kts
@@ -48,8 +48,8 @@ dependencies {
   implementation("org.apache.iceberg:iceberg-azure")
 
   compileOnly(libs.errorprone.annotations)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(nessieProject("nessie-immutables-std"))
+  annotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   implementation(nessieProject("nessie-gc-base"))
 

--- a/gc/gc-iceberg-inttest/build.gradle.kts
+++ b/gc/gc-iceberg-inttest/build.gradle.kts
@@ -116,9 +116,8 @@ dependencies {
   intTestImplementation(nessieProject("nessie-gcs-testcontainer"))
   intTestRuntimeOnly(libs.hadoop.azure)
 
-  intTestCompileOnly(libs.immutables.builder)
-  intTestCompileOnly(libs.immutables.value.annotations)
-  intTestAnnotationProcessor(libs.immutables.value.processor)
+  intTestCompileOnly(nessieProject("nessie-immutables-std"))
+  intTestAnnotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   intTestRuntimeOnly(libs.logback.classic)
 

--- a/gc/gc-iceberg-mock/build.gradle.kts
+++ b/gc/gc-iceberg-mock/build.gradle.kts
@@ -23,8 +23,8 @@ dependencies {
   compileOnly("org.apache.iceberg:iceberg-core")
 
   compileOnly(libs.errorprone.annotations)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(nessieProject("nessie-immutables-std"))
+  annotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   implementation(libs.guava)
   implementation(platform(libs.jackson.bom))
@@ -44,8 +44,8 @@ dependencies {
   testImplementation(platform(libs.iceberg.bom))
   testImplementation("org.apache.iceberg:iceberg-core")
 
-  testCompileOnly(libs.immutables.value.annotations)
-  testAnnotationProcessor(libs.immutables.value.processor)
+  testCompileOnly(nessieProject("nessie-immutables-std"))
+  testAnnotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   testCompileOnly(libs.microprofile.openapi)
 

--- a/gc/gc-iceberg/build.gradle.kts
+++ b/gc/gc-iceberg/build.gradle.kts
@@ -23,8 +23,8 @@ dependencies {
   implementation("org.apache.iceberg:iceberg-core")
 
   compileOnly(libs.errorprone.annotations)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(nessieProject("nessie-immutables-std"))
+  annotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   implementation(nessieProject("nessie-model"))
   implementation(nessieProject("nessie-gc-base"))

--- a/gc/gc-repository-jdbc/build.gradle.kts
+++ b/gc/gc-repository-jdbc/build.gradle.kts
@@ -20,8 +20,8 @@ publishingHelper { mavenName = "Nessie - GC - JDBC live-contents-set persistence
 
 dependencies {
   compileOnly(libs.errorprone.annotations)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(nessieProject("nessie-immutables-std"))
+  annotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
   compileOnly(libs.jetbrains.annotations)
 
   implementation(nessieProject("nessie-model"))
@@ -40,6 +40,7 @@ dependencies {
 
   compileOnly(libs.jakarta.validation.api)
   compileOnly(libs.jakarta.annotation.api)
+  compileOnly(libs.findbugs.jsr305)
 
   compileOnly(platform(libs.jackson.bom))
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")
@@ -66,5 +67,5 @@ dependencies {
   intTestImplementation("org.testcontainers:mysql")
   intTestRuntimeOnly(libs.docker.java.api)
   intTestImplementation(project(":nessie-container-spec-helper"))
-  intTestCompileOnly(libs.immutables.value.annotations)
+  intTestCompileOnly(project(":nessie-immutables-std"))
 }

--- a/gc/gc-tool-inttest/build.gradle.kts
+++ b/gc/gc-tool-inttest/build.gradle.kts
@@ -29,8 +29,8 @@ dependencies {
   implementation(nessieProject("nessie-gc-tool", "shadow"))
 
   compileOnly(libs.errorprone.annotations)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(nessieProject("nessie-immutables-std"))
+  annotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   // hadoop-common brings Jackson in ancient versions, pulling in the Jackson BOM to avoid that
   implementation(platform(libs.jackson.bom))

--- a/gc/gc-tool/build.gradle.kts
+++ b/gc/gc-tool/build.gradle.kts
@@ -36,8 +36,8 @@ dependencies {
   implementation(nessieProject("nessie-notice"))
 
   compileOnly(libs.errorprone.annotations)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(nessieProject("nessie-immutables-std"))
+  annotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   implementation(platform(libs.iceberg.bom))
   implementation("org.apache.iceberg:iceberg-core")
@@ -101,8 +101,8 @@ dependencies {
 
   testRuntimeOnly(libs.logback.classic)
 
-  testCompileOnly(libs.immutables.value.annotations)
-  testAnnotationProcessor(libs.immutables.value.processor)
+  testCompileOnly(nessieProject("nessie-immutables-std"))
+  testAnnotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   testCompileOnly("com.fasterxml.jackson.core:jackson-annotations")
   testCompileOnly(libs.microprofile.openapi)

--- a/gradle/projects.main.properties
+++ b/gradle/projects.main.properties
@@ -25,6 +25,7 @@ nessie-gc-base-tests=gc/gc-base-tests
 nessie-gc-repository-jdbc=gc/gc-repository-jdbc
 nessie-gcs-testcontainer=testing/gcs-container
 nessie-immutables=tools/immutables
+nessie-immutables-std=tools/immutables-std
 nessie-perftest-gatling=perftest/gatling
 nessie-perftest-simulations=perftest/simulations
 nessie-jaxrs-testextension=servers/jax-rs-testextension

--- a/integrations/spark-extensions-basetests/build.gradle.kts
+++ b/integrations/spark-extensions-basetests/build.gradle.kts
@@ -40,11 +40,11 @@ dependencies {
   implementation(libs.microprofile.openapi)
 
   compileOnly(libs.errorprone.annotations)
-  compileOnly(libs.immutables.value.annotations)
   // This lets Immutables discover the right Guava version, otherwise we end with Guava 16 (from
   // 14), and Immutables uses Objects.toStringHelper instead of MoreObjects.toStringHelper.
   compileOnly(libs.guava)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(nessieProject("nessie-immutables-std"))
+  annotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   implementation(platform(libs.junit.bom))
   implementation(libs.bundles.junit.testing)

--- a/servers/quarkus-common/build.gradle.kts
+++ b/servers/quarkus-common/build.gradle.kts
@@ -78,9 +78,8 @@ dependencies {
   implementation("com.fasterxml.jackson.core:jackson-databind")
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   implementation("org.jboss.slf4j:slf4j-jboss-logmanager")
   implementation("io.opentelemetry:opentelemetry-opencensus-shim") // for Google BigTable

--- a/servers/quarkus-config/build.gradle.kts
+++ b/servers/quarkus-config/build.gradle.kts
@@ -28,9 +28,8 @@ dependencies {
   compileOnly("io.quarkus:quarkus-core")
   compileOnly("io.smallrye.config:smallrye-config-core")
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(nessieProject("nessie-immutables-std"))
+  annotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   implementation(libs.guava)
 

--- a/servers/quarkus-distcache/build.gradle.kts
+++ b/servers/quarkus-distcache/build.gradle.kts
@@ -34,8 +34,8 @@ dependencies {
   implementation(libs.guava)
   implementation(libs.slf4j.api)
 
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testFixturesApi(platform(libs.junit.bom))
   testFixturesApi(libs.bundles.junit.testing)

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -92,8 +92,8 @@ dependencies {
 
   compileOnly(libs.microprofile.openapi)
 
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   openapiSource(project(":nessie-model")) { isTransitive = false }
 

--- a/servers/quarkus-tests/build.gradle.kts
+++ b/servers/quarkus-tests/build.gradle.kts
@@ -60,5 +60,5 @@ dependencies {
   implementation(libs.testcontainers.keycloak)
   implementation(libs.keycloak.admin.client)
 
-  compileOnly(libs.immutables.value.annotations)
+  compileOnly(project(":nessie-immutables-std"))
 }

--- a/servers/services/build.gradle.kts
+++ b/servers/services/build.gradle.kts
@@ -29,9 +29,8 @@ dependencies {
   implementation(platform(libs.cel.bom))
   implementation("org.projectnessie.cel:cel-standalone")
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
   implementation(libs.guava)
 
   compileOnly(libs.jakarta.validation.api)

--- a/tasks/api/build.gradle.kts
+++ b/tasks/api/build.gradle.kts
@@ -31,9 +31,8 @@ dependencies {
   implementation(libs.guava)
   implementation(libs.slf4j.api)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   implementation(platform(libs.jackson.bom))
   implementation("com.fasterxml.jackson.core:jackson-databind")

--- a/tasks/service/async/build.gradle.kts
+++ b/tasks/service/async/build.gradle.kts
@@ -22,9 +22,8 @@ dependencies {
   compileOnly(libs.vertx.core)
   compileOnly(libs.microprofile.contextpropagation.api)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.bundles.junit.testing)

--- a/tasks/service/impl/build.gradle.kts
+++ b/tasks/service/impl/build.gradle.kts
@@ -27,9 +27,8 @@ dependencies {
   compileOnly(libs.jakarta.annotation.api)
   compileOnly(libs.jakarta.inject.api)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   compileOnly(libs.errorprone.annotations)
   implementation(libs.guava)
@@ -52,9 +51,8 @@ dependencies {
   testCompileOnly(libs.jakarta.validation.api)
   testCompileOnly(libs.jakarta.annotation.api)
 
-  testCompileOnly(libs.immutables.builder)
-  testCompileOnly(libs.immutables.value.annotations)
-  testAnnotationProcessor(libs.immutables.value.processor)
+  testCompileOnly(project(":nessie-immutables-std"))
+  testAnnotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testImplementation(platform(libs.jackson.bom))
   testImplementation("com.fasterxml.jackson.core:jackson-databind")

--- a/testing/azurite-container/build.gradle.kts
+++ b/testing/azurite-container/build.gradle.kts
@@ -21,7 +21,7 @@ publishingHelper { mavenName = "Nessie - Azurite testcontainer" }
 dependencies {
   implementation(libs.slf4j.api)
   implementation(project(":nessie-container-spec-helper"))
-  compileOnly(libs.immutables.value.annotations)
+  compileOnly(project(":nessie-immutables-std"))
   api(platform(libs.testcontainers.bom))
   api("org.testcontainers:testcontainers")
 
@@ -33,8 +33,8 @@ dependencies {
   compileOnly(libs.findbugs.jsr305)
   compileOnly(libs.errorprone.annotations)
 
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   compileOnly(platform(libs.junit.bom))
   compileOnly("org.junit.jupiter:junit-jupiter-api")

--- a/testing/container-spec-helper/build.gradle.kts
+++ b/testing/container-spec-helper/build.gradle.kts
@@ -23,8 +23,8 @@ dependencies {
   api(platform(libs.testcontainers.bom))
   api("org.testcontainers:testcontainers")
 
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testImplementation(libs.bundles.junit.testing)
 }

--- a/testing/gcs-container/build.gradle.kts
+++ b/testing/gcs-container/build.gradle.kts
@@ -21,7 +21,7 @@ publishingHelper { mavenName = "Nessie - GCS testcontainer" }
 dependencies {
   implementation(libs.slf4j.api)
   implementation(project(":nessie-container-spec-helper"))
-  compileOnly(libs.immutables.value.annotations)
+  compileOnly(project(":nessie-immutables-std"))
   api(platform(libs.testcontainers.bom))
   api("org.testcontainers:testcontainers")
 
@@ -32,8 +32,8 @@ dependencies {
   compileOnly(libs.findbugs.jsr305)
   compileOnly(libs.errorprone.annotations)
 
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   compileOnly(platform(libs.junit.bom))
   compileOnly("org.junit.jupiter:junit-jupiter-api")

--- a/testing/keycloak-container/build.gradle.kts
+++ b/testing/keycloak-container/build.gradle.kts
@@ -21,7 +21,7 @@ publishingHelper { mavenName = "Nessie - Keycloak testcontainer" }
 dependencies {
   implementation(libs.slf4j.api)
   implementation(project(":nessie-container-spec-helper"))
-  compileOnly(libs.immutables.value.annotations)
+  compileOnly(project(":nessie-immutables-std"))
   api(libs.keycloak.admin.client)
   api(libs.testcontainers.keycloak) {
     exclude(group = "org.slf4j") // uses SLF4J 2.x, we are not ready yet
@@ -31,6 +31,6 @@ dependencies {
   compileOnly(libs.findbugs.jsr305)
   compileOnly(libs.errorprone.annotations)
 
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 }

--- a/testing/minio-container/build.gradle.kts
+++ b/testing/minio-container/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
   implementation(platform(libs.testcontainers.bom))
   implementation("org.testcontainers:testcontainers")
   implementation(project(":nessie-container-spec-helper"))
-  compileOnly(libs.immutables.value.annotations)
+  compileOnly(project(":nessie-immutables-std"))
 
   implementation(platform(libs.awssdk.bom))
   implementation("software.amazon.awssdk:s3")

--- a/testing/nessie-container/build.gradle.kts
+++ b/testing/nessie-container/build.gradle.kts
@@ -23,12 +23,12 @@ dependencies {
   implementation(platform(libs.testcontainers.bom))
   implementation("org.testcontainers:testcontainers")
   implementation(project(":nessie-container-spec-helper"))
-  compileOnly(libs.immutables.value.annotations)
+  compileOnly(project(":nessie-immutables-std"))
 
   compileOnly(libs.jakarta.annotation.api)
   compileOnly(libs.findbugs.jsr305)
   compileOnly(libs.errorprone.annotations)
 
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 }

--- a/testing/object-storage-mock/build.gradle.kts
+++ b/testing/object-storage-mock/build.gradle.kts
@@ -38,8 +38,8 @@ dependencies {
   implementation("org.glassfish.jersey.media:jersey-media-json-jackson")
 
   compileOnly(libs.errorprone.annotations)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   implementation(libs.guava)
 
@@ -69,8 +69,8 @@ dependencies {
   testImplementation(platform(libs.google.cloud.storage.bom))
   testImplementation("com.google.cloud:google-cloud-storage")
 
-  testCompileOnly(libs.immutables.value.annotations)
-  testAnnotationProcessor(libs.immutables.value.processor)
+  testCompileOnly(project(":nessie-immutables-std"))
+  testAnnotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testCompileOnly(libs.microprofile.openapi)
 

--- a/testing/trino-container/build.gradle.kts
+++ b/testing/trino-container/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   implementation(libs.okhttp3)
 
   compileOnly(libs.errorprone.annotations)
-  compileOnly(libs.immutables.value.annotations)
+  compileOnly(project(":nessie-immutables-std"))
 
   intTestImplementation(libs.bundles.junit.testing)
   intTestRuntimeOnly(libs.logback.classic)

--- a/tools/content-generator/build.gradle.kts
+++ b/tools/content-generator/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 
   compileOnly(libs.jakarta.validation.api)
   compileOnly(libs.jakarta.annotation.api)
+  compileOnly(libs.findbugs.jsr305)
 
   compileOnly(libs.microprofile.openapi)
   runtimeOnly(libs.slf4j.api)
@@ -42,9 +43,8 @@ dependencies {
   implementation("com.fasterxml.jackson.core:jackson-annotations")
   implementation("com.fasterxml.jackson.core:jackson-databind")
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testFixturesImplementation(project(":nessie-client"))
 

--- a/tools/immutables-std/build.gradle.kts
+++ b/tools/immutables-std/build.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2025 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins { id("nessie-conventions-client") }
+
+publishingHelper { mavenName = "Nessie - Build tool - Immutables without javax annotations" }
+
+val processor by configurations.creating
+
+processor.extendsFrom(configurations.api.get())
+
+dependencies {
+  api(libs.immutables.builder)
+  api(libs.immutables.value.annotations)
+
+  processor(libs.immutables.value.processor)
+  processor(project)
+}

--- a/tools/immutables-std/src/main/resources/META-INF/extensions/org.immutables.inhibit-classpath
+++ b/tools/immutables-std/src/main/resources/META-INF/extensions/org.immutables.inhibit-classpath
@@ -1,0 +1,6 @@
+javax.annotation.Nullable
+javax.annotation.CheckReturnValue;
+javax.annotation.Nullable;
+javax.annotation.ParametersAreNonnullByDefault;
+javax.annotation.concurrent.Immutable;
+javax.annotation.concurrent.NotThreadSafe;

--- a/tools/immutables/src/main/resources/META-INF/extensions/org.immutables.inhibit-classpath
+++ b/tools/immutables/src/main/resources/META-INF/extensions/org.immutables.inhibit-classpath
@@ -1,0 +1,6 @@
+javax.annotation.Nullable
+javax.annotation.CheckReturnValue;
+javax.annotation.Nullable;
+javax.annotation.ParametersAreNonnullByDefault;
+javax.annotation.concurrent.Immutable;
+javax.annotation.concurrent.NotThreadSafe;

--- a/tools/server-admin/build.gradle.kts
+++ b/tools/server-admin/build.gradle.kts
@@ -83,9 +83,8 @@ dependencies {
   compileOnly(libs.microprofile.openapi)
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testFixturesApi(project(":nessie-quarkus-tests"))
   testFixturesApi(project(":nessie-versioned-tests"))

--- a/tools/storage/uri/build.gradle.kts
+++ b/tools/storage/uri/build.gradle.kts
@@ -18,6 +18,8 @@ plugins { id("nessie-conventions-server") }
 
 dependencies {
   implementation(libs.guava)
+  compileOnly(libs.jakarta.annotation.api)
+  compileOnly(libs.findbugs.jsr305)
 
   testImplementation(libs.assertj.core)
 }

--- a/versioned/spi/build.gradle.kts
+++ b/versioned/spi/build.gradle.kts
@@ -22,9 +22,8 @@ dependencies {
   implementation(project(":nessie-model"))
   api(project(path = ":nessie-protobuf-relocated", configuration = "shadow"))
   implementation("com.fasterxml.jackson.core:jackson-databind")
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
   compileOnly(libs.microprofile.openapi)
 
   compileOnly(platform(libs.opentelemetry.instrumentation.bom.alpha))
@@ -47,8 +46,8 @@ dependencies {
   testCompileOnly("com.fasterxml.jackson.core:jackson-annotations")
 
   testCompileOnly(libs.microprofile.openapi)
-  testCompileOnly(libs.immutables.value.annotations)
-  testAnnotationProcessor(libs.immutables.value.processor)
+  testCompileOnly(project(":nessie-immutables-std"))
+  testAnnotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
   testCompileOnly(libs.jakarta.ws.rs.api)
   testCompileOnly(libs.jakarta.validation.api)
   testCompileOnly(libs.jakarta.annotation.api)

--- a/versioned/storage/batching/build.gradle.kts
+++ b/versioned/storage/batching/build.gradle.kts
@@ -25,15 +25,15 @@ dependencies {
 
   compileOnly(libs.jakarta.validation.api)
   compileOnly(libs.jakarta.annotation.api)
+  compileOnly(libs.findbugs.jsr305)
 
   compileOnly(libs.errorprone.annotations)
   implementation(libs.guava)
 
   compileOnly(project(":nessie-versioned-storage-testextension"))
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testImplementation(project(":nessie-versioned-storage-common-tests"))
   testImplementation(project(":nessie-versioned-storage-inmemory"))

--- a/versioned/storage/bigtable-tests/build.gradle.kts
+++ b/versioned/storage/bigtable-tests/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
   implementation(project(":nessie-versioned-storage-common"))
   implementation(project(":nessie-versioned-storage-testextension"))
   implementation(project(":nessie-container-spec-helper"))
-  compileOnly(libs.immutables.value.annotations)
+  compileOnly(project(":nessie-immutables-std"))
 
   implementation(libs.slf4j.api)
 

--- a/versioned/storage/bigtable/build.gradle.kts
+++ b/versioned/storage/bigtable/build.gradle.kts
@@ -36,9 +36,8 @@ dependencies {
   implementation(libs.guava)
   implementation(libs.slf4j.api)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   intTestImplementation(project(":nessie-versioned-storage-bigtable-tests"))
   intTestImplementation(project(":nessie-versioned-storage-common-tests"))

--- a/versioned/storage/cache/build.gradle.kts
+++ b/versioned/storage/cache/build.gradle.kts
@@ -33,17 +33,15 @@ dependencies {
   implementation(libs.caffeine)
   implementation(libs.micrometer.core)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testImplementation(project(":nessie-versioned-storage-common-tests"))
   testImplementation(project(":nessie-versioned-storage-testextension"))
   testImplementation(project(":nessie-versioned-storage-inmemory"))
 
-  testCompileOnly(libs.immutables.builder)
-  testCompileOnly(libs.immutables.value.annotations)
-  testAnnotationProcessor(libs.immutables.value.processor)
+  testCompileOnly(project(":nessie-immutables-std"))
+  testAnnotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testImplementation(platform(libs.jackson.bom))
   testImplementation("com.fasterxml.jackson.core:jackson-annotations")

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
@@ -33,7 +33,6 @@ import io.micrometer.core.instrument.binder.cache.CaffeineStatsCounter;
 import jakarta.annotation.Nonnull;
 import java.lang.ref.SoftReference;
 import java.time.Duration;
-import org.checkerframework.checker.index.qual.NonNegative;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
@@ -87,7 +86,7 @@ class CaffeineCacheBackend implements CacheBackend {
                       CacheKeyValue key,
                       CacheKeyValue value,
                       long currentTimeNanos,
-                      @NonNegative long currentDurationNanos) {
+                      long currentDurationNanos) {
                     return expireAfterCreate(key, value, currentTimeNanos);
                   }
 
@@ -96,7 +95,7 @@ class CaffeineCacheBackend implements CacheBackend {
                       CacheKeyValue key,
                       CacheKeyValue value,
                       long currentTimeNanos,
-                      @NonNegative long currentDurationNanos) {
+                      long currentDurationNanos) {
                     return currentDurationNanos;
                   }
                 })

--- a/versioned/storage/cassandra-tests/build.gradle.kts
+++ b/versioned/storage/cassandra-tests/build.gradle.kts
@@ -28,9 +28,8 @@ dependencies {
 
   compileOnly(libs.jakarta.annotation.api)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   implementation(platform(libs.cassandra.driver.bom))
   implementation("org.apache.cassandra:java-driver-core")

--- a/versioned/storage/cassandra/build.gradle.kts
+++ b/versioned/storage/cassandra/build.gradle.kts
@@ -41,9 +41,8 @@ dependencies {
     exclude("com.github.spotbugs", "spotbugs-annotations")
   }
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   intTestImplementation(project(":nessie-versioned-storage-cassandra-tests"))
   intTestImplementation(project(":nessie-versioned-storage-common-tests"))

--- a/versioned/storage/cassandra2-tests/build.gradle.kts
+++ b/versioned/storage/cassandra2-tests/build.gradle.kts
@@ -28,9 +28,8 @@ dependencies {
 
   compileOnly(libs.jakarta.annotation.api)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(nessieProject("nessie-immutables-std"))
+  annotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   implementation(platform(libs.cassandra.driver.bom))
   implementation("org.apache.cassandra:java-driver-core")

--- a/versioned/storage/cassandra2/build.gradle.kts
+++ b/versioned/storage/cassandra2/build.gradle.kts
@@ -41,9 +41,8 @@ dependencies {
     exclude("com.github.spotbugs", "spotbugs-annotations")
   }
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(nessieProject("nessie-immutables-std"))
+  annotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   intTestImplementation(project(":nessie-versioned-storage-cassandra2-tests"))
   intTestImplementation(project(":nessie-versioned-storage-common-tests"))

--- a/versioned/storage/common-serialize/build.gradle.kts
+++ b/versioned/storage/common-serialize/build.gradle.kts
@@ -34,9 +34,8 @@ dependencies {
 
   testImplementation(project(":nessie-versioned-storage-common-tests"))
 
-  testCompileOnly(libs.immutables.builder)
-  testCompileOnly(libs.immutables.value.annotations)
-  testAnnotationProcessor(libs.immutables.value.processor)
+  testCompileOnly(project(":nessie-immutables-std"))
+  testAnnotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.bundles.junit.testing)

--- a/versioned/storage/common-tests/build.gradle.kts
+++ b/versioned/storage/common-tests/build.gradle.kts
@@ -38,9 +38,8 @@ dependencies {
 
   implementation(libs.logback.classic)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   compileOnly(libs.microprofile.openapi)
   implementation(platform(libs.jackson.bom))

--- a/versioned/storage/common/build.gradle.kts
+++ b/versioned/storage/common/build.gradle.kts
@@ -37,9 +37,8 @@ dependencies {
   implementation(project(path = ":nessie-protobuf-relocated", configuration = "shadow"))
   implementation(libs.slf4j.api)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   implementation(platform(libs.jackson.bom))
   implementation("com.fasterxml.jackson.core:jackson-databind")

--- a/versioned/storage/dynamodb-tests/build.gradle.kts
+++ b/versioned/storage/dynamodb-tests/build.gradle.kts
@@ -28,9 +28,8 @@ dependencies {
 
   compileOnly(libs.jakarta.annotation.api)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   implementation(platform(libs.awssdk.bom))
   implementation("software.amazon.awssdk:dynamodb")

--- a/versioned/storage/dynamodb/build.gradle.kts
+++ b/versioned/storage/dynamodb/build.gradle.kts
@@ -39,9 +39,8 @@ dependencies {
   implementation("software.amazon.awssdk:dynamodb")
   implementation("software.amazon.awssdk:apache-client")
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   intTestImplementation(project(":nessie-versioned-storage-dynamodb-tests"))
   intTestImplementation(project(":nessie-versioned-storage-common-tests"))

--- a/versioned/storage/dynamodb2-tests/build.gradle.kts
+++ b/versioned/storage/dynamodb2-tests/build.gradle.kts
@@ -28,9 +28,8 @@ dependencies {
 
   compileOnly(libs.jakarta.annotation.api)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(nessieProject("nessie-immutables-std"))
+  annotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   implementation(platform(libs.awssdk.bom))
   implementation("software.amazon.awssdk:dynamodb")

--- a/versioned/storage/dynamodb2/build.gradle.kts
+++ b/versioned/storage/dynamodb2/build.gradle.kts
@@ -39,9 +39,8 @@ dependencies {
   implementation("software.amazon.awssdk:dynamodb")
   implementation("software.amazon.awssdk:apache-client")
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(nessieProject("nessie-immutables-std"))
+  annotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   intTestImplementation(project(":nessie-versioned-storage-dynamodb2-tests"))
   intTestImplementation(project(":nessie-versioned-storage-common-tests"))

--- a/versioned/storage/inmemory-tests/build.gradle.kts
+++ b/versioned/storage/inmemory-tests/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
   implementation(project(":nessie-versioned-storage-common"))
   implementation(project(":nessie-versioned-storage-testextension"))
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 }

--- a/versioned/storage/inmemory/build.gradle.kts
+++ b/versioned/storage/inmemory/build.gradle.kts
@@ -30,9 +30,8 @@ dependencies {
   compileOnly(libs.errorprone.annotations)
   implementation(libs.guava)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testImplementation(project(":nessie-versioned-storage-inmemory-tests"))
   testImplementation(project(":nessie-versioned-storage-common-tests"))

--- a/versioned/storage/jdbc-tests/build.gradle.kts
+++ b/versioned/storage/jdbc-tests/build.gradle.kts
@@ -28,9 +28,8 @@ dependencies {
 
   compileOnly(libs.jakarta.annotation.api)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   implementation(libs.agroal.pool)
 

--- a/versioned/storage/jdbc/build.gradle.kts
+++ b/versioned/storage/jdbc/build.gradle.kts
@@ -36,9 +36,8 @@ dependencies {
   implementation(libs.agrona)
   implementation(libs.slf4j.api)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testFixturesApi(project(":nessie-versioned-storage-jdbc-tests"))
   testFixturesApi(project(":nessie-versioned-storage-common"))

--- a/versioned/storage/jdbc2-tests/build.gradle.kts
+++ b/versioned/storage/jdbc2-tests/build.gradle.kts
@@ -28,9 +28,8 @@ dependencies {
 
   compileOnly(libs.jakarta.annotation.api)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(nessieProject("nessie-immutables-std"))
+  annotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   implementation(libs.agroal.pool)
 

--- a/versioned/storage/jdbc2/build.gradle.kts
+++ b/versioned/storage/jdbc2/build.gradle.kts
@@ -36,9 +36,8 @@ dependencies {
   implementation(libs.agrona)
   implementation(libs.slf4j.api)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(nessieProject("nessie-immutables-std"))
+  annotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   testFixturesApi(project(":nessie-versioned-storage-jdbc2-tests"))
   testFixturesApi(project(":nessie-versioned-storage-common"))

--- a/versioned/storage/mongodb-tests/build.gradle.kts
+++ b/versioned/storage/mongodb-tests/build.gradle.kts
@@ -28,9 +28,8 @@ dependencies {
 
   implementation(libs.slf4j.api)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   implementation(libs.mongodb.driver.sync)
 

--- a/versioned/storage/mongodb/build.gradle.kts
+++ b/versioned/storage/mongodb/build.gradle.kts
@@ -37,9 +37,8 @@ dependencies {
 
   implementation(libs.mongodb.driver.sync)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   intTestImplementation(project(":nessie-versioned-storage-mongodb-tests"))
   intTestImplementation(project(":nessie-versioned-storage-common-tests"))

--- a/versioned/storage/mongodb2-tests/build.gradle.kts
+++ b/versioned/storage/mongodb2-tests/build.gradle.kts
@@ -28,9 +28,8 @@ dependencies {
 
   implementation(libs.slf4j.api)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(nessieProject("nessie-immutables-std"))
+  annotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   implementation(libs.mongodb.driver.sync)
 

--- a/versioned/storage/mongodb2/build.gradle.kts
+++ b/versioned/storage/mongodb2/build.gradle.kts
@@ -37,9 +37,8 @@ dependencies {
 
   implementation(libs.mongodb.driver.sync)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(nessieProject("nessie-immutables-std"))
+  annotationProcessor(nessieProject("nessie-immutables-std", configuration = "processor"))
 
   intTestImplementation(project(":nessie-versioned-storage-mongodb2-tests"))
   intTestImplementation(project(":nessie-versioned-storage-common-tests"))

--- a/versioned/storage/rocksdb/build.gradle.kts
+++ b/versioned/storage/rocksdb/build.gradle.kts
@@ -32,9 +32,8 @@ dependencies {
 
   implementation(libs.rocksdb.jni)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testImplementation(project(":nessie-versioned-storage-rocksdb-tests"))
   testImplementation(project(":nessie-versioned-storage-common-tests"))

--- a/versioned/storage/store/build.gradle.kts
+++ b/versioned/storage/store/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 
   compileOnly(libs.jakarta.validation.api)
   compileOnly(libs.jakarta.annotation.api)
+  compileOnly(libs.findbugs.jsr305)
 
   compileOnly(libs.microprofile.openapi)
   compileOnly(libs.errorprone.annotations)
@@ -40,9 +41,8 @@ dependencies {
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")
   implementation("com.fasterxml.jackson.core:jackson-databind")
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   compileOnly(platform(libs.jackson.bom))
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")

--- a/versioned/storage/testextension/build.gradle.kts
+++ b/versioned/storage/testextension/build.gradle.kts
@@ -32,9 +32,8 @@ dependencies {
   compileOnly(libs.errorprone.annotations)
   implementation(libs.guava)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   implementation(platform(libs.junit.bom))
   implementation(libs.bundles.junit.testing)

--- a/versioned/tests/build.gradle.kts
+++ b/versioned/tests/build.gradle.kts
@@ -23,8 +23,8 @@ dependencies {
   implementation(project(":nessie-versioned-spi"))
   implementation(libs.guava)
   implementation(libs.slf4j.api)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   compileOnly(platform(libs.jackson.bom))
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")

--- a/versioned/transfer/build.gradle.kts
+++ b/versioned/transfer/build.gradle.kts
@@ -48,9 +48,8 @@ dependencies {
   compileOnly(libs.jakarta.validation.api)
   compileOnly(libs.jakarta.annotation.api)
 
-  compileOnly(libs.immutables.builder)
-  compileOnly(libs.immutables.value.annotations)
-  annotationProcessor(libs.immutables.value.processor)
+  compileOnly(project(":nessie-immutables-std"))
+  annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
   testFixturesImplementation(platform(libs.jackson.bom))
   testFixturesImplementation("com.fasterxml.jackson.core:jackson-databind")


### PR DESCRIPTION
Guava 33.4.5 removes the (for us transitive) dependency to "jsr305", causing quite some build errors.

This change does a couple of (rather boring) things:
1. Introduce `nessie-immutables-std` as a replacement for the "raw" usage of immutables, but preventing the generation of javax. annotations (jakarta. instead)
3. Remove usage of checkerframework annotation (also no longer transitively available)
2. Let builds use `nessie-immutables-std` instead

Those 3 changes are distinct commits in this PR.