### PR TITLE
Build/local-testing: Allow using custom Quarkus versions and not enforce Quarkus platform versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,23 @@ git config core.eol lf
 git checkout main
 ```
 
+#### Testing custom/newer Quarkus versions
+
+Nessie releases use the Quarkus version defined in the `libs` version catalog using Gradle's `enforcedPlatform`
+dependency constraint mechanism. This means that the Quarkus version used by default is fixed and the dependencies
+defined by the Quarkus platform are enforced.
+
+For testing purposes, it is possible to use a different Quarkus version by setting the `quarkus.custom.version`
+system property.
+It is also possible to not enforce the Quarkus platform versions, i.e. using Gradle's `platform` dependency
+constraint mechanism, by setting the `quarkus.custom.noEnforcePlatform` system property to `true`.
+
+Example, to test against a pre-release Quarkus 3.28.0.CR1 version:
+```bash
+./gradlew -Dquarkus.custom.version=3.28.0.CR1 -Dquarkus.custom.noEnforcedPlatform=true test
+./gradlew -Dquarkus.custom.version=3.28.0.CR1 -Dquarkus.custom.noEnforcedPlatform=true intTest
+```
+
 ### Style guide
 
 Changes must adhere to the style guide and this will be verified by the continuous integration build.

--- a/catalog/secrets/vault/build.gradle.kts
+++ b/catalog/secrets/vault/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
   implementation(project(":nessie-catalog-secrets-api"))
   implementation(libs.guava)
 
-  implementation(enforcedPlatform(libs.quarkus.bom))
+  implementation(quarkusPlatform(project))
   implementation(libs.quarkus.vault)
 
   compileOnly(project(":nessie-immutables"))

--- a/catalog/service/rest/build.gradle.kts
+++ b/catalog/service/rest/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
 
   implementation(libs.smallrye.mutiny)
 
-  implementation(enforcedPlatform(libs.quarkus.bom))
+  implementation(quarkusPlatform(project))
   implementation("io.quarkus:quarkus-rest-common")
   implementation("io.quarkus:quarkus-rest")
 

--- a/events/quarkus/build.gradle.kts
+++ b/events/quarkus/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   implementation(project(":nessie-quarkus-config"))
 
   // Quarkus
-  implementation(enforcedPlatform(libs.quarkus.bom))
+  implementation(quarkusPlatform(project))
   implementation("io.quarkus:quarkus-vertx")
 
   // Metrics
@@ -45,7 +45,7 @@ dependencies {
 
   testImplementation(project(":nessie-model"))
 
-  testImplementation(enforcedPlatform(libs.quarkus.bom))
+  testImplementation(quarkusPlatform(project))
   testImplementation("io.quarkus:quarkus-opentelemetry")
   testImplementation("io.quarkus:quarkus-micrometer")
   testImplementation("io.quarkus:quarkus-micrometer-registry-prometheus")

--- a/events/quarkus/build.gradle.kts
+++ b/events/quarkus/build.gradle.kts
@@ -16,6 +16,11 @@
 
 plugins {
   alias(libs.plugins.quarkus)
+    .version(
+      libs.plugins.quarkus.asProvider().map {
+        System.getProperty("quarkus.custom.version", it.version.requiredVersion)
+      }
+    )
   id("nessie-conventions-quarkus")
 }
 

--- a/events/ri/build.gradle.kts
+++ b/events/ri/build.gradle.kts
@@ -18,6 +18,11 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
   alias(libs.plugins.quarkus)
+    .version(
+      libs.plugins.quarkus.asProvider().map {
+        System.getProperty("quarkus.custom.version", it.version.requiredVersion)
+      }
+    )
   id("nessie-conventions-quarkus")
 }
 

--- a/events/ri/build.gradle.kts
+++ b/events/ri/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   implementation(project(":nessie-events-spi"))
 
   // Quarkus
-  implementation(enforcedPlatform(libs.quarkus.bom))
+  implementation(quarkusPlatform(project))
   implementation("io.quarkus:quarkus-core")
 
   // Quarkus - Kafka
@@ -60,7 +60,7 @@ dependencies {
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.bundles.junit.testing)
   testImplementation(libs.awaitility)
-  testImplementation(enforcedPlatform(libs.quarkus.bom))
+  testImplementation(quarkusPlatform(project))
   testImplementation("io.quarkus:quarkus-junit5")
 
   testCompileOnly(libs.microprofile.openapi)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -124,11 +124,8 @@ picocli = { module = "info.picocli:picocli-codegen", version.ref = "picocli" }
 picocli-codegen = { module = "info.picocli:picocli-codegen", version.ref = "picocli" }
 postgresql = { module = "org.postgresql:postgresql", version = "42.7.7" }
 protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf" }
-quarkus-amazon-services-bom = { module = "io.quarkus.platform:quarkus-amazon-services-bom", version.ref = "quarkusPlatform" }
 quarkus-azure-services-bom = { module = "io.quarkiverse.azureservices:quarkus-azure-services-bom", version = "1.1.9" }
 quarkus-bom = { module = "io.quarkus.platform:quarkus-bom", version.ref = "quarkusPlatform" }
-quarkus-cassandra-bom = { module = "io.quarkus.platform:quarkus-cassandra-bom", version.ref = "quarkusPlatform" }
-quarkus-google-cloud-services-bom = { module = "io.quarkus.platform:quarkus-google-cloud-services-bom", version.ref = "quarkusPlatform" }
 quarkus-logging-sentry = { module = "io.quarkiverse.loggingsentry:quarkus-logging-sentry", version = "2.1.8" }
 quarkus-vault = { module = "io.quarkiverse.vault:quarkus-vault", version.ref = "quarkusVault" }
 quarkus-vault-deployment = { module = "io.quarkiverse.vault:quarkus-vault-deployment", version.ref = "quarkusVault" }

--- a/servers/quarkus-authn/build.gradle.kts
+++ b/servers/quarkus-authn/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 
   implementation(libs.guava)
 
-  implementation(enforcedPlatform(libs.quarkus.bom))
+  implementation(quarkusPlatform(project))
   implementation("io.quarkus:quarkus-security")
   implementation("io.quarkus:quarkus-vertx-http")
 

--- a/servers/quarkus-authz/build.gradle.kts
+++ b/servers/quarkus-authz/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 
   implementation(libs.guava)
 
-  implementation(enforcedPlatform(libs.quarkus.bom))
+  implementation(quarkusPlatform(project))
   implementation("io.quarkus:quarkus-security")
   implementation("io.quarkus:quarkus-vertx-http")
 

--- a/servers/quarkus-catalog/build.gradle.kts
+++ b/servers/quarkus-catalog/build.gradle.kts
@@ -34,8 +34,8 @@ dependencies {
   implementation(project(":nessie-services-config"))
   implementation(project(":nessie-versioned-storage-common"))
 
-  implementation(enforcedPlatform(libs.quarkus.bom))
-  implementation(enforcedPlatform(libs.quarkus.amazon.services.bom))
+  implementation(quarkusPlatform(project))
+  implementation(quarkusExtension(project, "amazon-services"))
   implementation("io.quarkus:quarkus-core")
   implementation("io.quarkus:quarkus-jackson")
   implementation("io.micrometer:micrometer-core")
@@ -67,7 +67,7 @@ dependencies {
   testFixturesApi(platform(libs.junit.bom))
   testFixturesApi(libs.bundles.junit.testing)
 
-  testFixturesApi(enforcedPlatform(libs.quarkus.bom))
+  testFixturesApi(quarkusPlatform(project))
   testFixturesApi("io.quarkus:quarkus-core")
 
   testRuntimeOnly(libs.logback.classic)

--- a/servers/quarkus-common/build.gradle.kts
+++ b/servers/quarkus-common/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
   implementation(project(":nessie-versioned-storage-rocksdb"))
   implementation(project(":nessie-versioned-storage-store"))
 
-  implementation(enforcedPlatform(libs.quarkus.bom))
+  implementation(quarkusPlatform(project))
   implementation("io.quarkus:quarkus-mongodb-client")
   implementation("io.quarkus:quarkus-hibernate-validator")
   implementation("io.quarkus:quarkus-agroal")
@@ -60,15 +60,15 @@ dependencies {
   implementation("io.quarkus:quarkus-opentelemetry")
   implementation("io.quarkus:quarkus-micrometer")
   implementation("io.smallrye.config:smallrye-config-source-keystore")
-  implementation(enforcedPlatform(libs.quarkus.amazon.services.bom))
+  implementation(quarkusExtension(project, "amazon-services"))
   implementation("io.quarkiverse.amazonservices:quarkus-amazon-dynamodb")
   implementation("software.amazon.awssdk:sts")
   implementation("software.amazon.awssdk:apache-client") {
     exclude("commons-logging", "commons-logging")
   }
-  implementation(enforcedPlatform(libs.quarkus.google.cloud.services.bom))
+  implementation(quarkusExtension(project, "google-cloud-services"))
   implementation("io.quarkiverse.googlecloudservices:quarkus-google-cloud-bigtable")
-  implementation(enforcedPlatform(libs.quarkus.cassandra.bom))
+  implementation(quarkusExtension(project, "cassandra"))
   implementation(enforcedPlatform(libs.cassandra.driver.bom))
   implementation("com.datastax.oss.quarkus:cassandra-quarkus-client") {
     // spotbugs-annotations has only a GPL license!
@@ -97,7 +97,7 @@ dependencies {
   testFixturesApi(platform(libs.junit.bom))
   testFixturesApi(libs.bundles.junit.testing)
 
-  testFixturesApi(enforcedPlatform(libs.quarkus.bom))
+  testFixturesApi(quarkusPlatform(project))
   testFixturesApi("io.quarkus:quarkus-core")
 
   testRuntimeOnly(libs.logback.classic)

--- a/servers/quarkus-config/build.gradle.kts
+++ b/servers/quarkus-config/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 
   compileOnly(project(":nessie-doc-generator-annotations"))
 
-  compileOnly(enforcedPlatform(libs.quarkus.bom))
+  compileOnly(quarkusPlatform(project))
   compileOnly("io.quarkus:quarkus-core")
   compileOnly("io.smallrye.config:smallrye-config-core")
 
@@ -36,7 +36,7 @@ dependencies {
   testFixturesApi(platform(libs.junit.bom))
   testFixturesApi(libs.bundles.junit.testing)
 
-  testFixturesApi(enforcedPlatform(libs.quarkus.bom))
+  testFixturesApi(quarkusPlatform(project))
   testFixturesApi("io.quarkus:quarkus-core")
 
   testRuntimeOnly(libs.logback.classic)

--- a/servers/quarkus-distcache/build.gradle.kts
+++ b/servers/quarkus-distcache/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
   implementation(project(":nessie-versioned-storage-common"))
   implementation(project(":nessie-network-tools"))
 
-  implementation(enforcedPlatform(libs.quarkus.bom))
+  implementation(quarkusPlatform(project))
   implementation("io.quarkus:quarkus-core")
   implementation("io.quarkus:quarkus-rest")
 

--- a/servers/quarkus-ext/deployment/build.gradle.kts
+++ b/servers/quarkus-ext/deployment/build.gradle.kts
@@ -19,7 +19,7 @@ plugins { id("nessie-conventions-java21") }
 publishingHelper { mavenName = "Nessie - Quarkus Extension (Deployment)" }
 
 dependencies {
-  implementation(enforcedPlatform(libs.quarkus.bom))
+  implementation(quarkusPlatform(project))
   implementation("io.quarkus:quarkus-arc-deployment")
   implementation("io.quarkus:quarkus-core-deployment")
   annotationProcessor("io.quarkus:quarkus-extension-processor")

--- a/servers/quarkus-ext/runtime/build.gradle.kts
+++ b/servers/quarkus-ext/runtime/build.gradle.kts
@@ -16,6 +16,11 @@
 
 plugins {
   alias(libs.plugins.quarkus.extension)
+    .version(
+      libs.plugins.quarkus.extension.map {
+        System.getProperty("quarkus.custom.version", it.version.requiredVersion)
+      }
+    )
   id("nessie-conventions-java21")
 }
 

--- a/servers/quarkus-ext/runtime/build.gradle.kts
+++ b/servers/quarkus-ext/runtime/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 publishingHelper { mavenName = "Nessie - Quarkus Extension (Runtime)" }
 
 dependencies {
-  implementation(enforcedPlatform(libs.quarkus.bom))
+  implementation(quarkusPlatform(project))
   implementation("io.quarkus:quarkus-arc")
 }
 

--- a/servers/quarkus-rest/build.gradle.kts
+++ b/servers/quarkus-rest/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
   implementation(project(":nessie-model"))
   implementation(project(":nessie-rest-common"))
 
-  implementation(enforcedPlatform(libs.quarkus.bom))
+  implementation(quarkusPlatform(project))
   implementation("io.quarkus:quarkus-core")
   implementation("io.quarkus:quarkus-rest")
   implementation("io.quarkus:quarkus-rest-jackson")

--- a/servers/quarkus-secrets/build.gradle.kts
+++ b/servers/quarkus-secrets/build.gradle.kts
@@ -35,8 +35,8 @@ dependencies {
   implementation(project(":nessie-catalog-secrets-vault"))
   implementation(project(":nessie-quarkus-config"))
 
-  implementation(enforcedPlatform(libs.quarkus.bom))
-  implementation(enforcedPlatform(libs.quarkus.amazon.services.bom))
+  implementation(quarkusPlatform(project))
+  implementation(quarkusExtension(project, "amazon-services"))
   implementation("io.quarkus:quarkus-core")
   implementation("io.quarkus:quarkus-jackson")
   implementation("io.micrometer:micrometer-core")
@@ -48,10 +48,10 @@ dependencies {
     exclude("commons-logging", "commons-logging")
   }
 
-  implementation(enforcedPlatform(libs.quarkus.amazon.services.bom))
+  implementation(quarkusExtension(project, "amazon-services"))
   implementation("io.quarkiverse.amazonservices:quarkus-amazon-secretsmanager")
 
-  implementation(enforcedPlatform(libs.quarkus.google.cloud.services.bom))
+  implementation(quarkusExtension(project, "google-cloud-services"))
   implementation("io.quarkiverse.googlecloudservices:quarkus-google-cloud-secret-manager")
 
   implementation(libs.quarkus.vault)
@@ -67,7 +67,7 @@ dependencies {
   testFixturesApi(platform(libs.junit.bom))
   testFixturesApi(libs.bundles.junit.testing)
 
-  testFixturesApi(enforcedPlatform(libs.quarkus.bom))
+  testFixturesApi(quarkusPlatform(project))
   testFixturesApi("io.quarkus:quarkus-core")
 
   testRuntimeOnly(libs.logback.classic)

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -66,8 +66,8 @@ dependencies {
   compileOnly(project(":nessie-quarkus-ext-deployment"))
   implementation(project(":nessie-quarkus-ext"))
 
-  implementation(enforcedPlatform(libs.quarkus.bom))
-  implementation(enforcedPlatform(libs.quarkus.amazon.services.bom))
+  implementation(quarkusPlatform(project))
+  implementation(quarkusExtension(project, "amazon-services"))
   implementation("io.quarkus:quarkus-rest")
   implementation("io.quarkus:quarkus-rest-jackson")
   implementation("io.quarkus:quarkus-reactive-routes")
@@ -133,7 +133,7 @@ dependencies {
     // [com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava(compile)]
     exclude("com.google.guava")
   }
-  testFixturesApi(enforcedPlatform(libs.quarkus.bom))
+  testFixturesApi(quarkusPlatform(project))
   testFixturesImplementation("com.fasterxml.jackson.core:jackson-annotations")
   testFixturesApi("io.quarkus:quarkus-test-security")
   testFixturesApi("io.quarkus:quarkus-test-oidc-server")

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -19,6 +19,11 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
   alias(libs.plugins.quarkus)
+    .version(
+      libs.plugins.quarkus.asProvider().map {
+        System.getProperty("quarkus.custom.version", it.version.requiredVersion)
+      }
+    )
   id("nessie-conventions-quarkus")
   id("nessie-license-report")
 }

--- a/servers/quarkus-tests/build.gradle.kts
+++ b/servers/quarkus-tests/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
   implementation(project(":nessie-versioned-storage-testextension"))
   implementation(project(":nessie-container-spec-helper"))
 
-  implementation(enforcedPlatform(libs.quarkus.bom))
+  implementation(quarkusPlatform(project))
   implementation("io.quarkus:quarkus-junit5")
 
   implementation(platform(libs.testcontainers.bom))
@@ -54,7 +54,7 @@ dependencies {
     exclude("software.amazon.awssdk", "apache-client")
   }
 
-  implementation(platform(libs.quarkus.amazon.services.bom))
+  implementation(quarkusExtension(project, "amazon-services"))
   implementation("io.quarkiverse.amazonservices:quarkus-amazon-dynamodb")
 
   implementation(libs.testcontainers.keycloak)

--- a/tools/server-admin/build.gradle.kts
+++ b/tools/server-admin/build.gradle.kts
@@ -67,8 +67,8 @@ dependencies {
 
   implementation(libs.guava)
 
-  implementation(enforcedPlatform(libs.quarkus.bom))
-  implementation(enforcedPlatform(libs.quarkus.amazon.services.bom))
+  implementation(quarkusPlatform(project))
+  implementation(quarkusExtension(project, "amazon-services"))
   implementation("io.quarkus:quarkus-picocli")
 
   implementation(platform(libs.jackson.bom))
@@ -100,7 +100,7 @@ dependencies {
   intTestImplementation(project(":nessie-versioned-storage-dynamodb2-tests"))
   intTestImplementation(project(":nessie-multi-env-test-engine"))
   testFixturesApi(project(":nessie-versioned-storage-testextension"))
-  testFixturesApi(enforcedPlatform(libs.quarkus.bom))
+  testFixturesApi(quarkusPlatform(project))
   testFixturesApi("io.quarkus:quarkus-junit5")
   testFixturesApi(libs.microprofile.openapi)
 

--- a/tools/server-admin/build.gradle.kts
+++ b/tools/server-admin/build.gradle.kts
@@ -19,6 +19,11 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
   alias(libs.plugins.quarkus)
+    .version(
+      libs.plugins.quarkus.asProvider().map {
+        System.getProperty("quarkus.custom.version", it.version.requiredVersion)
+      }
+    )
   id("nessie-conventions-quarkus")
   id("nessie-license-report")
 }


### PR DESCRIPTION
Nessie releases use the Quarkus version defined in the `libs` version catalog using Gradle's `enforcedPlatform`
dependency constraint mechanism. This means that the Quarkus version used by default is fixed and the dependencies
defined by the Quarkus platform are enforced.

For testing purposes, it is possible to use a different Quarkus version by setting the `quarkus.custom.version`
system property.
It is also possible to not enforce the Quarkus platform versions, i.e. using Gradle's `platform` dependency
constraint mechanism, by setting the `quarkus.custom.noEnforcePlatform` system property to `true`.

Example, to test against a pre-release Quarkus 3.28.0.CR1 version:
```bash
./gradlew -Dquarkus.custom.version=3.28.0.CR1 -Dquarkus.custom.noEnforcedPlatform=true test
./gradlew -Dquarkus.custom.version=3.28.0.CR1 -Dquarkus.custom.noEnforcedPlatform=true intTest
```