### PR TITLE
Fix release workflow in case no non-renovate commits happened

### DIFF
--- a/tools/releases/create-gh-release-notes.sh
+++ b/tools/releases/create-gh-release-notes.sh
@@ -82,7 +82,8 @@ fi
 # xargs trims
 NUM_COMMITS=$(git log --format='format:%h' ${LAST_TAG}..HEAD^1 | wc -l | xargs)
 
-git log --perl-regexp --author '^(?!.*renovate|.*nessie-release-workflow).*$' --format='format:* %s' ${LAST_TAG}..${GIT_TAG} | grep -v '^\* \[release\] .*$' > ./release-log
+git log --perl-regexp --author '^(?!.*renovate|.*nessie-release-workflow).*$' --format='format:* %s' ${LAST_TAG}..${GIT_TAG} > ./raw-log
+grep -v '^\* \[release\] .*$' ./raw-log || true > ./release-log
 
 Q_CLI_URL="https://github.com/projectnessie/nessie/releases/download/nessie-${RELEASE_VERSION}/nessie-cli-${RELEASE_VERSION}.jar"
 Q_GC_TOOL_URL="https://github.com/projectnessie/nessie/releases/download/nessie-${RELEASE_VERSION}/nessie-gc-${RELEASE_VERSION}.jar"


### PR DESCRIPTION
`grep` exits with code `1` if nothing matched, this change deals with that special case.