### PR TITLE
chore(deps): update plugin maven-central-publish to v0.9.0

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -131,9 +131,9 @@ jobs:
         #    https://central.sonatype.org/publish/publish-portal-api/#uploading-a-deployment-bundle
         run: |
           # 2 Retries - to mitigate "HTTP/502 Bad Gateway" issues
-          ./gradlew publishAggregateMavenCentralDeployment -Prelease -Puber-jar --no-scan --stacktrace || \
-            ./gradlew publishAggregateMavenCentralDeployment -Prelease -Puber-jar --no-scan --stacktrace || \
-            ./gradlew publishAggregateMavenCentralDeployment -Prelease -Puber-jar --no-scan --stacktrace
+          ./gradlew publishAllModulesToMavenCentralPortalRepository -Prelease -Puber-jar --no-scan --stacktrace || \
+            ./gradlew publishAllModulesToMavenCentralPortalRepository -Prelease -Puber-jar --no-scan --stacktrace || \
+            ./gradlew publishAllModulesToMavenCentralPortalRepository -Prelease -Puber-jar --no-scan --stacktrace
 
       - name: Generate changelog
         run: ./gradlew --no-scan --quiet --console=plain getChangelog --no-header --no-links > "${ARTIFACTS}/nessie-changelog-${RELEASE_VERSION}.md"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-import io.github.zenhelix.gradle.plugin.MavenCentralUploaderPlugin.Companion.MAVEN_CENTRAL_PORTAL_NAME
-import io.github.zenhelix.gradle.plugin.extension.MavenCentralUploaderExtension
 import io.github.zenhelix.gradle.plugin.extension.PublishingType
-import io.github.zenhelix.gradle.plugin.task.PublishBundleMavenCentralTask
-import io.github.zenhelix.gradle.plugin.task.ZipDeploymentTask
 import java.time.Duration
-import org.gradle.api.publish.plugins.PublishingPlugin.PUBLISH_TASK_GROUP
 import org.gradle.kotlin.dsl.mavenCentralPortal
 import org.jetbrains.changelog.date
 import org.jetbrains.gradle.ext.settings
@@ -82,123 +77,15 @@ mavenCentralPortal {
   // baseUrl = "https://central.sonatype.com"
   uploader {
     // 2 seconds * 3600 = 7200 seconds = 2hrs
-    delayRetriesStatusCheck = Duration.ofSeconds(2)
-    maxRetriesStatusCheck = 3600
-
-    aggregate {
-      // Aggregate submodules into a single archive
-      modules = true
-      // Aggregate publications into a single archive for each module
-      modulePublications = true
-    }
+    statusCheckDelay = Duration.ofSeconds(2)
+    maxStatusChecks = 3600
   }
 }
