### PR TITLE
Quarkus: Tackle some more deprecated/changed configs

### DIFF
--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -299,10 +299,10 @@ quarkus.cassandra.health.enabled=false
 ## some parameters are only configured at build time. These have been marked as such https://quarkus.io/guides/config#overriding-properties-at-runtime
 quarkus.log.level=INFO
 quarkus.log.console.level=INFO
-quarkus.log.console.json=false
+quarkus.log.console.json.enabled=false
 #quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%X{traceId},%X{spanId},%X{sampled}] [%c{3.}] (%t) %s%e%n
 quarkus.log.file.level=INFO
-quarkus.log.file.json=false
+quarkus.log.file.json.enabled=false
 quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%X{traceId},%X{spanId},%X{sampled}] [%c{3.}] (%t) %s%e%n
 quarkus.log.category."io.netty".level=WARN
 # Effectively disable HTTP request logging to the console (HTTP access logs happen at INFO level)
@@ -362,9 +362,9 @@ quarkus.management.test-port=0
 # entries. Also, the Swagger UI is rather a dev-mode thing and is only available on the Quarkus management port and
 # therefore not publicly available.
 quarkus.swagger-ui.always-include=false
-quarkus.swagger-ui.enable=false
+quarkus.swagger-ui.enabled=false
 # The /q/openapi endpoint is disabled for the same reasons
-quarkus.smallrye-openapi.enable=false
+quarkus.smallrye-openapi.enabled=false
 
 # Required for propagation of request-scoped beans to health checks
 quarkus.smallrye-health.context-propagation=true
@@ -379,7 +379,7 @@ quarkus.application.name=Nessie
 ## sentry specific settings
 quarkus.log.sentry.level=ERROR
 quarkus.log.sentry.in-app-packages=org.projectnessie
-quarkus.log.sentry=false
+quarkus.log.sentry.enabled=false
 #quarkus.log.sentry.dsn=https://<fillin>.ingest.sentry.io/<fillin>
 
 quarkus.banner.path=nessie-banner.txt


### PR DESCRIPTION
Tackles
```
Unrecognized configuration key "quarkus.log.sentry" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
The "quarkus.swagger-ui.enable" config property is deprecated and should not be used anymore.
The "quarkus.smallrye-openapi.enable" config property is deprecated and should not be used anymore.
The "quarkus.log.file.json" config property is deprecated and should not be used anymore.
The "quarkus.log.console.json" config property is deprecated and should not be used anymore.
```