### PR TITLE
Support parsing compressed metadata files in registerTable

### DIFF
--- a/catalog/service/common/src/main/java/org/projectnessie/catalog/service/files/MetadataUtil.java
+++ b/catalog/service/common/src/main/java/org/projectnessie/catalog/service/files/MetadataUtil.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.service.files;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.GZIPInputStream;
+import org.projectnessie.catalog.files.api.ObjectIO;
+import org.projectnessie.storage.uri.StorageUri;
+
+public final class MetadataUtil {
+  private MetadataUtil() {}
+
+  public static InputStream readMetadata(ObjectIO io, StorageUri uri) throws IOException {
+    boolean compressed =
+        uri.requiredPath().endsWith(".gz") || uri.requiredPath().endsWith(".gz.metadata.json");
+    final InputStream input = io.readObject(uri);
+    if (compressed) {
+      return new GZIPInputStream(input);
+    }
+    return input;
+  }
+}

--- a/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/ImportSnapshotWorker.java
+++ b/catalog/service/impl/src/main/java/org/projectnessie/catalog/service/impl/ImportSnapshotWorker.java
@@ -17,6 +17,7 @@ package org.projectnessie.catalog.service.impl;
 
 import static org.projectnessie.catalog.formats.iceberg.nessie.NessieModelIceberg.icebergTableSnapshotToNessie;
 import static org.projectnessie.catalog.formats.iceberg.nessie.NessieModelIceberg.icebergViewSnapshotToNessie;
+import static org.projectnessie.catalog.service.files.MetadataUtil.readMetadata;
 import static org.projectnessie.catalog.service.impl.Util.nessieIdToObjId;
 import static org.projectnessie.catalog.service.impl.Util.objIdToNessieId;
 import static org.projectnessie.catalog.service.objtypes.EntityObj.entityObjIdForContent;
@@ -29,7 +30,6 @@ import java.time.Instant;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.LongSupplier;
-import java.util.zip.GZIPInputStream;
 import org.projectnessie.catalog.formats.iceberg.manifest.IcebergFileFormat;
 import org.projectnessie.catalog.formats.iceberg.meta.IcebergJson;
 import org.projectnessie.catalog.formats.iceberg.meta.IcebergTableMetadata;
@@ -266,16 +266,7 @@ final class ImportSnapshotWorker {
 
   private <T> T icebergMetadata(StorageUri metadataLocation, Class<? extends T> metadataType)
       throws IOException {
-    InputStream input = metadataInputStream(metadataLocation);
+    InputStream input = readMetadata(taskRequest.objectIO(), metadataLocation);
     return IcebergJson.objectMapper().readValue(input, metadataType);
-  }
-
-  private InputStream metadataInputStream(StorageUri metadataLocation) throws IOException {
-    final InputStream input = taskRequest.objectIO().readObject(metadataLocation);
-    if (metadataLocation.requiredPath().endsWith(".gz")
-        || metadataLocation.requiredPath().endsWith(".gz.metadata.json")) {
-      return new GZIPInputStream(input);
-    }
-    return input;
   }
 }

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1TableResource.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergApiV1TableResource.java
@@ -37,6 +37,7 @@ import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpda
 import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.SetDefaultSortOrder.setDefaultSortOrder;
 import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.SetProperties.setProperties;
 import static org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate.UpgradeFormatVersion.upgradeFormatVersion;
+import static org.projectnessie.catalog.service.files.MetadataUtil.readMetadata;
 import static org.projectnessie.catalog.service.rest.TableRef.tableRef;
 import static org.projectnessie.model.Content.Type.ICEBERG_TABLE;
 import static org.projectnessie.model.Reference.ReferenceType.BRANCH;
@@ -467,7 +468,7 @@ public class IcebergApiV1TableResource extends IcebergApiV1ResourceBase {
 
     IcebergTableMetadata tableMetadata;
     try (InputStream metadataInput =
-        objectIO.readObject(StorageUri.of(registerTableRequest.metadataLocation()))) {
+        readMetadata(objectIO, StorageUri.of(registerTableRequest.metadataLocation()))) {
       tableMetadata =
           IcebergJson.objectMapper().readValue(metadataInput, IcebergTableMetadata.class);
     }


### PR DESCRIPTION
Add `MetadataUtil` to hold common code for reading metadata files.

Use it both for reading prior snapshots and for registerTable API calls.

Note: new metadata files created by Nessie remain uncompressed.

Fixes #11425