### PR TITLE
Maven publication: Produce correct `<scm><tag>` in `pom.xml`

### DIFF
--- a/build-logic/src/main/kotlin/PublishingHelperPlugin.kt
+++ b/build-logic/src/main/kotlin/PublishingHelperPlugin.kt
@@ -145,7 +145,10 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
                           "scm:git:https://github.com/projectnessie/$nessieRepoName"
                         )
                         url.set("https://github.com/projectnessie/$nessieRepoName/tree/main")
-                        tag.set("main")
+                        val version = project.version.toString()
+                        if (!version.endsWith("-SNAPSHOT")) {
+                          tag.set("nessie-$version")
+                        }
                       }
                       issueManagement {
                         system.set("Github")


### PR DESCRIPTION
`project.scm.tag` in a Maven pom is intended to refer to the SCM (Git) tag. We currently publish `main`, which is incorrect.

This change omits the SCM tag for snapshot builds, but emits the Git tag for releases.