### PR TITLE
Build: improve caching

### DIFF
--- a/catalog/format/iceberg/build.gradle.kts
+++ b/catalog/format/iceberg/build.gradle.kts
@@ -80,6 +80,7 @@ val generateAvroSchemas by
     mainClass.set("org.projectnessie.catalog.formats.iceberg.GenerateAvroSchemas")
     args("$generatedAvroSchemas/org/projectnessie/catalog/formats/iceberg")
 
+    outputs.cacheIf { true }
     outputs.dir(generatedAvroSchemas)
 
     doFirst { delete(generatedAvroSchemas) }

--- a/cli/grammar/build.gradle.kts
+++ b/cli/grammar/build.gradle.kts
@@ -51,6 +51,10 @@ dependencies {
 }
 
 abstract class Generate : JavaExec() {
+  init {
+    outputs.cacheIf { true }
+  }
+
   @get:InputDirectory
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val sourceDir: DirectoryProperty

--- a/gc/gc-tool/build.gradle.kts
+++ b/gc/gc-tool/build.gradle.kts
@@ -148,6 +148,7 @@ val generateAutoComplete by
     )
 
     inputs.files("src/main").withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.cacheIf { true }
     outputs.dir(completionScriptsDir)
   }
 

--- a/tools/doc-generator/site-gen/build.gradle.kts
+++ b/tools/doc-generator/site-gen/build.gradle.kts
@@ -83,6 +83,7 @@ val generatedMarkdownDocs = tasks.register<JavaExec>("generatedMarkdownDocs") {
 
   mainClass = "org.projectnessie.nessie.docgen.DocGenTool"
 
+  outputs.cacheIf { true }
   outputs.dir(generatedMarkdownDocsDir)
   inputs.files(doclet)
   inputs.files(genProjects)
@@ -144,6 +145,7 @@ val cliHelp by tasks.registering(JavaExec::class) {
   mainClass = "-jar"
 
   inputs.files(cliRunner)
+  outputs.cacheIf { true }
   outputs.dir(cliHelpDir)
 
   classpath(cliRunner)
@@ -190,6 +192,7 @@ for (cmdArgs in listOf(
   t.configure {
     inputs.files(gcRunner)
     val dir = layout.buildDirectory.dir("gc-$name")
+    outputs.cacheIf { true }
     outputs.dir(dir)
 
     classpath(gcRunner)
@@ -233,6 +236,7 @@ for (cmdArgs in listOf(
   t.configure {
     inputs.files(serverAdminRunner)
     val dir = layout.buildDirectory.dir("serverAdmin-$name")
+    outputs.cacheIf { true }
     outputs.dir(dir)
 
     classpath(serverAdminRunner)


### PR DESCRIPTION
`(Java)Exec` tasks are not cacheable by default, as annotated with `@DisableCachingByDefault`, but all task definitions in the build provide "proper" inputs and outputs, which are worth to be cached. Adding an `outputs.cacheIf { true }` enables caching on these tasks.