### PR TITLE
OAuth2 (Authorization Code): Include extra parameters in authorization URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Fixes
 
+- A bug has been resolved in the OAuth2 Authorization Code grant type. This fix addresses an issue
+  where the `extra-params` configuration option was not being properly included in the authorization
+  URI. Consequently, users, particularly Auth0 users passing the `audience` parameter, were receiving
+  opaque tokens instead of JWTs.
+
 ### Commits
 
 ## [0.104.2] Release (2025-06-12)

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeFlow.java
@@ -111,7 +111,7 @@ class AuthorizationCodeFlow extends AbstractFlow {
     redirectUri =
         String.format("http://localhost:%d%s", server.getAddress().getPort(), CONTEXT_PATH);
     URI authEndpoint = config.getResolvedAuthEndpoint();
-    authorizationUri =
+    UriBuilder uriBuilder =
         new UriBuilder(authEndpoint.resolve("/"))
             .path(authEndpoint.getPath())
             .queryParam("response_type", "code")
@@ -119,8 +119,9 @@ class AuthorizationCodeFlow extends AbstractFlow {
             .queryParam(
                 "scope", config.getScopes().stream().reduce((a, b) -> a + " " + b).orElse(null))
             .queryParam("redirect_uri", redirectUri)
-            .queryParam("state", state)
-            .build();
+            .queryParam("state", state);
+    config.getExtraRequestParameters().forEach(uriBuilder::queryParam);
+    authorizationUri = uriBuilder.build();
     LOGGER.debug("Authorization Code Flow: started, redirect URI: {}", redirectUri);
   }
 


### PR DESCRIPTION
This fix addresses an issue where the `extra-params` configuration option was not being properly included in the authorization URI. Consequently, users, particularly Auth0 users passing the `audience` parameter, were receiving opaque tokens instead of JWTs.