### PR TITLE
Use `ghcr.io/snazy/maxio-release` instead of `minio/minio`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -212,7 +212,6 @@
         'software.amazon.awssdk{/,}**',
       ],
     },
-
     // Special versioning for Minio
     {
       matchManagers: [
@@ -222,11 +221,12 @@
       ],
       versioning: 'regex:^RELEASE\\.(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})T(?<build>\\d{2})-(?<revision>\\d{2})-\\d{2}Z',
       matchPackageNames: [
-        '/^quay.io/minio/minio/',
+        '/^ghcr.io/snazy/maxio-release/',
       ],
       // see https://docs.renovatebot.com/modules/versioning/#regular-expression-versioning
       // see https://github.com/renovatebot/renovate/issues/2438
     },
+
     {
       groupName: 'Quarkus Platform and Group',
       matchManagers: [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Changes
 
+- Migrate from the MinIO docker image repository to latest MinIO release w/ the recent security fix(es?).
+
 ### Deprecations
 
 ### Fixes

--- a/docker/all-in-one/docker-compose.yml
+++ b/docker/all-in-one/docker-compose.yml
@@ -176,7 +176,7 @@ services:
 
   # MinIO
   minio:
-    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: ghcr.io/snazy/maxio-release:RELEASE.2025-10-15T17-29-55Z
     ports:
       # API port
       - "9002:9000"
@@ -196,7 +196,7 @@ services:
 
   # Create MinIO bucket
   minio-setup:
-    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: ghcr.io/snazy/maxio-release:RELEASE.2025-10-15T17-29-55Z
     depends_on:
       minio:
         condition: service_healthy

--- a/docker/catalog-auth-s3-otel/docker-compose.yml
+++ b/docker/catalog-auth-s3-otel/docker-compose.yml
@@ -165,7 +165,7 @@ services:
 
   # MinIO
   minio:
-    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: ghcr.io/snazy/maxio-release:RELEASE.2025-10-15T17-29-55Z
     ports:
       # API port
       - "9002:9000"
@@ -185,7 +185,7 @@ services:
 
   # Create MinIO bucket
   minio-setup:
-    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: ghcr.io/snazy/maxio-release:RELEASE.2025-10-15T17-29-55Z
     depends_on:
       minio:
         condition: service_healthy

--- a/docker/catalog-auth-s3/docker-compose.yml
+++ b/docker/catalog-auth-s3/docker-compose.yml
@@ -112,7 +112,7 @@ services:
 
   # MinIO
   minio:
-    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: ghcr.io/snazy/maxio-release:RELEASE.2025-10-15T17-29-55Z
     ports:
       # API port
       - "9002:9000"
@@ -132,7 +132,7 @@ services:
 
   # Create MinIO bucket
   minio-setup:
-    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: ghcr.io/snazy/maxio-release:RELEASE.2025-10-15T17-29-55Z
     depends_on:
       minio:
         condition: service_healthy

--- a/docker/catalog-nginx-https/docker-compose.yml
+++ b/docker/catalog-nginx-https/docker-compose.yml
@@ -101,7 +101,7 @@ services:
 
   # MinIO
   minio:
-    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: ghcr.io/snazy/maxio-release:RELEASE.2025-10-15T17-29-55Z
     ports:
       # API port, used by Nessie
       - "9000:9000"
@@ -121,7 +121,7 @@ services:
 
   # Create MinIO bucket
   minio-setup:
-    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: ghcr.io/snazy/maxio-release:RELEASE.2025-10-15T17-29-55Z
     depends_on:
       minio:
         condition: service_healthy

--- a/site/docs/guides/spark-s3.md
+++ b/site/docs/guides/spark-s3.md
@@ -71,7 +71,7 @@ For this example, start a local Minio server using Docker:
 ```shell
 docker run -p 9000:9000 -p 9001:9001 --name minio \
  -e "MINIO_ROOT_USER=datauser" -e "MINIO_ROOT_PASSWORD=minioSecret" \
- quay.io/minio/minio:latest server /data --console-address ":9001"
+ ghcr.io/snazy/maxio-release:latest server /data --console-address ":9001"
 ```
 
 Configure AWS SDK crendetials the same way you would configure them for Amazon S3 (refer to the section above)

--- a/testing/minio-container/src/main/resources/org/projectnessie/minio/Dockerfile-minio-version
+++ b/testing/minio-container/src/main/resources/org/projectnessie/minio/Dockerfile-minio-version
@@ -1,3 +1,3 @@
 # Dockerfile to provide the image name and tag to a test.
 # Version is managed by Renovate - do not edit.
-FROM quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+FROM ghcr.io/snazy/maxio-release:RELEASE.2025-10-15T17-29-55Z


### PR DESCRIPTION
Minio stopped publishing binary release artifacts including Docker images recently. The Minio source however is stilled tagged in GitHub.

This change pulls builds from the maxio-release repository to get the latest MinIO release including the `mc` binary. The included OpenMaxIO console/UI is irrelevant for Nessie's testing use case of MinIO.