### PR TITLE
Cache: rework overshoot handling since Caffeine 3.2.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -99,6 +99,7 @@ jmh-generator-annprocess = { module = "org.openjdk.jmh:jmh-generator-annprocess"
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
+junit-pioneer = { module = "org.junit-pioneer:junit-pioneer", version = "2.3.0" }
 junit-platform-reporting = { module = "org.junit.platform:junit-platform-reporting" }
 kafka-clients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafka" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }

--- a/versioned/storage/cache/build.gradle.kts
+++ b/versioned/storage/cache/build.gradle.kts
@@ -49,5 +49,6 @@ dependencies {
 
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.bundles.junit.testing)
+  testImplementation(libs.junit.pioneer)
   testRuntimeOnly(libs.logback.classic)
 }

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
@@ -37,6 +37,8 @@ import jakarta.annotation.Nonnull;
 import java.lang.ref.SoftReference;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.IntConsumer;
 import java.util.function.LongSupplier;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
@@ -66,10 +68,12 @@ class CaffeineCacheBackend implements CacheBackend {
   private final long refCacheTtlNanos;
   private final long refCacheNegativeTtlNanos;
   private final boolean enableSoftReferences;
+  private final long capacityBytes;
   private final long admitWeight;
   private final AtomicLong rejections = new AtomicLong();
   private final IntConsumer rejectionsWeight;
   private final LongSupplier weightSupplier;
+  private final Lock aboveCapacityLock;
 
   CaffeineCacheBackend(CacheConfig config) {
     this.config = config;
@@ -78,15 +82,15 @@ class CaffeineCacheBackend implements CacheBackend {
     refCacheNegativeTtlNanos = config.referenceNegativeTtl().orElse(Duration.ZERO).toNanos();
     enableSoftReferences = config.enableSoftReferences().orElse(false);
 
-    var maxWeight = config.capacityMb() * ONE_MB;
-    admitWeight = maxWeight + (long) (maxWeight * config.cacheCapacityOvershoot());
+    capacityBytes = config.capacityMb() * ONE_MB;
+    admitWeight = capacityBytes + (long) (capacityBytes * config.cacheCapacityOvershoot());
 
     Caffeine<CacheKeyValue, CacheKeyValue> cacheBuilder =
         Caffeine.newBuilder()
             .executor(config.executor())
             .scheduler(Scheduler.systemScheduler())
             .ticker(config.clockNanos()::getAsLong)
-            .maximumWeight(maxWeight)
+            .maximumWeight(capacityBytes)
             .weigher(this::weigher)
             .expireAfter(
                 new Expiry<>() {
@@ -140,7 +144,7 @@ class CaffeineCacheBackend implements CacheBackend {
                       .register(reg);
 
                   // new gauges (providing base unit)
-                  Gauge.builder(METER_CACHE_CAPACITY, "", x -> maxWeight)
+                  Gauge.builder(METER_CACHE_CAPACITY, "", x -> capacityBytes)
                       .description("Total capacity of the objects cache in bytes.")
                       .tag("cache", CACHE_NAME)
                       .baseUnit(BaseUnits.BYTES)
@@ -169,6 +173,8 @@ class CaffeineCacheBackend implements CacheBackend {
 
     var eviction = cache.policy().eviction().orElseThrow();
     weightSupplier = () -> eviction.weightedSize().orElse(0L);
+
+    aboveCapacityLock = new ReentrantLock();
   }
 
   @VisibleForTesting
@@ -219,11 +225,24 @@ class CaffeineCacheBackend implements CacheBackend {
   @VisibleForTesting
   void cachePut(CacheKeyValue key, CacheKeyValue value) {
     var w = weigher(key, value);
-    if (weightSupplier.getAsLong() + w < admitWeight) {
+    var currentWeight = weightSupplier.getAsLong();
+    if (currentWeight < capacityBytes) {
       cache.put(key, value);
-    } else {
-      rejections.incrementAndGet();
-      rejectionsWeight.accept(w);
+      return;
+    }
+
+    aboveCapacityLock.lock();
+    try {
+      cache.cleanUp();
+      currentWeight = weightSupplier.getAsLong();
+      if (currentWeight + w < admitWeight) {
+        cache.put(key, value);
+      } else {
+        rejections.incrementAndGet();
+        rejectionsWeight.accept(w);
+      }
+    } finally {
+      aboveCapacityLock.unlock();
     }
   }
 


### PR DESCRIPTION
There is sadly no fix possible with Caffeine since 3.2.3. See [this reply](https://github.com/ben-manes/caffeine/issues/1897#issuecomment-3481719258).

The workaround I came up with is to change the logic a bit:

* If the cache-weight is less than the capacity: just put the entry to the cache, no "special handling".
* Otherwise do the following while holding an exclusive lock:
  * Explicitly trigger cache cleanup
  * If the cache-weight is less than the admitted capacity (overshooting), put the entry into the cache.
  * Else, reject and update meters accordingly.

We have to allow the "overshooting" to happen to enable (and trigger) the cache cleanup. Otherwise, cleanup would never happen ...