### PR TITLE
Update Sonatype publishing URLs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,13 @@ nexusPublishing {
     // default 10s
     delayBetween = java.time.Duration.ofSeconds(10)
   }
-  repositories { sonatype() }
+  repositories {
+    // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
+    sonatype {
+      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+    }
+  }
 }
 
 val buildToolIntegrationGradle by


### PR DESCRIPTION
The OSSRH service will reach end-of-life on June 30th, 2025. All publications will move to the "Central Portal" before that date.

This change updates the Nexus configuration according to [this sonatype page](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration).

Requires changes to the secrets.