### PR TITLE
Remove links to swaggerhub

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -358,6 +358,7 @@ jobs:
 
       - name: Update SwaggerHub
         uses: smartbear/swaggerhub-cli@cb7bb25da5a6885e491660a9747b4969e15ab295 # v0.9.1
+        continue-on-error: true
         env:
           XDG_CONFIG_HOME: "/tmp"
           SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Changes
 
+- OpenAPI specs are no longer published to swaggerhub.
+
 ### Deprecations
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Project Nessie is a Transactional Catalog for Data Lakes with Git-like semantics
 [![PyPI](https://img.shields.io/pypi/v/pynessie.svg?label=PyPI&logo=python&color=3f6ec6&style=for-the-badge&logoColor=white)](https://pypi.python.org/pypi/pynessie)
 [![quay.io Docker](https://img.shields.io/maven-central/v/org.projectnessie.nessie/nessie?label=quay.io+Docker&logo=docker&color=3f6ec6&style=for-the-badge&logoColor=white)](https://quay.io/repository/projectnessie/nessie?tab=tags)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/nessie&color=3f6ec6&labelColor=&style=for-the-badge&logoColor=white)](https://artifacthub.io/packages/search?repo=nessie)
-[![Swagger Hub](https://img.shields.io/badge/swagger%20hub-nessie-3f6ec6?style=for-the-badge&logo=swagger&link=https%3A%2F%2Fapp.swaggerhub.com%2Fapis%2Fprojectnessie%2Fnessie)](https://app.swaggerhub.com/apis/projectnessie/nessie)
 
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/projectnessie/nessie/ci.yml?branch=main&label=Main%20CI&logo=Github&style=flat-square)](https://github.com/projectnessie/nessie/actions/workflows/ci.yml?query=branch%3Amain)

--- a/api/README.md
+++ b/api/README.md
@@ -33,8 +33,6 @@ Clients built in `java` should build against the API of the `client` module.
 Clients build in other languages can generate language-specific bindings from the published OpenAPI specification of
 the Nessie API.
 
-The published version of the Nessie OpenAPI specification is available on [SwaggerHub](https://app.swaggerhub.com/apis/projectnessie/nessie).
-
 The current development version is available from a running Nessie server at http://localhost:9000/q/swagger-ui.
 
 # Migrating from API v1 to v2

--- a/site/docs/develop/rest.md
+++ b/site/docs/develop/rest.md
@@ -4,5 +4,3 @@ Nessie's REST APIs are how all applications interact with Nessie. The APIs are s
 according to the openapi v3 standard and are available when running the server by at the path
 `/nessie-openapi/openapi.yaml` (for example via `curl http://127.0.0.1:19120/nessie-openapi/openapi.yaml`)
 and on the Download/Release pages.
-
-The API can also be inspected at [SwaggerHub](https://app.swaggerhub.com/apis/projectnessie/nessie).

--- a/site/docs/downloads/index.md
+++ b/site/docs/downloads/index.md
@@ -169,8 +169,6 @@ Nessie repository.
 
 ## Nessie REST API
 
-=== "View on Swagger Hub"
-    [![Swagger Hub](https://img.shields.io/badge/swagger%20hub-nessie-3f6ec6?style=for-the-badge&logo=swagger&link=https%3A%2F%2Fapp.swaggerhub.com%2Fapis%2Fprojectnessie%2Fnessie)](https://app.swaggerhub.com/apis/projectnessie/nessie/{{ versions.nessie }})
 === "Download"
     [OpenAPI Download](https://github.com/projectnessie/nessie/releases/download/nessie-{{ versions.nessie }}/nessie-openapi-{{ versions.nessie }}.yaml)
 

--- a/site/docs/guides/ui.md
+++ b/site/docs/guides/ui.md
@@ -7,8 +7,3 @@ The UI automatically runs as part of starting the Nessie service. If running loc
 you can find the UI at [localhost:19120](http://localhost:19120/).
 
 ![Screenshot](../img/uidemo.gif){.bordered}
-
-### Swagger UI
-
-The Swagger UI allows for testing the REST API and reading the API docs. It is available
-at [SwaggerHub](https://app.swaggerhub.com/apis/projectnessie/nessie).

--- a/site/in-dev/configuration.md
+++ b/site/in-dev/configuration.md
@@ -540,10 +540,6 @@ The request could not be executed. Full error message: Failed to connect to loca
 This means that the server is unable to connect to the collector. Check that the collector is
 running and that the URL is correct.
 
-### Swagger UI
-The Swagger UI allows for testing the REST API and reading the API docs. It is available 
-at [SwaggerHub](https://app.swaggerhub.com/apis/projectnessie/nessie).
-
 ## Docker image options
 
 By default, Nessie listens on port 19120. To expose that port on the host, use `-p 19120:19120`. 

--- a/site/in-dev/index-release.md
+++ b/site/in-dev/index-release.md
@@ -169,8 +169,6 @@ Nessie repository.
 
 ## Nessie REST API
 
-=== "View on Swagger Hub"
-    [![Swagger Hub](https://img.shields.io/badge/swagger%20hub-nessie-3f6ec6?style=for-the-badge&logo=swagger&link=https%3A%2F%2Fapp.swaggerhub.com%2Fapis%2Fprojectnessie%2Fnessie)](https://app.swaggerhub.com/apis/projectnessie/nessie/::NESSIE_VERSION::)
 === "Download"
     [OpenAPI Download](https://github.com/projectnessie/nessie/releases/download/nessie-::NESSIE_VERSION::/nessie-openapi-::NESSIE_VERSION::.yaml)
 


### PR DESCRIPTION
Nessie release publications fail for quite some time now due to `Error: Exceeded access limits for projectnessie.` in the `publish-openapi` release workflow job.

This change updates the release-workflow to not fail at all during swaggerhub api calls (hoping it may continue to work at some point), but remove the links to swaggerhub on the web site and in-tree docs.