-
-// The following code aggregates the publishable parts of every module into a single zip.
-// This is necessary to have an "atomic" release of all modules.
-
-val mavenCentralDeploymentZipAggregation by configurations.creating
-
-mavenCentralDeploymentZipAggregation.isTransitive = true
-
-val zipAggregateMavenCentralDeployment by
-  tasks.registering(Zip::class) {
-    group = PUBLISH_TASK_GROUP
-    description = "Generates the aggregated Maven publication zip file."
-
-    inputs.files(mavenCentralDeploymentZipAggregation)
-    from(mavenCentralDeploymentZipAggregation.map { zipTree(it) })
-    // archiveFileName = mavenCentralPortal.deploymentName.orElse(project.name)
-    destinationDirectory.set(layout.buildDirectory.dir("aggregatedDistribution"))
-    doLast { logger.lifecycle("Built aggregated distribution ${archiveFile.get()}") }
-  }
-
-val publishAggregateMavenCentralDeployment by
-  tasks.registering(PublishBundleMavenCentralTask::class) {
-    group = PUBLISH_TASK_GROUP
-    description =
-      "Publishes the aggregated Maven publications $MAVEN_CENTRAL_PORTAL_NAME repository."
-
-    val task = this
-
-    dependsOn(zipAggregateMavenCentralDeployment)
-    inputs.file(zipAggregateMavenCentralDeployment.flatMap { it.archiveFile })
-
-    project.extensions.configure<MavenCentralUploaderExtension> {
-      val ext = this
-      task.baseUrl.set(ext.baseUrl)
-      task.credentials.set(
-        ext.credentials.username.flatMap { username ->
-          ext.credentials.password.map { password ->
-            io.github.zenhelix.gradle.plugin.client.model.Credentials.UsernamePasswordCredentials(
-              username,
-              password,
-            )
-          }
-        }
-      )
-
-      task.publishingType.set(
-        ext.publishingType.map {
-          when (it) {
-            PublishingType.AUTOMATIC ->
-              io.github.zenhelix.gradle.plugin.client.model.PublishingType.AUTOMATIC
-            PublishingType.USER_MANAGED ->
-              io.github.zenhelix.gradle.plugin.client.model.PublishingType.USER_MANAGED
-          }
-        }
-      )
-      task.deploymentName.set(ext.deploymentName)
-
-      task.maxRetriesStatusCheck.set(ext.uploader.maxRetriesStatusCheck)
-      task.delayRetriesStatusCheck.set(ext.uploader.delayRetriesStatusCheck)
-
-      task.zipFile.set(zipAggregateMavenCentralDeployment.flatMap { it.archiveFile })
-    }
-  }
 
 // Configure the 'io.github.zenhelix.maven-central-publish' plugin to all projects
 allprojects.forEach { p ->
   p.pluginManager.withPlugin("maven-publish") {
     p.pluginManager.apply("io.github.zenhelix.maven-central-publish")
-    p.extensions.configure<MavenCentralUploaderExtension> {
-      val aggregatedMavenCentralDeploymentZipPart by p.configurations.creating
-      aggregatedMavenCentralDeploymentZipPart.description = "Maven central publication zip"
-      val aggregatedMavenCentralDeploymentZipPartElements by p.configurations.creating
-      aggregatedMavenCentralDeploymentZipPartElements.description =
-        "Elements for the Maven central publication zip"
-      aggregatedMavenCentralDeploymentZipPartElements.isCanBeResolved = false
-      aggregatedMavenCentralDeploymentZipPartElements.extendsFrom(
-        aggregatedMavenCentralDeploymentZipPart
-      )
-      aggregatedMavenCentralDeploymentZipPartElements.attributes {
-        attribute(
-          Usage.USAGE_ATTRIBUTE,
-          project.getObjects().named(Usage::class.java, "publication"),
-        )
-      }
-
-      val aggregatemavenCentralDeployment by
-        p.tasks.registering {
-          val zip = p.tasks.findByName("zipDeploymentMavenPublication") as ZipDeploymentTask
-          dependsOn(zip)
-          outputs.file(zip.archiveFile.get().asFile)
-        }
-
-      val artifact =
-        p.artifacts.add(
-          aggregatedMavenCentralDeploymentZipPart.name,
-          aggregatemavenCentralDeployment,
-        ) {
-          builtBy(aggregatemavenCentralDeployment)
-        }
-      aggregatedMavenCentralDeploymentZipPart.outgoing.artifact(artifact)
-
-      rootProject.dependencies.add(
-        mavenCentralDeploymentZipAggregation.name,
-        rootProject.dependencies.project(p.path, aggregatedMavenCentralDeploymentZipPart.name),
-      )
-    }
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -158,7 +158,7 @@ zstd-jni = { module = "com.github.luben:zstd-jni", version = "1.5.7-5" }
 [plugins]
 gatling = { id = "io.gatling.gradle", version = "3.14.6" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
-maven-central-publish = { id = "io.github.zenhelix.maven-central-publish", version = "0.8.0" }
+maven-central-publish = { id = "io.github.zenhelix.maven-central-publish", version = "0.9.0" }
 nessie-run = { id = "org.projectnessie", version = "0.32.2" }
 protobuf = { id = "com.google.protobuf", version = "0.9.5" }
 quarkus = { id = "io.quarkus", version.ref = "quarkusPlugin" }


### PR DESCRIPTION
Also update (clean up) the previous custom logic to publish to Maven Central as a single bundle zip, as the functionality is now included in the new plugin version.