### PR TITLE
Introduce a hard capacity limit for the objects cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ as necessary. Empty sections will not end in the release notes.
 
 * Introduces a hard objects-cache capacity limit to ensure that the cache does never consume more than
   the configured cache-capacity plus a configurable "overshoot" (defaults to 10%). New cache entries are
-  admitted as long as the current cache size is less than the "cache-capacity + overshoot". The
-  "overshoot" is necessary to eventually trigger the cache eviction.
+  admitted as long as the current cache size is less than the "cache-capacity + overshoot".
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ as necessary. Empty sections will not end in the release notes.
 
 ### New Features
 
+* Introduces a hard objects-cache capacity limit to ensure that the cache does never consume more than
+  the configured cache-capacity plus a configurable "overshoot" (defaults to 10%). New cache entries are
+  admitted as long as the current cache size is less than the "cache-capacity + overshoot". The
+  "overshoot" is necessary to eventually trigger the cache eviction.
+
 ### Changes
 
 * Nessie's REST API endpoints now accept "truncated timestamps" in relative-commit-specs, aka without the

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3IamPolicies.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3IamPolicies.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Scheduler;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -139,6 +140,7 @@ final class S3IamPolicies {
         Caffeine.newBuilder()
             .maximumSize(2000)
             .expireAfterAccess(Duration.of(1, ChronoUnit.HOURS))
+            .scheduler(Scheduler.systemScheduler())
             .build(ParsedIamStatements::parseStatement);
 
     private static ObjectNode parseStatement(String stmt) {

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/PersistProvider.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/PersistProvider.java
@@ -15,8 +15,10 @@
  */
 package org.projectnessie.quarkus.providers.storage;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 import static org.projectnessie.quarkus.config.QuarkusStoreConfig.DEFAULT_CONFIG_CACHE_ENABLE_SOFT_REFERENCES;
+import static org.projectnessie.quarkus.config.QuarkusStoreConfig.DEFAULT_CONFIG_CAPACITY_OVERSHOOT;
 import static org.projectnessie.versioned.storage.common.logic.Logics.repositoryLogic;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -150,9 +152,13 @@ public class PersistProvider {
               .cacheEnableSoftReferences()
               .orElse(DEFAULT_CONFIG_CACHE_ENABLE_SOFT_REFERENCES);
 
+      var cacheCapacityOvershoot =
+          storeConfig.cacheCapacityOvershoot().orElse(DEFAULT_CONFIG_CAPACITY_OVERSHOOT);
+      checkArgument(cacheCapacityOvershoot > 0d && cacheCapacityOvershoot <= 1d);
       CacheConfig.Builder cacheConfig =
           CacheConfig.builder()
               .capacityMb(effectiveCacheSizeMB)
+              .cacheCapacityOvershoot(cacheCapacityOvershoot)
               .enableSoftReferences(enableSoftReferences);
       if (meterRegistry.isResolvable()) {
         cacheConfig.meterRegistry(meterRegistry.get());

--- a/servers/quarkus-config/src/main/java/org/projectnessie/quarkus/config/QuarkusStoreConfig.java
+++ b/servers/quarkus-config/src/main/java/org/projectnessie/quarkus/config/QuarkusStoreConfig.java
@@ -115,6 +115,7 @@ public interface QuarkusStoreConfig extends StoreConfig {
   String CONFIG_CACHE_CAPACITY_MB = "cache-capacity-mb";
 
   boolean DEFAULT_CONFIG_CACHE_ENABLE_SOFT_REFERENCES = true;
+  double DEFAULT_CONFIG_CAPACITY_OVERSHOOT = 0.1d;
 
   /**
    * Fixed amount of heap used to cache objects, set to 0 to disable the cache entirely. Must not be
@@ -160,6 +161,22 @@ public interface QuarkusStoreConfig extends StoreConfig {
    */
   @WithName(CONFIG_CACHE_CAPACITY_FRACTION_ADJUST_MB)
   OptionalInt cacheCapacityFractionAdjustMB();
+
+  String CONFIG_CACHE_CAPACITY_OVERSHOOT = "cache-capacity-overshoot";
+
+  /**
+   * Admitted cache-capacity-overshoot fraction, defaults to {@code 0.1} (10 %).
+   *
+   * <p>New elements are admitted to be added to the cache, if the cache's size is less than {@code
+   * cache-capacity * (1 + cache-capacity-overshoot}.
+   *
+   * <p>Cache eviction happens asynchronously. Situations when eviction cannot keep up with the
+   * amount of data added could lead to out-of-memory situations.
+   *
+   * <p>Value must be greater than 0, if present.
+   */
+  @WithName(CONFIG_CACHE_CAPACITY_OVERSHOOT)
+  OptionalDouble cacheCapacityOvershoot();
 
   @WithName(CONFIG_REFERENCE_CACHE_TTL)
   @Override

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CacheConfig.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CacheConfig.java
@@ -21,6 +21,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.Executor;
 import java.util.function.LongSupplier;
 import org.immutables.value.Value;
 
@@ -41,9 +42,21 @@ public interface CacheConfig {
 
   Optional<Boolean> enableSoftReferences();
 
+  double cacheCapacityOvershoot();
+
   @Value.Default
   default LongSupplier clockNanos() {
     return System::nanoTime;
+  }
+
+  /**
+   * Executor used by Caffeine, see {@link
+   * com.github.benmanes.caffeine.cache.Caffeine#executor(Executor)}, only present for targeted
+   * tests.
+   */
+  @Value.Default
+  default Executor executor() {
+    return Runnable::run;
   }
 
   static Builder builder() {
@@ -80,6 +93,12 @@ public interface CacheConfig {
 
     @CanIgnoreReturnValue
     Builder enableSoftReferences(boolean enableSoftReferences);
+
+    @CanIgnoreReturnValue
+    Builder cacheCapacityOvershoot(double cacheCapacityOvershoot);
+
+    @CanIgnoreReturnValue
+    Builder executor(Executor executor);
 
     CacheConfig build();
   }

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
@@ -56,8 +56,8 @@ class CaffeineCacheBackend implements CacheBackend {
   static final long ONE_MB = 1024L * 1024L;
   public static final String METER_CACHE_CAPACITY_MB = "cache_capacity_mb";
   public static final String METER_CACHE_CAPACITY = "cache.capacity";
+  public static final String METER_CACHE_ADMIT_CAPACITY = "cache.capacity.admitted";
   public static final String METER_CACHE_WEIGHT = "cache.weight";
-  public static final String METER_CACHE_REJECTIONS = "cache.rejections";
   public static final String METER_CACHE_REJECTED_WEIGHT = "cache.rejected-weight";
 
   private final CacheConfig config;
@@ -145,13 +145,13 @@ class CaffeineCacheBackend implements CacheBackend {
                       .tag("cache", CACHE_NAME)
                       .baseUnit(BaseUnits.BYTES)
                       .register(reg);
-                  Gauge.builder(METER_CACHE_WEIGHT, "", x -> (double) currentWeightReported())
-                      .description("Current reported weight of the objects cache in bytes.")
+                  Gauge.builder(METER_CACHE_ADMIT_CAPACITY, "", x -> admitWeight)
+                      .description("Admitted capacity of the objects cache in bytes.")
                       .tag("cache", CACHE_NAME)
                       .baseUnit(BaseUnits.BYTES)
                       .register(reg);
-                  Gauge.builder(METER_CACHE_REJECTIONS, "", x -> rejections.get())
-                      .description("Number of cache-puts that have been rejected.")
+                  Gauge.builder(METER_CACHE_WEIGHT, "", x -> (double) currentWeightReported())
+                      .description("Current reported weight of the objects cache in bytes.")
                       .tag("cache", CACHE_NAME)
                       .baseUnit(BaseUnits.BYTES)
                       .register(reg);

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
@@ -16,7 +16,6 @@
 package org.projectnessie.versioned.storage.cache;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.projectnessie.versioned.storage.common.persist.ObjType.CACHE_UNLIMITED;
@@ -28,11 +27,18 @@ import static org.projectnessie.versioned.storage.serialize.ProtoSerialization.s
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Expiry;
-import io.micrometer.core.instrument.Tag;
+import com.github.benmanes.caffeine.cache.Scheduler;
+import com.google.common.annotations.VisibleForTesting;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.binder.cache.CaffeineStatsCounter;
 import jakarta.annotation.Nonnull;
 import java.lang.ref.SoftReference;
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.IntConsumer;
+import java.util.function.LongSupplier;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
@@ -47,12 +53,23 @@ class CaffeineCacheBackend implements CacheBackend {
   private static final CacheKeyValue NON_EXISTING_SENTINEL =
       new CacheKeyValue("x", ObjId.EMPTY_OBJ_ID, 0L, new byte[0], null, false);
 
+  static final long ONE_MB = 1024L * 1024L;
+  public static final String METER_CACHE_CAPACITY_MB = "cache_capacity_mb";
+  public static final String METER_CACHE_CAPACITY = "cache.capacity";
+  public static final String METER_CACHE_WEIGHT = "cache.weight";
+  public static final String METER_CACHE_REJECTIONS = "cache.rejections";
+  public static final String METER_CACHE_REJECTED_WEIGHT = "cache.rejected-weight";
+
   private final CacheConfig config;
   final Cache<CacheKeyValue, CacheKeyValue> cache;
 
   private final long refCacheTtlNanos;
   private final long refCacheNegativeTtlNanos;
   private final boolean enableSoftReferences;
+  private final long admitWeight;
+  private final AtomicLong rejections = new AtomicLong();
+  private final IntConsumer rejectionsWeight;
+  private final LongSupplier weightSupplier;
 
   CaffeineCacheBackend(CacheConfig config) {
     this.config = config;
@@ -61,15 +78,23 @@ class CaffeineCacheBackend implements CacheBackend {
     refCacheNegativeTtlNanos = config.referenceNegativeTtl().orElse(Duration.ZERO).toNanos();
     enableSoftReferences = config.enableSoftReferences().orElse(false);
 
+    var maxWeight = config.capacityMb() * ONE_MB;
+    admitWeight = maxWeight + (long) (maxWeight * config.cacheCapacityOvershoot());
+
     Caffeine<CacheKeyValue, CacheKeyValue> cacheBuilder =
         Caffeine.newBuilder()
-            .maximumWeight(config.capacityMb() * 1024L * 1024L)
+            .executor(config.executor())
+            .scheduler(Scheduler.systemScheduler())
+            .ticker(config.clockNanos()::getAsLong)
+            .maximumWeight(maxWeight)
             .weigher(this::weigher)
             .expireAfter(
-                new Expiry<CacheKeyValue, CacheKeyValue>() {
+                new Expiry<>() {
                   @Override
                   public long expireAfterCreate(
-                      CacheKeyValue key, CacheKeyValue value, long currentTimeNanos) {
+                      @Nonnull CacheKeyValue key,
+                      @Nonnull CacheKeyValue value,
+                      long currentTimeNanos) {
                     long expire = key.expiresAtNanosEpoch;
                     if (expire == CACHE_UNLIMITED) {
                       return Long.MAX_VALUE;
@@ -83,8 +108,8 @@ class CaffeineCacheBackend implements CacheBackend {
 
                   @Override
                   public long expireAfterUpdate(
-                      CacheKeyValue key,
-                      CacheKeyValue value,
+                      @Nonnull CacheKeyValue key,
+                      @Nonnull CacheKeyValue value,
                       long currentTimeNanos,
                       long currentDurationNanos) {
                     return expireAfterCreate(key, value, currentTimeNanos);
@@ -92,27 +117,73 @@ class CaffeineCacheBackend implements CacheBackend {
 
                   @Override
                   public long expireAfterRead(
-                      CacheKeyValue key,
-                      CacheKeyValue value,
+                      @Nonnull CacheKeyValue key,
+                      @Nonnull CacheKeyValue value,
                       long currentTimeNanos,
                       long currentDurationNanos) {
                     return currentDurationNanos;
                   }
+                });
+    rejectionsWeight =
+        config
+            .meterRegistry()
+            .map(
+                reg -> {
+                  cacheBuilder.recordStats(() -> new CaffeineStatsCounter(reg, CACHE_NAME));
+                  // legacy gauge (using mb)
+                  Gauge.builder(METER_CACHE_CAPACITY_MB, "", x -> config.capacityMb())
+                      .description(
+                          "Total capacity of the objects cache in megabytes (x1024), prefer the new "
+                              + METER_CACHE_CAPACITY
+                              + " metric.")
+                      .tag("cache", CACHE_NAME)
+                      .register(reg);
+
+                  // new gauges (providing base unit)
+                  Gauge.builder(METER_CACHE_CAPACITY, "", x -> maxWeight)
+                      .description("Total capacity of the objects cache in bytes.")
+                      .tag("cache", CACHE_NAME)
+                      .baseUnit(BaseUnits.BYTES)
+                      .register(reg);
+                  Gauge.builder(METER_CACHE_WEIGHT, "", x -> (double) currentWeightReported())
+                      .description("Current reported weight of the objects cache in bytes.")
+                      .tag("cache", CACHE_NAME)
+                      .baseUnit(BaseUnits.BYTES)
+                      .register(reg);
+                  Gauge.builder(METER_CACHE_REJECTIONS, "", x -> rejections.get())
+                      .description("Number of cache-puts that have been rejected.")
+                      .tag("cache", CACHE_NAME)
+                      .baseUnit(BaseUnits.BYTES)
+                      .register(reg);
+                  var rejectedWeightSummary =
+                      DistributionSummary.builder(METER_CACHE_REJECTED_WEIGHT)
+                          .description("Weight of of rejected cache-puts in bytes.")
+                          .tag("cache", CACHE_NAME)
+                          .baseUnit(BaseUnits.BYTES)
+                          .register(reg);
+                  return (IntConsumer) rejectedWeightSummary::record;
                 })
-            .ticker(config.clockNanos()::getAsLong);
-    config
-        .meterRegistry()
-        .ifPresent(
-            meterRegistry -> {
-              cacheBuilder.recordStats(() -> new CaffeineStatsCounter(meterRegistry, CACHE_NAME));
-              meterRegistry.gauge(
-                  "cache_capacity_mb",
-                  singletonList(Tag.of("cache", CACHE_NAME)),
-                  "",
-                  x -> config.capacityMb());
-            });
+            .orElse(x -> {});
 
     this.cache = cacheBuilder.build();
+
+    var eviction = cache.policy().eviction().orElseThrow();
+    weightSupplier = () -> eviction.weightedSize().orElse(0L);
+  }
+
+  @VisibleForTesting
+  long currentWeightReported() {
+    return weightSupplier.getAsLong();
+  }
+
+  @VisibleForTesting
+  long rejections() {
+    return rejections.get();
+  }
+
+  @VisibleForTesting
+  long admitWeight() {
+    return admitWeight;
   }
 
   @Override
@@ -121,7 +192,7 @@ class CaffeineCacheBackend implements CacheBackend {
     return new CachingPersistImpl(persist, cache);
   }
 
-  private int weigher(CacheKeyValue key, CacheKeyValue value) {
+  private int weigher(CacheKeyValue key, CacheKeyValue ignoredValue) {
     int size = key.heapSize();
     size += CAFFEINE_OBJ_OVERHEAD;
     return size;
@@ -145,6 +216,17 @@ class CaffeineCacheBackend implements CacheBackend {
     putLocal(repositoryId, obj);
   }
 
+  @VisibleForTesting
+  void cachePut(CacheKeyValue key, CacheKeyValue value) {
+    var w = weigher(key, value);
+    if (weightSupplier.getAsLong() + w < admitWeight) {
+      cache.put(key, value);
+    } else {
+      rejections.incrementAndGet();
+      rejectionsWeight.accept(w);
+    }
+  }
+
   @Override
   public void putLocal(@Nonnull String repositoryId, @Nonnull Obj obj) {
     long expiresAt =
@@ -162,7 +244,7 @@ class CaffeineCacheBackend implements CacheBackend {
       CacheKeyValue keyValue =
           cacheKeyValue(
               repositoryId, obj.id(), expiresAtNanos, serialized, obj, enableSoftReferences);
-      cache.put(keyValue, keyValue);
+      cachePut(keyValue, keyValue);
     } catch (ObjTooLargeException e) {
       // this should never happen
       throw new RuntimeException(e);
@@ -183,7 +265,7 @@ class CaffeineCacheBackend implements CacheBackend {
         expiresAt == CACHE_UNLIMITED ? CACHE_UNLIMITED : MICROSECONDS.toNanos(expiresAt);
     CacheKeyValue keyValue = cacheKeyValue(repositoryId, id, expiresAtNanos, enableSoftReferences);
 
-    cache.put(keyValue, NON_EXISTING_SENTINEL);
+    cachePut(keyValue, NON_EXISTING_SENTINEL);
   }
 
   @Override
@@ -230,7 +312,7 @@ class CaffeineCacheBackend implements CacheBackend {
             serializeReference(r),
             r,
             enableSoftReferences);
-    cache.put(keyValue, keyValue);
+    cachePut(keyValue, keyValue);
   }
 
   @Override
@@ -245,7 +327,7 @@ class CaffeineCacheBackend implements CacheBackend {
             id,
             config.clockNanos().getAsLong() + refCacheNegativeTtlNanos,
             enableSoftReferences);
-    cache.put(key, NON_EXISTING_SENTINEL);
+    cachePut(key, NON_EXISTING_SENTINEL);
   }
 
   @Override

--- a/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCacheConfig.java
+++ b/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCacheConfig.java
@@ -73,6 +73,6 @@ public class TestCacheConfig {
   }
 
   private static CacheConfig.Builder defaultBuilder() {
-    return CacheConfig.builder().capacityMb(1);
+    return CacheConfig.builder().capacityMb(1).cacheCapacityOvershoot(0.1d);
   }
 }

--- a/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCacheExpiration.java
+++ b/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCacheExpiration.java
@@ -45,6 +45,7 @@ public class TestCacheExpiration {
                 .capacityMb(8)
                 .clockNanos(() -> MICROSECONDS.toNanos(currentTime.get()))
                 .enableSoftReferences(enableSoftReferences)
+                .cacheCapacityOvershoot(0.1d)
                 .build());
 
     CacheTestObjTypeBundle.DefaultCachingObj defaultCachingObj =

--- a/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCacheOvershoot.java
+++ b/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCacheOvershoot.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2025 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.cache;
+
+import static java.util.concurrent.CompletableFuture.delayedExecutor;
+import static org.projectnessie.versioned.storage.cache.CaffeineCacheBackend.METER_CACHE_REJECTED_WEIGHT;
+import static org.projectnessie.versioned.storage.cache.CaffeineCacheBackend.METER_CACHE_REJECTIONS;
+import static org.projectnessie.versioned.storage.cache.CaffeineCacheBackend.METER_CACHE_WEIGHT;
+import static org.projectnessie.versioned.storage.common.persist.ObjId.randomObjId;
+
+import com.google.common.base.Strings;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.versioned.storage.commontests.objtypes.SimpleTestObj;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestCacheOvershoot {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @RepeatedTest(3) // consider the first repetition as a warmup (C1/C2)
+  public void testCacheOvershootDirectEviction() throws Exception {
+    testCacheOvershoot(Runnable::run);
+  }
+
+  @RepeatedTest(3) // consider the first repetition as a warmup (C1/C2)
+  public void testCacheOvershootDelayedEviction() throws Exception {
+    // Production uses Runnable::run, but that lets this test sometimes run way too
+    // long, so we introduce some delay to simulate the case that eviction cannot keep up.
+    testCacheOvershoot(t -> delayedExecutor(2, TimeUnit.MILLISECONDS).execute(t));
+  }
+
+  private void testCacheOvershoot(Executor evictionExecutor) throws Exception {
+    var meterRegistry = new SimpleMeterRegistry();
+
+    var config =
+        CacheConfig.builder()
+            .capacityMb(4)
+            .cacheCapacityOvershoot(0.1d)
+            .executor(evictionExecutor)
+            .meterRegistry(meterRegistry)
+            .build();
+    var cache = new CaffeineCacheBackend(config);
+
+    var metersByName =
+        meterRegistry.getMeters().stream()
+            .collect(Collectors.toMap(m -> m.getId().getName(), Function.identity(), (a, b) -> a));
+    soft.assertThat(metersByName)
+        .containsKeys(METER_CACHE_WEIGHT, METER_CACHE_REJECTIONS, METER_CACHE_REJECTED_WEIGHT);
+    var meterWeightReported = (Gauge) metersByName.get(METER_CACHE_WEIGHT);
+    var meterRejections = (Gauge) metersByName.get(METER_CACHE_REJECTIONS);
+    var meterRejectedWeight = (DistributionSummary) metersByName.get(METER_CACHE_REJECTED_WEIGHT);
+
+    var maxWeight = config.capacityMb() * 1024L * 1024L;
+    var admitWeight = cache.admitWeight();
+
+    var str = Strings.repeat("a", 4096);
+
+    var numThreads = 8;
+
+    for (int i = 0; i < maxWeight / 5000; i++) {
+      cache.put("repo", SimpleTestObj.builder().id(randomObjId()).text(str).build());
+    }
+
+    soft.assertThat(cache.currentWeightReported()).isLessThanOrEqualTo(admitWeight);
+    soft.assertThat(cache.rejections()).isEqualTo(0L);
+    soft.assertThat(meterWeightReported.value()).isGreaterThan(0d);
+    soft.assertThat(meterRejections.value()).isEqualTo((double) cache.rejections());
+
+    var executor = Executors.newFixedThreadPool(numThreads);
+    var seenOvershoot = false;
+    var stop = new AtomicBoolean();
+    try {
+      for (int i = 0; i < numThreads; i++) {
+        executor.execute(
+            () -> {
+              while (!stop.get()) {
+                cache.put("repo", SimpleTestObj.builder().id(randomObjId()).text(str).build());
+                Thread.yield();
+              }
+            });
+      }
+
+      for (int i = 0; i < 50 && !seenOvershoot; i++) {
+        Thread.sleep(10);
+        var w = cache.currentWeightReported();
+        if (w > maxWeight) {
+          seenOvershoot = true;
+        }
+      }
+    } finally {
+      stop.set(true);
+
+      executor.shutdown();
+      executor.awaitTermination(10, TimeUnit.MINUTES);
+    }
+
+    soft.assertThat(cache.currentWeightReported()).isLessThanOrEqualTo(admitWeight);
+    soft.assertThat(cache.rejections()).isEqualTo(0L);
+    // comparing the tracked & reported weights would be flaky, as eviction can still happen
+    soft.assertThat(meterRejections.value()).isEqualTo(0d);
+    soft.assertThat(meterRejectedWeight.totalAmount()).isEqualTo(0d);
+    soft.assertThat(seenOvershoot).isFalse();
+  }
+}

--- a/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestNegativeCaching.java
+++ b/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestNegativeCaching.java
@@ -52,6 +52,7 @@ public class TestNegativeCaching {
             CacheConfig.builder()
                 .capacityMb(16)
                 .enableSoftReferences(enableSoftReferences)
+                .cacheCapacityOvershoot(0.1d)
                 .build());
     Persist cachedPersist = spy(cacheBackend.wrap(backing));
 
@@ -87,6 +88,7 @@ public class TestNegativeCaching {
             CacheConfig.builder()
                 .capacityMb(16)
                 .enableSoftReferences(enableSoftReferences)
+                .cacheCapacityOvershoot(0.1d)
                 .build());
     Persist cachedPersist = spy(cacheBackend.wrap(backing));
 
@@ -178,6 +180,7 @@ public class TestNegativeCaching {
             CacheConfig.builder()
                 .capacityMb(16)
                 .enableSoftReferences(enableSoftReferences)
+                .cacheCapacityOvershoot(0.1d)
                 .build());
     Persist cachedPersist = spy(cacheBackend.wrap(backing));
 
@@ -210,6 +213,7 @@ public class TestNegativeCaching {
             CacheConfig.builder()
                 .capacityMb(16)
                 .enableSoftReferences(enableSoftReferences)
+                .cacheCapacityOvershoot(0.1d)
                 .build());
     Persist cachedPersist = spy(cacheBackend.wrap(backing));
 

--- a/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestReferenceCaching.java
+++ b/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestReferenceCaching.java
@@ -48,6 +48,7 @@ public class TestReferenceCaching {
                 .clockNanos(clockNanos)
                 .referenceTtl(Duration.ofMinutes(1))
                 .referenceNegativeTtl(Duration.ofSeconds(1))
+                .cacheCapacityOvershoot(0.1d)
                 .build())
         .wrap(persist);
   }

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestVersionStoreReferenceCaching.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestVersionStoreReferenceCaching.java
@@ -53,6 +53,7 @@ public class TestVersionStoreReferenceCaching {
                 .clockNanos(clockNanos)
                 .referenceTtl(Duration.ofMinutes(1))
                 .referenceNegativeTtl(Duration.ofSeconds(1))
+                .cacheCapacityOvershoot(0.1d)
                 .build())
         .wrap(persist);
   }

--- a/versioned/storage/testextension/src/main/java/org/projectnessie/versioned/storage/testextension/ClassPersistInstances.java
+++ b/versioned/storage/testextension/src/main/java/org/projectnessie/versioned/storage/testextension/ClassPersistInstances.java
@@ -61,6 +61,7 @@ final class ClassPersistInstances {
                     .referenceTtl(Duration.ofMinutes(1))
                     .referenceNegativeTtl(Duration.ofMinutes(1))
                     .enableSoftReferences(nessiePersistCache.enableSoftReferences())
+                    .cacheCapacityOvershoot(0.1d)
                     .build())
             : null;
 


### PR DESCRIPTION
Implements a hard limit to prevent the cache's retained heap size to grow "infinitely" in case cache eviction cannot keep up with newly added entries. The default is to allow 10% on top of the cache-capacity.

The "overshoot" is necessary to eventually trigger the cache eviction.

Also adds the recommended `Scheduler.systemScheduler`