### PR TITLE
Object-storage-mock: Fix off-by-1 for HTTP range requests

### DIFF
--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/HeapStorageBucket.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/HeapStorageBucket.java
@@ -179,11 +179,11 @@ public class HeapStorageBucket {
           // .storageClass(StorageClass.STANDARD)
           .writer(
               ((range, output) -> {
-                if (range == null) {
+                if (range == null || range.everything()) {
                   output.write(newData);
                 } else {
                   int offset = (int) range.start();
-                  long len = Math.min(newData.length - offset, range.end() - range.start());
+                  long len = Math.min(newData.length - offset, range.length());
                   output.write(newData, offset, (int) len);
                 }
               }));

--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/Range.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/Range.java
@@ -39,6 +39,15 @@ public interface Range {
 
   OptionalLong total();
 
+  default boolean everything() {
+    return start() == 0 && end() == Long.MAX_VALUE;
+  }
+
+  default long length() {
+    var len = end() - start() + 1L;
+    return len < 0 ? Long.MAX_VALUE : len;
+  }
+
   /** Can parse AWS style and "standard" {@code Range} header values. */
   @SuppressWarnings("unused") // JAX-RS factory function
   static Range fromString(String rangeString) {

--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/S3Resource.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/S3Resource.java
@@ -334,10 +334,6 @@ public class S3Resource {
       @HeaderParam(IF_NONE_MATCH) List<String> noneMatch,
       @HeaderParam(IF_MODIFIED_SINCE) Date modifiedSince,
       @HeaderParam(IF_UNMODIFIED_SINCE) Date unmodifiedSince) {
-    if (range != null) {
-      // TODO Iceberg does this :(    return notImplemented();
-    }
-
     return withBucketObject(
         bucketName,
         objectName,


### PR DESCRIPTION
The start and end byte locations of HTTP range request headers are _inclusive_.

If a HTTP Range header is present and specifies 0/9223372036854775807 for start/end, the calculation for the request-length in HeapStorageBucket's object range-request handling was wrong (off by one). As `Long.MAX_VALUE/9223372036854775807 - 0L + 1L` becomes `-1L`, a new function `Range.everything()` was introduced to prevent this overflow.