### PR TITLE
Fix javadocs for checkstyle, add `--continue` to CI jobs, remove retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,28 +81,31 @@ jobs:
             -x :nessie-server-admin-tool:compileAll \
             -x :nessie-events-quarkus:compileAll \
             -x :nessie-events-ri:compileAll \
+            --continue \
             --scan
 
       - name: Gradle / Compile Quarkus
         run: |
-          # 2 Retries - to mitigate https://github.com/gradle/gradle/issues/25751
-          ./gradlew :nessie-quarkus:compileAll :nessie-server-admin-tool:compileAll :nessie-events-quarkus:compileAll :nessie-events-ri:compileAll --scan || \
-            ./gradlew :nessie-quarkus:compileAll :nessie-server-admin-tool:compileAll :nessie-events-quarkus:compileAll :nessie-events-ri:compileAll --scan || \
-            ./gradlew :nessie-quarkus:compileAll :nessie-server-admin-tool:compileAll :nessie-events-quarkus:compileAll :nessie-events-ri:compileAll --scan
+          ./gradlew :nessie-quarkus:compileAll \
+            :nessie-server-admin-tool:compileAll \
+            :nessie-events-quarkus:compileAll \
+            :nessie-events-ri:compileAll \
+            --continue \
+            --scan
 
       - name: Gradle / Code checks
-        run: ./gradlew codeChecks --scan
+        run: ./gradlew codeChecks --continue --scan
 
       - name: Gradle / Assemble
-        run: ./gradlew assemble --scan
+        run: ./gradlew assemble --continue --scan
 
       - name: Gradle / Publish to Maven local
-        run: ./gradlew publishToMavenLocal --scan
+        run: ./gradlew publishToMavenLocal --continue --scan
 
       # This is a rather quick one and uses the output of 'publishToMavenLocal', which uses the
       # outputs of 'assemble'
       - name: Gradle / build tools integration tests
-        run: ./gradlew buildToolsIntegrationTest
+        run: ./gradlew buildToolsIntegrationTest --continue
 
       - name: Save partial Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-save
@@ -125,7 +128,17 @@ jobs:
         uses: ./.github/actions/ci-incr-build-cache-prepare
 
       - name: Gradle / test
-        run: ./gradlew test :nessie-client:check -x :nessie-client:intTest -x :nessie-quarkus:test -x :nessie-server-admin-tool:test -x :nessie-events-quarkus:test -x :nessie-events-ri:test --scan
+        run: |
+          ./gradlew \
+            test \
+            :nessie-client:check \
+            -x :nessie-client:intTest \
+            -x :nessie-quarkus:test \
+            -x :nessie-server-admin-tool:test \
+            -x :nessie-events-quarkus:test \
+            -x :nessie-events-ri:test \
+            --continue \
+            --scan
 
       - name: Capture Test Reports
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -159,24 +172,15 @@ jobs:
 
       - name: Gradle / Test Quarkus Server
         run: |
-          # 2 Retries - to mitigate https://github.com/gradle/gradle/issues/25751
-          ./gradlew :nessie-quarkus:test --scan || \
-            ./gradlew :nessie-quarkus:test --scan || \
-            ./gradlew :nessie-quarkus:test --scan
+          ./gradlew :nessie-quarkus:test --scan
 
       - name: Gradle / Test Quarkus Events
         run: |
-          # 2 Retries - to mitigate https://github.com/gradle/gradle/issues/25751
-          ./gradlew :nessie-events-quarkus:test --scan || \
-            ./gradlew :nessie-events-quarkus:test --scan || \
-            ./gradlew :nessie-events-quarkus:test --scan
+          ./gradlew :nessie-events-quarkus:test --scan
 
       - name: Gradle / Test Quarkus Events RI
         run: |
-          # 2 Retries - to mitigate https://github.com/gradle/gradle/issues/25751
-          ./gradlew :nessie-events-ri:test --scan || \
-            ./gradlew :nessie-events-ri:test --scan || \
-            ./gradlew :nessie-events-ri:test --scan
+          ./gradlew :nessie-events-ri:test --scan
 
       - name: Dump quarkus.log
         if: ${{ failure() }}
@@ -241,6 +245,7 @@ jobs:
             $(cat ../persist-prjs.txt) \
             $(cat ../storage-prjs.txt) \
             $(cat ../spark-prjs.txt) \
+            --continue \
             --scan
 
       - name: Capture Test Reports
@@ -283,7 +288,7 @@ jobs:
           ./gradlew :listProjectsWithPrefix --prefix :nessie-versioned-persist- --output ../persist-prjs.txt
           echo "::endgroup::"
 
-          ./gradlew $(cat ../persist-prjs.txt) $(cat ../storage-prjs.txt) --scan
+          ./gradlew $(cat ../persist-prjs.txt) $(cat ../storage-prjs.txt) --continue --scan
 
       - name: Capture Test Reports
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -326,7 +331,7 @@ jobs:
           ./gradlew :listProjectsWithPrefix --prefix :nessie-spark-ext --output ../spark-prjs.txt
           echo "::endgroup::"
 
