### PR TITLE
Disable `ITOAuth2ClientAuthelia.testOAuth2AuthorizationCode()`

### DIFF
--- a/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2ClientAuthelia.java
+++ b/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2ClientAuthelia.java
@@ -31,6 +31,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -110,6 +111,8 @@ public class ITOAuth2ClientAuthelia {
 
   @Test
   @Timeout(15)
+  @Disabled(
+      "Disabled for now, see https://github.com/projectnessie/nessie/pull/10818#issuecomment-2880103972")
   void testOAuth2AuthorizationCode() throws Exception {
     try (InteractiveResourceOwnerEmulator resourceOwner =
         new AutheliaAuthorizationCodeResourceOwnerEmulator(


### PR DESCRIPTION
See also #10818, especially this comment:
Looks like it's an issue w/ Authelia and the requested `offline_access` scope, because of [`If the client requests the offline_access or offline scope the mode will automatically be explicit regardless of client configuration.`](https://www.authelia.com/configuration/identity-providers/openid-connect/clients/#implicit). But this doesn't really explain why the test passes locally but not in GHA.