### PR TITLE
CI/Caching: Fix Gradle cache retention

### DIFF
--- a/.github/actions/ci-incr-build-cache-prepare/action.yml
+++ b/.github/actions/ci-incr-build-cache-prepare/action.yml
@@ -28,6 +28,27 @@ runs:
           echo "GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE=${{ inputs.job-instance }}" >> ${GITHUB_ENV}
         fi
 
+    - name: Configure Gradle cache retention settings
+      # Without these settings, the Gradle Setup action will evict effectively all "restored incremental" entries,
+      # as it will remove all cache entries created before the start-time of the "Store Gradle Cache" job.
+      # The total size of GitHub caches for each repository is limited to 10GB, which means that we have to use
+      # more aggressive retention settings to keep the size of the Gradle cache stored in GitHub at an appropriate
+      # size.
+      shell: bash
+      run: |
+        mkdir -p ~/.gradle/init.d
+        cat > ~/.gradle/init.d/cache-settings.gradle.kts <<!
+        beforeSettings {
+          caches {
+            releasedWrappers.setRemoveUnusedEntriesAfterDays(5)
+            snapshotWrappers.setRemoveUnusedEntriesAfterDays(1)
+            downloadedResources.setRemoveUnusedEntriesAfterDays(2)
+            createdResources.setRemoveUnusedEntriesAfterDays(5)
+            buildCache.setRemoveUnusedEntriesAfterDays(5)
+          }
+        }
+        !
+
     - name: Gradle / Setup
       uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
       with:
@@ -55,7 +76,7 @@ runs:
         if [[ -d ~/downloaded-artifacts/ ]] ; then
           find ~/downloaded-artifacts/ -type f -name "ci-gradle-caches-*-${{ inputs.java-version }}.tar" | while read arch ; do
             echo "Adding archive content from $arch ..."
-            (cd ~/.gradle/caches/ ; tar xf $arch)
+            (cd ~/.gradle/caches/ ; tar xf $arch --atime-preserve)
           done
         else
           echo "No previous build cache artifacts downloaded."

--- a/.github/actions/ci-incr-build-cache-save/action.yml
+++ b/.github/actions/ci-incr-build-cache-save/action.yml
@@ -31,7 +31,6 @@ runs:
             -path './[0-9]*/kotlin-dsl/*' -or \
             -path './jars-*/*' -or \
             -path './modules-*/files-*/*' -or \
-            -path './modules-*/files-*/*' -or \
             -path './build-cache-*/*' \
             ')' | grep -v '[.]lock$'  > ~/ci-gradle-caches-diff || true
           echo "Identified $(wc -l < ~/ci-gradle-caches-diff) changed/added files in caches/"
@@ -45,7 +44,7 @@ runs:
           fi
           echo "::endgroup::"
         fi
-    - name: Archive code-checks incremental
+    - name: Archive incremental Gradle caches
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ci-gradle-caches-${{ inputs.job-name }}-${{ inputs.java-version }}

--- a/.github/actions/dev-tool-java/action.yml
+++ b/.github/actions/dev-tool-java/action.yml
@@ -36,17 +36,3 @@ runs:
         # See https://www.testcontainers.org/features/configuration/#disabling-the-startup-checks
         checks.disable=true
         !
-    - name: Setup gradle.properties
-      shell: bash
-      run: |
-        mkdir -p ~/.gradle/init.d
-        cat > ~/.gradle/init.d/cache-settings.gradle.kts <<!
-        beforeSettings {
-          caches {
-            releasedWrappers.setRemoveUnusedEntriesAfterDays(2)
-            snapshotWrappers.setRemoveUnusedEntriesAfterDays(1)
-            downloadedResources.setRemoveUnusedEntriesAfterDays(5)
-            createdResources.setRemoveUnusedEntriesAfterDays(2)
-          }
-        }
-        !

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1033,7 +1033,4 @@ jobs:
         with:
           cache-read-only: false
 
-      - name: Trigger Gradle home cleanup
-        run: ./gradlew --no-daemon :showVersion
-
-      # Note: the "Post Gradle invocation" archives the updated build cache.
+      # Note: the "Post ..."-step cleans up stale cache entries and archives the updated build cache.


### PR DESCRIPTION
Older versions of Gradle's setup-gradle action did not actively trigger stale cache entry cleanup, which is why there was a separate step "Trigger Gradle home cleanup" in `gradle.yml`. Nowadays, that action triggers a "noop build" to explicitly trigger stale cache entry cleanup, but uses somewhat different defaults than [described here](https://docs.gradle.org/current/userguide/directory_layout.html#dir:gradle_user_home:configure_cache_cleanup).

This change adds an explicit configuration for Gradle cache cleanup/retention with reasonable values considering the total 10GB limit for all GitHub caches per repository.

The change described above lead to a behavioral change, which evicts all non-accessed cache entries within the current GH workflow job, which effectively evicted all cache entries from dependent jobs - in other words: the (build) cache was nearly empty, leading to full rebuilds. This behavior could be observed in the output of the "Post Collect partial Gradle build caches"-step in the log message "Build cache (/home/runner/.gradle/caches/build-cache-1) removing files not accessed on or after ..." showing the timestamp when the setup-gradle action was started.