### PR TITLE
fix: migrate aws.region → client.region (Fixes #8262)

### DIFF
--- a/gc/gc-iceberg-files/build.gradle.kts
+++ b/gc/gc-iceberg-files/build.gradle.kts
@@ -85,7 +85,7 @@ dependencies {
 }
 
 tasks.withType(Test::class.java).configureEach {
-  systemProperty("aws.region", "us-east-1")
+  systemProperty("client.region", "us-east-1")
   // Java 23 & Hadoop
   systemProperty("java.security.manager", "allow")
   jvmArgumentProviders.add(

--- a/gc/gc-iceberg-inttest/build.gradle.kts
+++ b/gc/gc-iceberg-inttest/build.gradle.kts
@@ -147,7 +147,7 @@ forceJavaVersionForTests(sparkScala.runtimeJavaVersion)
 tasks.named<Test>("intTest").configure { forkEvery = 1 }
 
 tasks.withType(Test::class.java).configureEach {
-  systemProperty("aws.region", "us-east-1")
+  systemProperty("client.region", "us-east-1")
   jvmArgumentProviders.add(
     CommandLineArgumentProvider {
       val tmpdir = project.layout.buildDirectory.get().asFile.resolve("tmpdir")

--- a/gc/gc-iceberg-inttest/src/intTest/java/org/projectnessie/gc/iceberg/inttest/ITSparkIcebergNessieS3.java
+++ b/gc/gc-iceberg-inttest/src/intTest/java/org/projectnessie/gc/iceberg/inttest/ITSparkIcebergNessieS3.java
@@ -62,7 +62,7 @@ public class ITSparkIcebergNessieS3 extends AbstractITSparkIcebergNessieObjectSt
     r.put(CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.aws.s3.S3FileIO");
     r.putAll(minio.icebergProperties());
 
-    System.setProperty("aws.region", "us-east-1");
+    System.setProperty("client.region", "us-east-1");
     System.setProperty("aws.s3.endpoint", minio.s3endpoint());
     System.setProperty("aws.s3.accessKey", minio.accessKey());
     System.setProperty("aws.s3.secretAccessKey", minio.secretKey());

--- a/gc/gc-tool-inttest/build.gradle.kts
+++ b/gc/gc-tool-inttest/build.gradle.kts
@@ -121,7 +121,7 @@ dependencies {
 val intTest = tasks.named<Test>("intTest")
 
 intTest.configure {
-  systemProperty("aws.region", "us-east-1")
+  systemProperty("client.region", "us-east-1")
   // Java 23 & Hadoop
   systemProperty("java.security.manager", "allow")
 }

--- a/gc/gc-tool-inttest/src/intTest/java/org/projectnessie/gc/tool/inttest/ITSparkIcebergNessieCLI.java
+++ b/gc/gc-tool-inttest/src/intTest/java/org/projectnessie/gc/tool/inttest/ITSparkIcebergNessieCLI.java
@@ -70,7 +70,7 @@ public class ITSparkIcebergNessieCLI extends SparkSqlTestBase {
     r.put(CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.aws.s3.S3FileIO");
     r.putAll(minio.icebergProperties());
 
-    System.setProperty("aws.region", "us-east-1");
+    System.setProperty("client.region", "us-east-1");
     System.setProperty("aws.s3.endpoint", minio.s3endpoint());
     System.setProperty("aws.s3.accessKey", minio.accessKey());
     System.setProperty("aws.s3.secretAccessKey", minio.secretKey());

--- a/testing/minio-container/build.gradle.kts
+++ b/testing/minio-container/build.gradle.kts
@@ -41,4 +41,4 @@ dependencies {
   intTestRuntimeOnly(libs.logback.classic)
 }
 
-tasks.withType(Test::class.java).configureEach { systemProperty("aws.region", "us-east-1") }
+tasks.withType(Test::class.java).configureEach { systemProperty("client.region", "us-east-1") }

--- a/testing/object-storage-mock/build.gradle.kts
+++ b/testing/object-storage-mock/build.gradle.kts
@@ -78,4 +78,4 @@ dependencies {
   testImplementation(libs.bundles.junit.testing)
 }
 
-tasks.withType(Test::class.java).configureEach { systemProperty("aws.region", "us-east-1") }
+tasks.withType(Test::class.java).configureEach { systemProperty("client.region", "us-east-1") }


### PR DESCRIPTION
Replaces all internal uses of the system property aws.region with Iceberg’s client.region