### PR TITLE
Migrate to a different Maven publishing plugin

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -127,15 +127,13 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.OSSRH_ACCESS_ID }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_TOKEN }}
-          # To release commits that used Maven to build
-          MAVEN_USERNAME: ${{ secrets.OSSRH_ACCESS_ID }}
-          MAVEN_OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        # Ref: Maven Central Publisher API:
+        #    https://central.sonatype.org/publish/publish-portal-api/#uploading-a-deployment-bundle
         run: |
           # 2 Retries - to mitigate "HTTP/502 Bad Gateway" issues
-          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease -Puber-jar --no-scan --stacktrace || \
-            ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease -Puber-jar --no-scan --stacktrace || \
-            ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease -Puber-jar --no-scan --stacktrace
+          ./gradlew publishAggregateMavenCentralDeployment -Prelease -Puber-jar --no-scan --stacktrace || \
+            ./gradlew publishAggregateMavenCentralDeployment -Prelease -Puber-jar --no-scan --stacktrace || \
+            ./gradlew publishAggregateMavenCentralDeployment -Prelease -Puber-jar --no-scan --stacktrace
 
       - name: Generate changelog
         run: ./gradlew --no-scan --quiet --console=plain getChangelog --no-header --no-links > "${ARTIFACTS}/nessie-changelog-${RELEASE_VERSION}.md"

--- a/build-logic/src/main/kotlin/nessie-common-src.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-common-src.gradle.kts
@@ -210,7 +210,7 @@ class MemoizedGitInfo {
         val info =
           mapOf(
             "Nessie-Version" to
-              rootProject.layout.projectDirectory.file("version.txt").asFile.readText(),
+              rootProject.layout.projectDirectory.file("version.txt").asFile.readText().trim(),
             "Nessie-Build-Git-Head" to gitHead,
             "Nessie-Build-Git-Describe" to gitDescribe,
             "Nessie-Build-Timestamp" to timestamp,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,6 +94,9 @@ mavenCentralPortal {
   }
 }
 
+// The following code aggregates the publishable parts of every module into a single zip.
+// This is necessary to have an "atomic" release of all modules.
+
 val mavenCentralDeploymentZipAggregation by configurations.creating
 
 mavenCentralDeploymentZipAggregation.isTransitive = true

--- a/gc/gc-iceberg-inttest/build.gradle.kts
+++ b/gc/gc-iceberg-inttest/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-client")
+  id("nessie-conventions-unpublished-tool")
   alias(libs.plugins.nessie.run)
 }
 

--- a/gc/gc-iceberg-inttest/build.gradle.kts
+++ b/gc/gc-iceberg-inttest/build.gradle.kts
@@ -19,6 +19,8 @@ plugins {
   alias(libs.plugins.nessie.run)
 }
 
+tasks.withType<JavaCompile>().configureEach { options.release = 11 }
+
 publishingHelper { mavenName = "Nessie - GC - Integration tests" }
 
 val sparkScala = useSparkScalaVersionsForProject("3.5", "2.12")

--- a/gc/gc-tool-inttest/build.gradle.kts
+++ b/gc/gc-tool-inttest/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-client")
+  id("nessie-conventions-unpublished-tool")
   alias(libs.plugins.nessie.run)
 }
 

--- a/gc/gc-tool-inttest/build.gradle.kts
+++ b/gc/gc-tool-inttest/build.gradle.kts
@@ -19,6 +19,8 @@ plugins {
   alias(libs.plugins.nessie.run)
 }
 
+tasks.withType<JavaCompile>().configureEach { options.release = 11 }
+
 publishingHelper { mavenName = "Nessie - GC - CLI integration test" }
 
 val sparkScala = useSparkScalaVersionsForProject("3.4", "2.12")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -161,8 +161,8 @@ zstd-jni = { module = "com.github.luben:zstd-jni", version = "1.5.7-3" }
 [plugins]
 gatling = { id = "io.gatling.gradle", version = "3.13.5.4" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
+maven-central-publish = { id = "io.github.zenhelix.maven-central-publish", version = "0.8.0" }
 nessie-run = { id = "org.projectnessie", version = "0.32.2" }
-nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 protobuf = { id = "com.google.protobuf", version = "0.9.5" }
 quarkus = { id = "io.quarkus", version.ref = "quarkusPlugin" }
 quarkus-extension = { id = "io.quarkus.extension", version.ref = "quarkusPlugin" }

--- a/nessie-iceberg/build.gradle.kts
+++ b/nessie-iceberg/build.gradle.kts
@@ -16,7 +16,6 @@
 
 plugins {
   id("nessie-conventions-root")
-  alias(libs.plugins.nexus.publish.plugin)
 }
 
 publishingHelper { mavenName = "Nessie-Iceberg" }

--- a/nessie-iceberg/build.gradle.kts
+++ b/nessie-iceberg/build.gradle.kts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-plugins {
-  id("nessie-conventions-root")
-}
+plugins { id("nessie-conventions-root") }
 
 publishingHelper { mavenName = "Nessie-Iceberg" }
 


### PR DESCRIPTION
Nessie and CEL-java are using the [Gradle Nexus publish plugin](https://github.com/gradle-nexus/publish-plugin), which works great for publishing to Nexus and Sonatype OSSRH. Sonatype OSSRH reaches EOL on June 30, 2025 - a migration to "Maven Central Repository" is necessary. [Sonatype mentions](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration) that is's enough to update the configuration of the `gradle-nexus/publish-plugin`. A "canary" release of CEL-Java worked fine, but a Nessie release ran into quite some errors (empty deployment, missing mandatory files). This might be because of the _Portal OSSRH Staging API_, which _is a partial reimplementation of the OSSRH / Nexus Repository Manager 2 Staging APIs_. The noteable differences between CEL-Java and Nessie is that Nessie has way more artifacts and the publishing/deployment takes much longer (< 5 minutes vs 25-30 minutes).

In the mid/long term it is likely anyway the better alternative to use the [Portal Publisher API](https://central.sonatype.org/publish/publish-portal-api/). Althought there are many Gradle plugins around that support that API, none seems to fully fit the needs of multi-project deployments - to publish an aggregated file containing the contents for all modules to be released. Two Gradle plugins looked promising though:

* [GradleUp/nmcp](https://github.com/GradleUp/nmcp) (author also took over the shadow plugin) has support for "aggregated deployments", but in the current form the plugin fails for projects that change the build-directory, which is what the Nessie Spark extensions do.
* [zenhelix/maven-central-publish](https://github.com/zenhelix/maven-central-publish/tree/main) however was chosen as it was easier to integrate, but required some work in our root `build.gradle.kts` integrating the support for aggregated multi-project deployments.