### PR TITLE
Prepare for Gradle 9

### DIFF
--- a/build-logic/src/main/kotlin/PublishingHelperPlugin.kt
+++ b/build-logic/src/main/kotlin/PublishingHelperPlugin.kt
@@ -291,10 +291,7 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
           if ((depNode as NodeList).isNotEmpty()) depNode[0] as Node
           else node.appendNode("dependencies")
         project.configurations.getByName("shadow").allDependencies.forEach {
-          @Suppress("DEPRECATION")
-          if (
-            (it is ProjectDependency) || it !is org.gradle.api.artifacts.SelfResolvingDependency
-          ) {
+          if (it is ProjectDependency) {
             val dependencyNode = dependenciesNode.appendNode("dependency")
             dependencyNode.appendNode("groupId", it.group)
             dependencyNode.appendNode("artifactId", it.name)


### PR DESCRIPTION
Remove the usage of `org.gradle.api.artifacts.SelfResolvingDependency`. It was previously deprecated and has been removed in Gradle 9. The generated pom's are still good after this change.