-          ./gradlew $(cat ../spark-prjs.txt) --scan
+          ./gradlew $(cat ../spark-prjs.txt) --continue --scan
 
       - name: Capture Test Reports
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -360,10 +365,7 @@ jobs:
 
       - name: Gradle / intTest Quarkus Server
         run:
-          # 2 Retries - to mitigate https://github.com/gradle/gradle/issues/25751
-          ./gradlew :nessie-quarkus:intTest --scan || \
-            ./gradlew :nessie-quarkus:intTest --scan || \
-            ./gradlew :nessie-quarkus:intTest --scan
+          ./gradlew :nessie-quarkus:intTest --scan
 
       - name: Dump quarkus.log
         if: ${{ failure() }}
@@ -407,10 +409,7 @@ jobs:
 
       - name: Gradle / intTest Admin Tool
         run:
-          # 2 Retries - to mitigate https://github.com/gradle/gradle/issues/25751
-          ./gradlew :nessie-server-admin-tool:intTest --scan || \
-            ./gradlew :nessie-server-admin-tool:intTest --scan || \
-            ./gradlew :nessie-server-admin-tool:intTest --scan
+          ./gradlew :nessie-server-admin-tool:intTest --scan
 
       - name: Dump quarkus.log
         if: ${{ failure() }}
@@ -454,10 +453,7 @@ jobs:
 
       - name: Gradle / intTest Quarkus Events
         run:
-          # 2 Retries - to mitigate https://github.com/gradle/gradle/issues/25751
-          ./gradlew :nessie-events-quarkus:intTest --scan || \
-            ./gradlew :nessie-events-quarkus:intTest --scan || \
-            ./gradlew :nessie-events-quarkus:intTest --scan
+          ./gradlew :nessie-events-quarkus:intTest --scan
 
       - name: Dump quarkus.log
         if: ${{ failure() }}
@@ -945,10 +941,22 @@ jobs:
         run: ./gradlew :iceberg:iceberg-nessie:test --scan
 
       - name: Nessie Spark 3.4 / 2.13 Extensions test
-        run: ./gradlew -DscalaVersion=2.13 :nessie:nessie-iceberg:nessie-spark-extensions-3.4_2.13:test :nessie:nessie-iceberg:nessie-spark-extensions-3.4_2.13:intTest --scan
+        run: |
+          ./gradlew \
+            -DscalaVersion=2.13 \
+            :nessie:nessie-iceberg:nessie-spark-extensions-3.4_2.13:test \
+            :nessie:nessie-iceberg:nessie-spark-extensions-3.4_2.13:intTest \
+            --continue \
+            --scan
 
       - name: Nessie Spark 3.5 / 2.13 Extensions test
-        run: ./gradlew -DscalaVersion=2.13 :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:test :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:intTest --scan
+        run: |
+          ./gradlew \
+            -DscalaVersion=2.13 \
+            :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:test \
+            :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:intTest \
+            --continue \
+            --scan
 
       #- name: Publish Nessie + Iceberg to local Maven repo
       #  run: ./gradlew publishLocal --scan
@@ -967,7 +975,7 @@ jobs:
       #    !
 
       - name: Tools & Integrations tests
-        run: ./gradlew intTest --scan
+        run: ./gradlew intTest --continue --scan
 
   site:
     name: CI Website

--- a/api/model/src/main/java/org/projectnessie/api/v1/params/ReferencesParams.java
+++ b/api/model/src/main/java/org/projectnessie/api/v1/params/ReferencesParams.java
@@ -26,7 +26,7 @@ import org.projectnessie.model.FetchOption;
 
 /**
  * The purpose of this class is to include optional parameters that can be passed to {@link
- * HttpTreeApi#getAllReferences(ReferencesParams)}
+ * HttpTreeApi#getAllReferences(ReferencesParams)}.
  *
  * <p>For easier usage of this class, there is {@link ReferencesParams#builder()}, which allows
  * configuring/setting the different parameters.

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -270,7 +270,7 @@ public interface VersionStore {
       throws ReferenceNotFoundException, ReferenceAlreadyExistsException;
 
   /**
-   * Delete the provided NamedRef
+   * Delete the provided {@link NamedRef}.
    *
    * <p>Throws exception if the optional hash does not match the provided ref.
    *

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/config/StoreConfig.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/config/StoreConfig.java
@@ -81,7 +81,7 @@ public interface StoreConfig {
 
   /**
    * Whether namespace validation is enabled, changing this to false will break the Nessie
-   * specification!
+   * specification.
    *
    * <p>Committing operations by default enforce that all (parent) namespaces exist.
    *

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Persist.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Persist.java
@@ -369,7 +369,7 @@ public interface Persist {
   void deleteObj(@Nonnull ObjId id);
 
   /**
-   * Deletes multiple objects,
+   * Deletes multiple objects.
    *
    * <p>In case an object failed to be deleted, it is undefined whether other objects have been
    * deleted or not.


### PR DESCRIPTION
* Prepare for #11443
* Add Gradle `--continue` flag (continue on error)
* Remove now superfluous Gradle retries