### PR TITLE
Iceberg 1.10: S3 remote signing can no longer be "reconfigured"

### DIFF
--- a/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/AbstractIcebergCatalogIntTests.java
+++ b/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/AbstractIcebergCatalogIntTests.java
@@ -19,10 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.common.WithTestResource;
 import java.net.URI;
 import java.net.URL;
 import org.junit.jupiter.api.Test;
 
+@WithTestResource(IcebergResourceLifecycleManager.ForIntegrationTests.class)
 public abstract class AbstractIcebergCatalogIntTests extends AbstractIcebergCatalogTests {
 
   @Test

--- a/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/auth/AbstractAuthEnabledTests.java
+++ b/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/auth/AbstractAuthEnabledTests.java
@@ -34,11 +34,11 @@ import org.projectnessie.quarkus.tests.profiles.KeycloakTestResourceLifecycleMan
 import org.projectnessie.quarkus.tests.profiles.KeycloakTestResourceLifecycleManager.KeycloakClientId;
 import org.projectnessie.quarkus.tests.profiles.KeycloakTestResourceLifecycleManager.KeycloakClientSecret;
 import org.projectnessie.quarkus.tests.profiles.KeycloakTestResourceLifecycleManager.KeycloakTokenEndpointUri;
-import org.projectnessie.server.catalog.AbstractIcebergCatalogTests;
+import org.projectnessie.server.catalog.AbstractIcebergCatalogIntTests;
 import org.projectnessie.server.catalog.ObjectStorageMockTestResourceLifecycleManager;
 
 @WithTestResource(parallel = true, value = KeycloakTestResourceLifecycleManager.class)
-public abstract class AbstractAuthEnabledTests extends AbstractIcebergCatalogTests {
+public abstract class AbstractAuthEnabledTests extends AbstractIcebergCatalogIntTests {
 
   @KeycloakTokenEndpointUri protected URI tokenEndpoint;
 

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/AbstractIcebergCatalogUnitTests.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/AbstractIcebergCatalogUnitTests.java
@@ -55,7 +55,7 @@ import org.projectnessie.model.Operation;
 import org.projectnessie.objectstoragemock.HeapStorageBucket;
 import org.projectnessie.server.catalog.ObjectStorageMockTestResourceLifecycleManager.AccessCheckHandlerHolder;
 
-@WithTestResource(IcebergResourceLifecycleManager.class)
+@WithTestResource(IcebergResourceLifecycleManager.ForUnitTests.class)
 public abstract class AbstractIcebergCatalogUnitTests extends AbstractIcebergCatalogTests {
 
   HeapStorageBucket heapStorageBucket;

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/AbstractIcebergViewCatalogUnitTests.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/AbstractIcebergViewCatalogUnitTests.java
@@ -19,7 +19,7 @@ import io.quarkus.test.common.WithTestResource;
 import org.junit.jupiter.api.BeforeEach;
 import org.projectnessie.objectstoragemock.HeapStorageBucket;
 
-@WithTestResource(IcebergResourceLifecycleManager.class)
+@WithTestResource(IcebergResourceLifecycleManager.ForUnitTests.class)
 public abstract class AbstractIcebergViewCatalogUnitTests extends AbstractIcebergViewCatalogTests {
 
   HeapStorageBucket heapStorageBucket;

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/AdlsUnitTestProfile.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/AdlsUnitTestProfile.java
@@ -29,7 +29,7 @@ public class AdlsUnitTestProfile implements QuarkusTestProfile {
   public List<TestResourceEntry> testResources() {
     return List.of(
         new TestResourceEntry(ObjectStorageMockTestResourceLifecycleManager.class),
-        new TestResourceEntry(IcebergResourceLifecycleManager.class));
+        new TestResourceEntry(IcebergResourceLifecycleManager.ForUnitTests.class));
   }
 
   @Override

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/GcsUnitTestProfile.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/GcsUnitTestProfile.java
@@ -29,7 +29,7 @@ public class GcsUnitTestProfile implements QuarkusTestProfile {
   public List<TestResourceEntry> testResources() {
     return List.of(
         new TestResourceEntry(ObjectStorageMockTestResourceLifecycleManager.class),
-        new TestResourceEntry(IcebergResourceLifecycleManager.class));
+        new TestResourceEntry(IcebergResourceLifecycleManager.ForUnitTests.class));
   }
 
   @Override

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/S3UnitTestProfiles.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/S3UnitTestProfiles.java
@@ -53,7 +53,7 @@ public abstract class S3UnitTestProfiles implements QuarkusTestProfile {
         new TestResourceEntry(
             ObjectStorageMockTestResourceLifecycleManager.class,
             ImmutableMap.of(INIT_ADDRESS, "localhost")),
-        new TestResourceEntry(IcebergResourceLifecycleManager.class));
+        new TestResourceEntry(IcebergResourceLifecycleManager.ForUnitTests.class));
   }
 
   @Override

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/s3/TestVendedS3CredentialsExpiry.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/s3/TestVendedS3CredentialsExpiry.java
@@ -45,7 +45,7 @@ import org.projectnessie.server.catalog.ObjectStorageMockTestResourceLifecycleMa
 import org.projectnessie.server.catalog.S3UnitTestProfiles;
 
 @WithTestResource(ObjectStorageMockTestResourceLifecycleManager.class)
-@WithTestResource(IcebergResourceLifecycleManager.class)
+@WithTestResource(IcebergResourceLifecycleManager.ForUnitTests.class)
 @QuarkusTest
 @TestProfile(TestVendedS3CredentialsExpiry.Profile.class)
 public class TestVendedS3CredentialsExpiry {

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/IcebergResourceLifecycleManager.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/IcebergResourceLifecycleManager.java
@@ -15,20 +15,26 @@
  */
 package org.projectnessie.server.catalog;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.iceberg.aws.s3.signer.S3V4RestSignerClient;
+import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.auth.AuthManager;
 import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Attempt to clean up per-test resources registered against JVM global instances, threads and
- * related objects that are effectively held forever and cause OOMs.
+ * Clean up per-test resources registered against JVM global instances, threads and other statically
+ * held objects that are effectively held forever. Some of these can eventually cause OOMs
+ * especially in Quarkus unit tests.
  */
-public class IcebergResourceLifecycleManager implements QuarkusTestResourceLifecycleManager {
+public abstract class IcebergResourceLifecycleManager
+    implements QuarkusTestResourceLifecycleManager {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(IcebergResourceLifecycleManager.class);
@@ -38,28 +44,69 @@ public class IcebergResourceLifecycleManager implements QuarkusTestResourceLifec
     return Map.of();
   }
 
-  @Override
-  public void stop() {
+  /**
+   * Calls {@link #cleanupHadoopFileSystemStatisticsCleanerThread()}, {@link
+   * #stopIcebergWorkerPools()}, {@link #cleanupS3V4RestSignerClient()} and {@link
+   * #cleanupShutdownHooks()}.
+   */
+  public static class ForUnitTests extends IcebergResourceLifecycleManager {
+    @Override
+    public void stop() {
+      // Handling S3V4RestSignerClient in Quarkus unit tests is probably not necessary, as the class
+      // loaders for each unit are isolated.
+      // But it does not harm, so better to be on the "safe side".
+      cleanupS3V4RestSignerClient();
+      stopIcebergWorkerPools();
+      cleanupHadoopFileSystemStatisticsCleanerThread();
+      cleanupShutdownHooks();
+    }
+  }
+
+  /**
+   * Only clean up the {@link S3V4RestSignerClient} static fields which keep auth information, which
+   * breaks tests running with different auth setups. This is caused by <a
+   * href="https://github.com/apache/iceberg/pull/13215">PR 13215</a> since Iceberg 1.10. This
+   * implementation does not stop any thread pool or anything else that's handled for {@link
+   * ForUnitTests unit tests}.
+   */
+  public static class ForIntegrationTests extends IcebergResourceLifecycleManager {
+    @Override
+    public void stop() {
+      cleanupS3V4RestSignerClient();
+    }
+  }
+
+  /** Stops the delete and "common" worker pools in {@link ThreadPools}. */
+  public static void stopIcebergWorkerPools() {
     ThreadPools.getDeleteWorkerPool().shutdown();
     ThreadPools.getWorkerPool().shutdown();
+    LOGGER.info("Stopped Iceberg's delete + worker thread pools");
+  }
 
-    // Stop Hadoop's stats-cleaner thread, would never stop.
+  /** Stop Hadoop's stats-cleaner, it would never stop on its own. */
+  public static void cleanupHadoopFileSystemStatisticsCleanerThread() {
     try {
       Field statsDataCleanerThreadField =
           FileSystem.Statistics.class.getDeclaredField("STATS_DATA_CLEANER");
       statsDataCleanerThreadField.setAccessible(true);
       Thread statsDataCleanerThread = (Thread) statsDataCleanerThreadField.get(null);
       statsDataCleanerThread.interrupt();
+      LOGGER.info("Stopped Hadoop's stats-cleaner thread");
     } catch (Exception e) {
       LOGGER.error(
           "Failed to interrupt Thread org.apache.hadoop.fs.FileSystem.Statistics.STATS_DATA_CLEANER",
           e);
     }
+  }
 
-    // Stop other thread pools, registered for shutdown via Guava's
-    // MoreExecutors.Application.addDelayedShutdownHook.
-    // This also stops Iceberg's thread pools, those would be cleaned up at JVM shutdown,
-    // see org.apache.iceberg.util.ThreadPools.
+  /**
+   * Stop other thread pools, registered for shutdown via Guava's {@link
+   * com.google.common.util.concurrent.MoreExecutors#addDelayedShutdownHook}. This also stops
+   * Iceberg's thread pools, those would be cleaned up at JVM shutdown, see {@link
+   * org.apache.iceberg.util.ThreadPools}.
+   */
+  @SuppressWarnings("CallToThreadRun")
+  public static void cleanupShutdownHooks() {
     try {
       Class<?> c = Class.forName("java.lang.ApplicationShutdownHooks");
       Field hooksField = c.getDeclaredField("hooks");
@@ -75,13 +122,47 @@ public class IcebergResourceLifecycleManager implements QuarkusTestResourceLifec
         try {
           hook.run();
         } catch (Exception e) {
-          LOGGER.error("Failed to run delayed shutdown hook " + hook.getName(), e);
+          LOGGER.error("Failed to run delayed shutdown hook {}", hook.getName(), e);
         } finally {
           Runtime.getRuntime().removeShutdownHook(hook);
         }
       }
+      LOGGER.info("Interrupt cleanup application shutdown hooks");
     } catch (Exception e) {
       LOGGER.error("Failed to interrupt cleanup application shutdown hooks", e);
+    }
+  }
+
+  public static void cleanupS3V4RestSignerClient() {
+    try {
+      Class<S3V4RestSignerClient> c = S3V4RestSignerClient.class;
+
+      Field f = c.getDeclaredField("authManager");
+      f.setAccessible(true);
+      AuthManager authManager = (AuthManager) f.get(null);
+      if (authManager != null) {
+        f.set(null, null);
+        authManager.close();
+      }
+
+      f = c.getDeclaredField("httpClient");
+      f.setAccessible(true);
+      RESTClient httpClient = (RESTClient) f.get(null);
+      if (httpClient != null) {
+        f.set(null, null);
+        httpClient.close();
+      }
+
+      f = c.getDeclaredField("SIGNED_COMPONENT_CACHE");
+      f.setAccessible(true);
+      Cache<?, ?> cache = (Cache<?, ?>) f.get(null);
+      if (cache != null) {
+        cache.invalidateAll();
+      }
+
+      LOGGER.info("Cleaned up {}", c.getName());
+    } catch (Exception e) {
+      LOGGER.error("Failed to clean up {}", S3V4RestSignerClient.class.getName(), e);
     }
   }
 }


### PR DESCRIPTION
Since Iceberg 1.10 it is no longer possible to use different auth configurations with S3 remote signing. This is caused by https://github.com/apache/iceberg/pull/13215 which keeps auth related configuration in static fields in `o.a.i.aws.s3.signer.S3V4RestSignerClient`.