### PR TITLE
QUarkus: `RestAssured` may sometimes have the wrong port

### DIFF
--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestSinglePageApplicationRouting.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestSinglePageApplicationRouting.java
@@ -16,6 +16,7 @@
 package org.projectnessie.server;
 
 import static io.restassured.RestAssured.given;
+import static java.lang.String.format;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
@@ -29,6 +30,12 @@ class TestSinglePageApplicationRouting {
 
   @Test
   public void makeSureNonHomePathServesHtml() {
-    given().when().get("/tree/123").then().contentType(ContentType.HTML).statusCode(200);
+    given()
+        .when()
+        .baseUri(format("http://localhost:%d/", Integer.getInteger("quarkus.http.port")))
+        .get("/tree/123")
+        .then()
+        .contentType(ContentType.HTML)
+        .statusCode(200);
   }
 }


### PR DESCRIPTION
... this happened with the Quarkus 3.22.4 upgrade #10714. Possibly a value-visibility issue (the fields aren't `volatile`).