### PR TITLE
Make S3 signing URL validity configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ as necessary. Empty sections will not end in the release notes.
 
 ### New Features
 
+- Catalog/S3/request-signing: Add a per-S3-bucket config option `url-signing-expire` to override the default
+  3-hour lifetime of S3-URL-signing URLs.
+
 ### Changes
 
 ### Deprecations

--- a/catalog/files/api/src/main/java/org/projectnessie/catalog/files/api/ObjectIO.java
+++ b/catalog/files/api/src/main/java/org/projectnessie/catalog/files/api/ObjectIO.java
@@ -18,11 +18,12 @@ package org.projectnessie.catalog.files.api;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
 import org.projectnessie.storage.uri.StorageUri;
 
 public interface ObjectIO {
@@ -55,7 +56,7 @@ public interface ObjectIO {
   void configureIcebergTable(
       StorageLocations storageLocations,
       BiConsumer<String, String> config,
-      BooleanSupplier enableRequestSigning,
+      Predicate<Duration> enableRequestSigning,
       boolean canDoCredentialsVending);
 
   void trinoSampleConfig(

--- a/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/S3BucketOptions.java
+++ b/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/S3BucketOptions.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.net.URI;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -29,6 +31,8 @@ public interface S3BucketOptions extends BucketOptions {
 
   /** Default value for {@link #authType()}, being {@link S3AuthType#STATIC}. */
   S3AuthType DEFAULT_SERVER_AUTH_TYPE = S3AuthType.STATIC;
+
+  Duration DEFAULT_SIGN_URL_EXPIRE = Duration.of(3, ChronoUnit.HOURS);
 
   /**
    * Endpoint URI, required for private (non-AWS) clouds, specified either per bucket or in the
@@ -111,8 +115,25 @@ public interface S3BucketOptions extends BucketOptions {
    */
   Optional<URI> accessKey();
 
-  /** Optional parameter to disable S3 request signing. Default is to enable S3 request signing. */
+  /**
+   * Optional parameter to disable S3 request signing. Default is to enable S3 request signing.
+   *
+   * <p>See {@code url-signing-expire}.
+   */
   Optional<Boolean> requestSigningEnabled();
+
+  /**
+   * Defines the validity of the signing endpoint returned to clients, defaults to 3 hours.
+   *
+   * <p>See {@code request-signing-enabled}.
+   */
+  Optional<Duration> urlSigningExpire();
+
+  @Value.NonAttribute
+  @JsonIgnore
+  default Duration effectiveUrlSigningExpire() {
+    return urlSigningExpire().orElse(DEFAULT_SIGN_URL_EXPIRE);
+  }
 
   /**
    * The <a href="https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html">Security Token

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/DelegatingObjectIO.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/DelegatingObjectIO.java
@@ -18,10 +18,11 @@ package org.projectnessie.catalog.files;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
 import org.projectnessie.catalog.files.api.ObjectIO;
 import org.projectnessie.catalog.files.api.StorageLocations;
 import org.projectnessie.storage.uri.StorageUri;
@@ -66,7 +67,7 @@ public abstract class DelegatingObjectIO implements ObjectIO {
   public void configureIcebergTable(
       StorageLocations storageLocations,
       BiConsumer<String, String> config,
-      BooleanSupplier enableRequestSigning,
+      Predicate<Duration> enableRequestSigning,
       boolean canDoCredentialsVending) {
     resolve(storageLocations.warehouseLocation())
         .configureIcebergTable(

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsObjectIO.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsObjectIO.java
@@ -27,12 +27,13 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.projectnessie.catalog.files.api.ObjectIO;
@@ -132,7 +133,7 @@ public class AdlsObjectIO implements ObjectIO {
   public void configureIcebergTable(
       StorageLocations storageLocations,
       BiConsumer<String, String> config,
-      BooleanSupplier enableRequestSigning,
+      Predicate<Duration> enableRequestSigning,
       boolean canDoCredentialsVending) {
     if (Stream.concat(
             storageLocations.writeableLocations().stream(),

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsObjectIO.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsObjectIO.java
@@ -27,13 +27,14 @@ import com.google.cloud.storage.Storage.BlobWriteOption;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.channels.Channels;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.projectnessie.catalog.files.api.ObjectIO;
@@ -182,7 +183,7 @@ public class GcsObjectIO implements ObjectIO {
   public void configureIcebergTable(
       StorageLocations storageLocations,
       BiConsumer<String, String> config,
-      BooleanSupplier enableRequestSigning,
+      Predicate<Duration> enableRequestSigning,
       boolean canDoCredentialsVending) {
     if (Stream.concat(
             storageLocations.writeableLocations().stream(),

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/local/LocalObjectIO.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/local/LocalObjectIO.java
@@ -23,11 +23,12 @@ import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
 import org.projectnessie.catalog.files.api.ObjectIO;
 import org.projectnessie.catalog.files.api.StorageLocations;
 import org.projectnessie.storage.uri.StorageUri;
@@ -89,7 +90,7 @@ public class LocalObjectIO implements ObjectIO {
   public void configureIcebergTable(
       StorageLocations storageLocations,
       BiConsumer<String, String> config,
-      BooleanSupplier enableRequestSigning,
+      Predicate<Duration> enableRequestSigning,
       boolean canDoCredentialsVending) {}
 
   @Override

--- a/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/TestObjectIO.java
+++ b/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/TestObjectIO.java
@@ -126,11 +126,11 @@ class TestObjectIO {
         StorageLocations.storageLocations(whUri, List.of(whUri), List.of());
     Map<String, String> config = new HashMap<>();
 
-    objectIO.configureIcebergTable(storageLocations, config::put, () -> false, false);
+    objectIO.configureIcebergTable(storageLocations, config::put, x -> false, false);
     soft.assertThat(config).containsEntry(propName, expectedValue);
 
     config.clear();
-    objectIO.configureIcebergTable(storageLocations, config::put, () -> true, true);
+    objectIO.configureIcebergTable(storageLocations, config::put, x -> true, true);
     soft.assertThat(config).containsEntry(propName, expectedValue);
   }
 }


### PR DESCRIPTION
S3 signing URLs communicated to Iceberg REST clients currently have a hard coded validity of 3 hours. This can be too long for certain use cases. Since there's no way to instruct Iceberg clients to refresh the signing-URL, this change introduces a configuration (for all or just some buckets) to change that duration.