### PR TITLE
Client/auth-code-flow: Handle multiple interfaces w/ hostname `localhost`

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeFlow.java
@@ -24,11 +24,13 @@ import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -62,7 +64,7 @@ class AuthorizationCodeFlow extends AbstractFlow {
 
   private final PrintStream console;
   private final String state;
-  private final HttpServer server;
+  private final List<HttpServer> servers;
   private final String redirectUri;
   private final URI authorizationUri;
   private final Duration flowTimeout;
@@ -105,11 +107,11 @@ class AuthorizationCodeFlow extends AbstractFlow {
             .thenApply(this::fetchNewTokens)
             .whenComplete((tokens, error) -> log(error));
     closeFuture.thenRun(this::doClose);
-    server =
+    servers =
         createServer(config.getAuthorizationCodeFlowWebServerPort().orElse(0), this::doRequest);
     state = OAuth2Utils.randomAlphaNumString(STATE_LENGTH);
     redirectUri =
-        String.format("http://localhost:%d%s", server.getAddress().getPort(), CONTEXT_PATH);
+        String.format("http://localhost:%d%s", servers.get(0).getAddress().getPort(), CONTEXT_PATH);
     URI authEndpoint = config.getResolvedAuthEndpoint();
     authorizationUri =
         new UriBuilder(authEndpoint.resolve("/"))
@@ -132,7 +134,9 @@ class AuthorizationCodeFlow extends AbstractFlow {
   private void doClose() {
     inflightRequestsPhaser.arriveAndAwaitAdvance();
     LOGGER.debug("Authorization Code Flow: closing");
-    server.stop(0);
+    for (var server : servers) {
+      server.stop(0);
+    }
     // don't close the HTTP client nor the console, they are not ours
   }
 
@@ -238,22 +242,41 @@ class AuthorizationCodeFlow extends AbstractFlow {
     }
   }
 
-  private static HttpServer createServer(int port, HttpHandler handler) {
-    final HttpServer server;
+  private static List<HttpServer> createServer(int port, HttpHandler handler) {
+    var serversDispose = new ArrayList<HttpServer>();
     try {
-      server = HttpServer.create();
+      for (var networkInterfaces = NetworkInterface.getNetworkInterfaces();
+          networkInterfaces.hasMoreElements(); ) {
+        var networkInterface = networkInterfaces.nextElement();
+        if (!networkInterface.isLoopback()) {
+          continue;
+        }
+        for (var inetAddresses = networkInterface.getInetAddresses();
+            inetAddresses.hasMoreElements(); ) {
+          var inetAddress = inetAddresses.nextElement();
+          var server = HttpServer.create(new InetSocketAddress(inetAddress, port), 0);
+          serversDispose.add(server);
+          server.createContext(CONTEXT_PATH, handler);
+          server.start();
+          LOGGER.debug("Local http server started at {}", server.getAddress());
+          if (port == 0) {
+            port = server.getAddress().getPort();
+          }
+        }
+      }
+
+      var servers = List.copyOf(serversDispose);
+      serversDispose.clear();
+      return servers;
     } catch (IOException e) {
       throw new UncheckedIOException(e);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      for (var httpServer : serversDispose) {
+        httpServer.stop(0);
+      }
     }
-    server.createContext(CONTEXT_PATH, handler);
-    InetAddress local = InetAddress.getLoopbackAddress();
-    try {
-      server.bind(new InetSocketAddress(local, port), 0);
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
-    server.start();
-    return server;
   }
 
   private static void writeResponse(


### PR DESCRIPTION
Auth-code-flow test recently started to fail in CI for all PRs. Difficult to tell which change really causes the issues here.

Background: `org.projectnessie.client.auth.oauth2.AuthorizationCodeFlow` binds to the inet-address returned by `InetAddress.getLoopbackAddress()` and the redirect-URL uses `localhost`.

"As usual", the affected test `ITOAuth2ClientAuthelia` works fine locally. However, there's a little difference in the environment. In GH workflows, `localhost` resolves to both ::1 and 127.0.0.1, whereas locally `localhost` only resolves to 127.0.0.1. So it feels related to IPv4 vs IPv6.

Some experiments with different contents in `/etc/hosts`:
```
::1 localhost
127.0.0.1 localhost
```
--> test passes
```
127.0.0.1 localhost
::1 localhost
```
--> test passes
```
127.0.0.1 localhost
```
--> test passes
```
::1 localhost
```
--> test fails

This means that the issue is defintely related to which IP address (`127.0.0.1` or `::1`) `localhost` resolves to.

The change in this PR is to start one HTTP server for all loopback IP addresses.

Alternatives were:
* Bind to "all addresses": this feels a bit insecure, because it would open the http server to remote requests
* Inspect which interfaces have `localhost` in `InetAddress.getHostName()`. This performs a roundtrip to at least the local resolver, but more importantly it can still yield multiple addresses.
* Resolve `localhost` via `InetAddress.get[All]ByName()`. This performs a name service roundtrip (_usually_ only the local resolver, but still) - but it can also yield multiple addresses.
* Use the IP address (`127.0.0.1` or `::1` or whatever host address `InetAddress.getLoopbackAddress().getHostAddress()` returns) in the redirect URL. This would require changes to the allowed redirect-URLs in Authelia/Keycloak configurations. On top, some implementations have issues parsing IPv6 addresses in URLs (e.g. `http://[::1]:54321/foo/bar`) due to the repeated `:`.
* Inspect `/etc/hosts` - it's another can of worms especially on all the different operating system. So getting into that area for this use case feels wrong.

Side note: the order in which resolvers return an IP address is up to the resolver. There are no guarantees from a client's side of view (beside that some IP address, if resolvable, is returned).

Overall the approach to listen to all loopback addresses seems to be the best approach.

Additional debug logging has been added.
