### PR TITLE
Cache-config: fix default for "soft references" to `false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Changes
 
+* Change default of `nessie.version.store.persist.cache-enable-soft-references` to `false`
+
 ### Deprecations
 
 ### Fixes

--- a/servers/quarkus-config/src/main/java/org/projectnessie/quarkus/config/QuarkusStoreConfig.java
+++ b/servers/quarkus-config/src/main/java/org/projectnessie/quarkus/config/QuarkusStoreConfig.java
@@ -114,9 +114,6 @@ public interface QuarkusStoreConfig extends StoreConfig {
 
   String CONFIG_CACHE_CAPACITY_MB = "cache-capacity-mb";
 
-  boolean DEFAULT_CONFIG_CACHE_ENABLE_SOFT_REFERENCES = true;
-  double DEFAULT_CONFIG_CAPACITY_OVERSHOOT = 0.1d;
-
   /**
    * Fixed amount of heap used to cache objects, set to 0 to disable the cache entirely. Must not be
    * used with fractional cache sizing. See description for {@code cache-capacity-fraction-of-heap}
@@ -141,6 +138,7 @@ public interface QuarkusStoreConfig extends StoreConfig {
 
   /** When using fractional cache sizing, this amount in MB is the minimum cache size. */
   @WithName(CONFIG_CACHE_CAPACITY_FRACTION_MIN_SIZE_MB)
+  @WithDefault("" + DEFAULT_CACHE_CAPACITY_FRACTION_MIN_SIZE_MB)
   OptionalInt cacheCapacityFractionMinSizeMb();
 
   String CONFIG_CACHE_CAPACITY_FRACTION_OF_HEAP = "cache-capacity-fraction-of-heap";
@@ -151,6 +149,7 @@ public interface QuarkusStoreConfig extends StoreConfig {
    * of {@code .6} (60%) is assumed.
    */
   @WithName(CONFIG_CACHE_CAPACITY_FRACTION_OF_HEAP)
+  @WithDefault("" + DEFAULT_CACHE_CAPACITY_FRACTION_OF_HEAP)
   OptionalDouble cacheCapacityFractionOfHeap();
 
   String CONFIG_CACHE_CAPACITY_FRACTION_ADJUST_MB = "cache-capacity-fraction-adjust-mb";
@@ -160,6 +159,7 @@ public interface QuarkusStoreConfig extends StoreConfig {
    * when calculating the cache size.
    */
   @WithName(CONFIG_CACHE_CAPACITY_FRACTION_ADJUST_MB)
+  @WithDefault("" + DEFAULT_CACHE_CAPACITY_FRACTION_ADJUST_MB)
   OptionalInt cacheCapacityFractionAdjustMB();
 
   String CONFIG_CACHE_CAPACITY_OVERSHOOT = "cache-capacity-overshoot";
@@ -176,6 +176,7 @@ public interface QuarkusStoreConfig extends StoreConfig {
    * <p>Value must be greater than 0, if present.
    */
   @WithName(CONFIG_CACHE_CAPACITY_OVERSHOOT)
+  @WithDefault("" + DEFAULT_CONFIG_CAPACITY_OVERSHOOT)
   OptionalDouble cacheCapacityOvershoot();
 
   @WithName(CONFIG_REFERENCE_CACHE_TTL)

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CacheSizing.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CacheSizing.java
@@ -16,6 +16,9 @@
 package org.projectnessie.versioned.storage.cache;
 
 import static com.google.common.base.Preconditions.checkState;
+import static org.projectnessie.versioned.storage.common.config.StoreConfig.DEFAULT_CACHE_CAPACITY_FRACTION_ADJUST_MB;
+import static org.projectnessie.versioned.storage.common.config.StoreConfig.DEFAULT_CACHE_CAPACITY_FRACTION_MIN_SIZE_MB;
+import static org.projectnessie.versioned.storage.common.config.StoreConfig.DEFAULT_CACHE_CAPACITY_FRACTION_OF_HEAP;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.OptionalDouble;
@@ -25,9 +28,9 @@ import org.immutables.value.Value;
 @Value.Immutable
 public interface CacheSizing {
 
-  int DEFAULT_HEAP_SIZE_KEEP_FREE = 256;
-  int DEFAULT_MIN_SIZE_MB = 64;
-  double DEFAULT_HEAP_FRACTION = 0.6d;
+  int DEFAULT_HEAP_SIZE_KEEP_FREE = DEFAULT_CACHE_CAPACITY_FRACTION_ADJUST_MB;
+  int DEFAULT_MIN_SIZE_MB = DEFAULT_CACHE_CAPACITY_FRACTION_MIN_SIZE_MB;
+  double DEFAULT_HEAP_FRACTION = DEFAULT_CACHE_CAPACITY_FRACTION_OF_HEAP;
 
   OptionalInt fixedSizeInMB();
 

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/config/StoreConfig.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/config/StoreConfig.java
@@ -73,6 +73,12 @@ public interface StoreConfig {
 
   String CONFIG_REFERENCE_NEGATIVE_CACHE_TTL = "reference-cache-negative-ttl";
 
+  boolean DEFAULT_CONFIG_CACHE_ENABLE_SOFT_REFERENCES = false;
+  int DEFAULT_CACHE_CAPACITY_FRACTION_MIN_SIZE_MB = 64;
+  int DEFAULT_CACHE_CAPACITY_FRACTION_ADJUST_MB = 256;
+  double DEFAULT_CACHE_CAPACITY_FRACTION_OF_HEAP = 0.6d;
+  double DEFAULT_CONFIG_CAPACITY_OVERSHOOT = 0.1d;
+
   /**
    * Whether namespace validation is enabled, changing this to false will break the Nessie
    * specification!


### PR DESCRIPTION
This change also adds some missing smallrye-config defaults, no change behavior for the other config options, which are missing [in the docs](https://projectnessie.org/nessie-0-103-3/configuration/#version-store-advanced-settings).