### PR TITLE
Testing/object-storage-mock: fix content-length for HTTP range requests

### DIFF
--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/AdlsGen2Resource.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/AdlsGen2Resource.java
@@ -191,7 +191,9 @@ public class AdlsGen2Resource {
   @Path("/{filesystem:[$a-z0-9](?!.*--)[-a-z0-9]{1,61}[a-z0-9]}/{path:.*}")
   @Produces(MediaType.WILDCARD)
   public Response getProperties(
-      @PathParam("filesystem") String filesystem, @PathParam("path") String path) {
+      @PathParam("filesystem") String filesystem,
+      @PathParam("path") String path,
+      @HeaderParam(RANGE) Range range) {
 
     String normalizedPath = stripLeadingSlash(path);
 
@@ -204,12 +206,15 @@ public class AdlsGen2Resource {
             return keyNotFound();
           }
 
-          return Response.ok()
-              .tag(obj.etag())
-              .type(obj.contentType())
-              .header(CONTENT_LENGTH, obj.contentLength())
-              .lastModified(new Date(obj.lastModified()))
-              .build();
+          Response.ResponseBuilder responseBuilder =
+              Response.ok()
+                  .tag(obj.etag())
+                  .type(obj.contentType())
+                  .lastModified(new Date(obj.lastModified()));
+          if (range == null) {
+            responseBuilder.header(CONTENT_LENGTH, obj.contentLength());
+          }
+          return responseBuilder.build();
         });
   }
 

--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/GcsResource.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/GcsResource.java
@@ -239,12 +239,15 @@ public class GcsResource {
                   .build();
             case media:
               StreamingOutput stream = output -> obj.writer().write(range, output);
-              return Response.ok(stream)
-                  .tag(obj.etag())
-                  .type(obj.contentType())
-                  .header(CONTENT_LENGTH, obj.contentLength())
-                  .lastModified(new Date(obj.lastModified()))
-                  .build();
+              Response.ResponseBuilder responseBuilder =
+                  Response.ok(stream)
+                      .tag(obj.etag())
+                      .type(obj.contentType())
+                      .lastModified(new Date(obj.lastModified()));
+              if (range == null) {
+                responseBuilder.header(CONTENT_LENGTH, obj.contentLength());
+              }
+              return responseBuilder.build();
             default:
               throw new IllegalArgumentException("alt = " + alt);
           }

--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/S3Resource.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/S3Resource.java
@@ -355,12 +355,15 @@ public class S3Resource {
             return notModified(obj.etag());
           }
           StreamingOutput stream = output -> obj.writer().write(range, output);
-          return Response.ok(stream)
-              .tag(obj.etag())
-              .type(obj.contentType())
-              .header(CONTENT_LENGTH, obj.contentLength())
-              .lastModified(new Date(obj.lastModified()))
-              .build();
+          Response.ResponseBuilder responseBuilder =
+              Response.ok(stream)
+                  .tag(obj.etag())
+                  .type(obj.contentType())
+                  .lastModified(new Date(obj.lastModified()));
+          if (range == null) {
+            responseBuilder.header(CONTENT_LENGTH, obj.contentLength());
+          }
+          return responseBuilder.build();
         });
   }
 


### PR DESCRIPTION
Fixes an issue where the HTTP Content-Length header was set to the total object's length despite the presence of a HTTP Range header, so the CL is wrong.