### PR TITLE
CI: Add a workflow to verify that Quarkus CR versions pass Nessie CI

### DIFF
--- a/.github/workflows/ci-quarkus-cr.yml
+++ b/.github/workflows/ci-quarkus-cr.yml
@@ -1,0 +1,814 @@
+# Copyright (C) 2020 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Unifies main + PR workflow.
+#
+# The unified CI workflow consists of 2 "stages":
+# - Checks - test, intTest, NesQuEIT, etc
+# - Finalize - a "success" dummy job for PRs + a "save to github-cache" job for push-to-main
+#
+# Utilizes the Gradle build cache for all stages. The updated build cache
+# of the jobs in the checks stage are saved as artifacts (with the minimum
+# retention period). The updated build cache is pushed back to GigHub's
+# cache when the checks have successfully finished.
+
+name: Quarkus CR Testing
+
+on:
+  workflow_dispatch:
+    inputs:
+      quarkusVersion:
+        description: 'Quarkus version to test against, for example 3.30.0.CR1'
+        required: true
+
+jobs:
+  code-checks:
+    name: Quarkus CR - Compilation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Setup runner
+        uses: ./.github/actions/setup-runner
+      - name: Setup Java, Gradle
+        uses: ./.github/actions/dev-tool-java
+
+      # Needed for the Quarkus plugin - can likely go away once we use Quarkus 3 or newer
+      - name: Bump Gradle daemon heap
+        run: sed -i 's/-Xms.*/-Xms6G -Xmx6G -XX:MaxMetaspaceSize=1g \\/' gradle.properties
+
+      - name: Prepare Gradle build cache
+        uses: ./.github/actions/ci-incr-build-cache-prepare
+
+      - name: Gradle / Compile All Source
+        run: |
+          ./gradlew \
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            compileAll --continue --scan
+
+      - name: Gradle / Assemble
+        run: |
+          ./gradlew \
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            assemble --continue --scan
+
+  test:
+    name: Quarkus CR - Test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Setup runner
+        uses: ./.github/actions/setup-runner
+      - name: Setup Java, Gradle
+        uses: ./.github/actions/dev-tool-java
+
+      - name: Prepare Gradle build cache
+        uses: ./.github/actions/ci-incr-build-cache-prepare
+
+      - name: Gradle / test
+        run: |
+          ./gradlew \
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            test \
+            :nessie-client:check \
+            -x :nessie-client:intTest \
+            -x :nessie-quarkus:test \
+            -x :nessie-server-admin-tool:test \
+            -x :nessie-events-quarkus:test \
+            -x :nessie-events-ri:test \
+            --continue \
+            --scan
+
+      - name: Capture Test Reports
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        if: ${{ failure() }}
+        with:
+          name: ci-test-reports
+          path: |
+            **/build/reports/*
+            **/build/test-results/*
+          retention-days: 7
+
+  test-quarkus:
+    name: Quarkus CR - Test Quarkus
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Setup runner
+        uses: ./.github/actions/setup-runner
+      - name: Setup Java, Gradle
+        uses: ./.github/actions/dev-tool-java
+
+      - name: Prepare Gradle build cache
+        uses: ./.github/actions/ci-incr-build-cache-prepare
+
+      - name: Gradle / Test Quarkus Server
+        run: |
+          ./gradlew \
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            :nessie-quarkus:test --scan
+
+      - name: Gradle / Test Quarkus Events
+        run: |
+          ./gradlew \
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            :nessie-events-quarkus:test --scan
+
+      - name: Gradle / Test Quarkus Events RI
+        run: |
+          ./gradlew \
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            :nessie-events-ri:test --scan
+
+      - name: Dump quarkus.log
+        if: ${{ failure() }}
+        run: |
+          find . -path "**/build/quarkus.log" | while read ql ; do
+            echo "::group::Quarkus build log $ql"
+            cat $ql
+            echo "::endgroup::"
+          done
+
+      - name: Capture Test Reports
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        if: ${{ failure() }}
+        with:
+          name: ci-test-quarkus-reports
+          path: |
+            **/build/quarkus.log
+            **/build/reports/*
+            **/build/test-results/*
+          retention-days: 7
+
+  int-test:
+    name: CI intTest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      SPARK_LOCAL_IP: localhost
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Setup runner
+        uses: ./.github/actions/setup-runner
+      - name: Setup Java, Gradle
+        uses: ./.github/actions/dev-tool-java
+
+      - name: Prepare Gradle build cache
+        uses: ./.github/actions/ci-incr-build-cache-prepare
+
+      - name: Gradle / intTest
+        run: |
+          echo "::group::Collect :nessie-versioned-storage projects"
+          ./gradlew \ 
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            :listProjectsWithPrefix --prefix :nessie-versioned-persist- --output ../persist-prjs.txt --exclude
+          echo "::endgroup::"
+
+          echo "::group::Collect :nessie-versioned-persist projects"
+          ./gradlew \ 
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            :listProjectsWithPrefix --prefix :nessie-versioned-storage- --output ../storage-prjs.txt --exclude
+          echo "::endgroup::"
+
+          echo "::group::Collect :nessie-spark-extensions projects"
+          ./gradlew \ 
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            :listProjectsWithPrefix --prefix :nessie-spark-ext --output ../spark-prjs.txt --exclude
+          echo "::endgroup::"
+
+          ./gradlew intTest \
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            -x :nessie-quarkus:intTest \
+            -x :nessie-server-admin-tool:intTest \
+            -x :nessie-events-quarkus:intTest \
+            $(cat ../persist-prjs.txt) \
+            $(cat ../storage-prjs.txt) \
+            $(cat ../spark-prjs.txt) \
+            --continue \
+            --scan
+
+      - name: Capture Test Reports
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        if: ${{ failure() }}
+        with:
+          name: ci-inttest-reports
+          path: |
+            **/build/reports/*
+            **/build/test-results/*
+          retention-days: 7
+
+  int-test-stores:
+    name: CI intTest versioned/stores
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Setup runner
+        uses: ./.github/actions/setup-runner
+      - name: Setup Java, Gradle
+        uses: ./.github/actions/dev-tool-java
+
+      - name: Prepare Gradle build cache
+        uses: ./.github/actions/ci-incr-build-cache-prepare
+
+      - name: Gradle / intTest versioned/stores
+        run: |
+          echo "::group::Collect :nessie-versioned-storage projects"
+          ./gradlew \ 
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            :listProjectsWithPrefix --prefix :nessie-versioned-storage- --output ../storage-prjs.txt
+          echo "::endgroup::"
+
+          echo "::group::Collect :nessie-versioned-persist projects"
+          ./gradlew \
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            :listProjectsWithPrefix --prefix :nessie-versioned-persist- --output ../persist-prjs.txt
+          echo "::endgroup::"
+
+          ./gradlew \
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            $(cat ../persist-prjs.txt) $(cat ../storage-prjs.txt) --continue --scan
+
+      - name: Capture Test Reports
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        if: ${{ failure() }}
+        with:
+          name: ci-inttest-stores-reports
+          path: |
+            **/build/reports/*
+            **/build/test-results/*
+          retention-days: 7
+
+  int-test-integrations:
+    name: CI intTest integrations
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      SPARK_LOCAL_IP: localhost
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Setup runner
+        uses: ./.github/actions/setup-runner
+      - name: Setup Java, Gradle
+        uses: ./.github/actions/dev-tool-java
+        with:
+          # Need Java 17 in addition to the default Java 21
+          additional-java-version: 17
+
+      - name: Prepare Gradle build cache
+        uses: ./.github/actions/ci-incr-build-cache-prepare
+
+      - name: Gradle / intTest integrations
+        run: |
+          echo "::group::Collect :nessie-spark-extensions projects"
+          ./gradlew \ 
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            :listProjectsWithPrefix --prefix :nessie-spark-ext --output ../spark-prjs.txt
+          echo "::endgroup::"
+
+          ./gradlew \ 
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            $(cat ../spark-prjs.txt) --continue --scan
+
+      - name: Capture Test Reports
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        if: ${{ failure() }}
+        with:
+          name: ci-inttest-integrations-reports
+          path: |
+            **/build/reports/*
+            **/build/test-results/*
+          retention-days: 7
+
+  int-test-quarkus-server:
+    name: CI intTest Quarkus Server
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Setup runner
+        uses: ./.github/actions/setup-runner
+      - name: Setup Java, Gradle
+        uses: ./.github/actions/dev-tool-java
+
+      - name: Prepare Gradle build cache
+        uses: ./.github/actions/ci-incr-build-cache-prepare
+
+      - name: Gradle / intTest Quarkus Server
+        run:
+          ./gradlew \ 
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            :nessie-quarkus:intTest --scan
+
+      - name: Dump quarkus.log
+        if: ${{ failure() }}
+        run: |
+          find . -path "**/build/quarkus.log" | while read ql ; do
+            echo "::group::Quarkus build log $ql"
+            cat $ql
+            echo "::endgroup::"
+          done
+
+      - name: Capture Test Reports
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        if: ${{ failure() }}
+        with:
+          name: ci-inttest-quarkus-server-reports
+          path: |
+            **/build/quarkus.log
+            **/build/reports/*
+            **/build/test-results/*
+          retention-days: 7
+
+  int-test-quarkus-tool:
+    name: CI intTest Admin Tool
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Setup runner
+        uses: ./.github/actions/setup-runner
+      - name: Setup Java, Gradle
+        uses: ./.github/actions/dev-tool-java
+
+      - name: Prepare Gradle build cache
+        uses: ./.github/actions/ci-incr-build-cache-prepare
+
+      - name: Gradle / intTest Admin Tool
+        run:
+          ./gradlew \ 
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            :nessie-server-admin-tool:intTest --scan
+
+      - name: Dump quarkus.log
+        if: ${{ failure() }}
+        run: |
+          find . -path "**/build/quarkus.log" | while read ql ; do
+            echo "::group::Quarkus build log $ql"
+            cat $ql
+            echo "::endgroup::"
+          done
+
+      - name: Capture Test Reports
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        if: ${{ failure() }}
+        with:
+          name: ci-inttest-quarkus-tool-reports
+          path: |
+            **/build/quarkus.log
+            **/build/reports/*
+            **/build/test-results/*
+          retention-days: 7
+
+  int-test-quarkus-events:
+    name: CI intTest Quarkus Events
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Setup runner
+        uses: ./.github/actions/setup-runner
+      - name: Setup Java, Gradle
+        uses: ./.github/actions/dev-tool-java
+
+      - name: Prepare Gradle build cache
+        uses: ./.github/actions/ci-incr-build-cache-prepare
+
+      - name: Gradle / intTest Quarkus Events
+        run:
+          ./gradlew \ 
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            :nessie-events-quarkus:intTest --scan
+
+      - name: Dump quarkus.log
+        if: ${{ failure() }}
+        run: |
+          find . -path "**/build/quarkus.log" | while read ql ; do
+            echo "::group::Quarkus build log $ql"
+            cat $ql
+            echo "::endgroup::"
+          done
+
+      - name: Capture Test Reports
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        if: ${{ failure() }}
+        with:
+          name: ci-inttest-quarkus-events-reports
+          path: |
+            **/build/quarkus.log
+            **/build/reports/*
+            **/build/test-results/*
+          retention-days: 7
+
+  docker-testing:
+    name: CI Docker and Helm checks
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+      - name: Setup runner
+        uses: ./.github/actions/setup-runner
+      - name: Setup Java, Gradle
+        uses: ./.github/actions/dev-tool-java
+
+      - name: Extract version
+        run: |
+          VERSION="$(cat version.txt)"
+          DOCKER_VERSION="${VERSION%-SNAPSHOT}"
+          echo ${DOCKER_VERSION}
+          echo "DOCKER_VERSION=${DOCKER_VERSION}" >> ${GITHUB_ENV}
+
+      # Free disk space (minikube warning: "Docker is nearly out of disk space, which may cause
+      # deployments to fail! (85% of capacity)")
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
+
+      - name: Setup Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        with:
+          # https://helm.sh/docs/topics/version_skew/
+          version: 'v3.11.3'
+
+      - name: Setup chart-testing
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+
+      - name: Setup Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
+        with:
+          python-version: '3.14'
+
+      - name: Setup & Start Minikube
+        uses: medyagh/setup-minikube@e3c7f79eb1e997eabccc536a6cf318a2b0fe19d9 # v0.0.20
+        with:
+          # If required, use the matrix strategy against this option to test against multiple Kubernetes versions:
+          kubernetes-version: stable
+          cache: false
+          # This _should_ work, but doesn't somehow (the image push fails). It errors out looking for a coredns pod
+          # with these settings...
+          #addons: 'registry'
+          #insecure-registry: '192.168.0.0/16'
+
+      - name: Setup Docker registry
+        run: |
+          echo "::group::Get registry IP"
+          DOCKER_REGISTRY="$(minikube ip)"
+          echo "Registry IP is ${DOCKER_REGISTRY}"
+          echo "::endgroup::"
+
+          echo "::group::Update buildkitd_conf for 'docker buildx build'"
+          # Use 'http' instead of 'https' during 'docker buildx build' in 'tools/dockerbuild/build-push-images.sh'
+          cat <<EOF > ../buildkitd.toml                                                                                                                                                                                                                                                                                            
+          [registry."${DOCKER_REGISTRY}:5000"]                                                                                                                                                                                                                                                                                 
+            http = true
+          EOF
+          buildkitd_conf="$(pwd)/../buildkitd.toml"
+          echo "::endgroup::"
+
+          echo "::group::Update /etc/docker/daemon.json for 'docker pull'"
+          echo "{\"insecure-registries\": [\"${DOCKER_REGISTRY}:5000\"]}" | \
+            sudo tee /etc/docker/daemon.json
+          echo "::endgroup::"
+
+          # minikube restart, because:
+          #   1. required after docker daemon restart 
+          #   2. tweak the "registry addon" into the start command
+          #   3. tweak the "insecure-registry" setting into the start command
+          # Must delete the minikube cluster to let the insecure-registry setting take effect.
+          # See 'Enabling Insecure Registries' in https://minikube.sigs.k8s.io/docs/handbook/registry/
+          echo "::group::Stop minikube"
+          minikube stop
+          echo "::endgroup::"
+          echo "::group::Delete minikube" 
+          minikube delete
+          echo "::endgroup::"
+          echo "::group::Restart docker daemon"
+          sudo systemctl restart docker
+          echo "::endgroup::"
+          echo "::group::Start minikube"
+          minikube start --insecure-registry="${DOCKER_REGISTRY}:5000" --addons=registry
+          echo "::endgroup::"
+
+          echo "BUILDX_CONFIG=--config ${buildkitd_conf}" >> ${GITHUB_ENV}
+          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}:5000/nessie-testing" >> ${GITHUB_ENV}
+          echo "DOCKER_GC_IMAGE=${DOCKER_REGISTRY}:5000/nessie-gc-testing" >> ${GITHUB_ENV}
+          echo "DOCKER_SERVER_ADMIN_IMAGE=${DOCKER_REGISTRY}:5000/nessie-server-admin-testing" >> ${GITHUB_ENV}
+          echo "DOCKER_CLI_IMAGE=${DOCKER_REGISTRY}:5000/nessie-cli-testing" >> ${GITHUB_ENV}
+
+      - name: Prepare Gradle build cache
+        uses: ./.github/actions/ci-incr-build-cache-prepare
+
+      - name: Docker images publishing
+        run: |
+          export CUSTOM_GRADLE_ARGS="-Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true"
+          
+          tools/dockerbuild/build-push-images.sh \
+            -g ":nessie-quarkus" \
+            -p "servers/quarkus-server" \
+            -d "Dockerfile-server" \
+            ${DOCKER_IMAGE}
+
+          tools/dockerbuild/build-push-images.sh \
+            -g ":nessie-gc-tool" \
+            -p "gc/gc-tool" \
+            -d "Dockerfile-gctool" \
+            ${DOCKER_GC_IMAGE}
+
+          tools/dockerbuild/build-push-images.sh \
+            -g ":nessie-server-admin-tool" \
+            -p "tools/server-admin" \
+            -d "Dockerfile-admintool" \
+            ${DOCKER_SERVER_ADMIN_IMAGE}
+
+          tools/dockerbuild/build-push-images.sh \
+            -g ":nessie-cli" \
+            -p "cli/cli" \
+            -d "Dockerfile-cli" \
+            ${DOCKER_CLI_IMAGE}
+
+      - name: Cleanup buildx
+        run: |
+          docker buildx use default
+          docker buildx rm nessiebuild
+
+      - name: Check if expected Docker images exist
+        run: |
+          docker pull ${DOCKER_IMAGE}:latest
+          docker pull ${DOCKER_IMAGE}:latest-java
+          docker pull ${DOCKER_IMAGE}:${DOCKER_VERSION}
+          docker pull ${DOCKER_IMAGE}:${DOCKER_VERSION}-java
+          docker pull ${DOCKER_GC_IMAGE}:latest
+          docker pull ${DOCKER_GC_IMAGE}:latest-java
+          docker pull ${DOCKER_GC_IMAGE}:${DOCKER_VERSION}
+          docker pull ${DOCKER_GC_IMAGE}:${DOCKER_VERSION}-java
+          docker pull ${DOCKER_SERVER_ADMIN_IMAGE}:latest
+          docker pull ${DOCKER_SERVER_ADMIN_IMAGE}:latest-java
+          docker pull ${DOCKER_SERVER_ADMIN_IMAGE}:${DOCKER_VERSION}
+          docker pull ${DOCKER_SERVER_ADMIN_IMAGE}:${DOCKER_VERSION}-java
+          docker pull ${DOCKER_CLI_IMAGE}:latest
+          docker pull ${DOCKER_CLI_IMAGE}:latest-java
+          docker pull ${DOCKER_CLI_IMAGE}:${DOCKER_VERSION}
+          docker pull ${DOCKER_CLI_IMAGE}:${DOCKER_VERSION}-java
+          cat <<! >> $GITHUB_STEP_SUMMARY
+          ## Docker images
+          
+          \`\`\`
+          $(docker images)
+          \`\`\`
+          !
+
+      - name: Check if Server Docker Java image works
+        run: |
+          docker run --rm --detach --name nessie ${DOCKER_IMAGE}:latest-java
+          echo "Let Nessie Java Docker image run for one minute (to make sure it starts up fine)..."
+          for i in {1..60}; do
+            STATUS="$(docker container inspect nessie | jq -r '.[0].State.Status')"
+            if [[ ${STATUS} != "running" ]] ; then
+              echo "Nessie Java Docker image stopped on its own ... a bug?" > /dev/stderr
+              docker logs nessie
+              cat <<! >> $GITHUB_STEP_SUMMARY
+              ## Nessie Java Docker image FAILED
+
+              \`\`\`
+              $(docker logs nessie)
+              \`\`\`
+          !
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "## Nessie Java Docker image smoke test: PASSED" >> $GITHUB_STEP_SUMMARY  
+          echo "Nessie Java Docker image smoke test: PASSED"
+          docker stop nessie
+
+      - name: Check if GC Tool Docker Java image works
+        run: |
+          if docker run --rm --name nessie-gc ${DOCKER_GC_IMAGE}:latest-java --help | grep -q "Usage: nessie-gc.jar"; then
+            echo "## GC Tool Java Docker image smoke test: PASSED" >> $GITHUB_STEP_SUMMARY  
+            echo "GC Tool Java Docker image smoke test: PASSED"
+          else
+           echo "GC Tool Java Docker image smoke test: FAILED" > /dev/stderr
+            cat <<! >> $GITHUB_STEP_SUMMARY
+            ## GC Tool Java Docker image FAILED
+
+            \`\`\`
+            $(docker logs nessie-gc)
+            \`\`\`
+          !
+            exit 1
+          fi
+
+      - name: Check if Server Admin Tool Docker Java image works
+        run: |
+          if docker run --rm --name nessie-server-admin ${DOCKER_SERVER_ADMIN_IMAGE}:latest-java --help | grep -q "Usage: nessie-server-admin"; then
+            echo "## Server Admin Tool Java Docker image smoke test: PASSED" >> $GITHUB_STEP_SUMMARY  
+            echo "Server Admin Tool Java Docker image smoke test: PASSED"
+          else
+           echo "Server Admin Tool Java Docker image smoke test: FAILED" > /dev/stderr
+            cat <<! >> $GITHUB_STEP_SUMMARY
+            ## Server Admin Tool Java Docker image FAILED
+
+            \`\`\`
+            $(docker logs nessie-server-admin)
+            \`\`\`
+          !
+            exit 1
+          fi
+
+      - name: Check if CLI Docker Java image works
+        run: |
+          if docker run --rm --name nessie-cli ${DOCKER_CLI_IMAGE}:latest-java --help | grep -q "Usage: nessie-cli.jar"; then
+            echo "## CLI Java Docker image smoke test: PASSED" >> $GITHUB_STEP_SUMMARY  
+            echo "CLI Java Docker image smoke test: PASSED"
+          else
+           echo "CLI Java Docker image smoke test: FAILED" > /dev/stderr
+            cat <<! >> $GITHUB_STEP_SUMMARY
+            ## CLI Java Docker image FAILED
+
+            \`\`\`
+            $(docker logs nessie-cli)
+            \`\`\`
+          !
+            exit 1
+          fi
+
+      - name: Run chart-testing (list-changed)
+        run: |
+          ct list-changed --target-branch ${{ github.event.repository.default_branch }}
+
+      - name: Run 'helm template' validation
+        run: |
+          cd helm/nessie
+          for f in values.yaml ci/*.yaml; do
+            echo "::group::helm template $f"
+            helm template --debug --namespace nessie-ns --values $f .
+            echo "::endgroup::"
+          done
+
+      - name: Run Helm unit tests
+        run: |
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git || true
+          helm unittest helm/nessie
+
+      - name: Run chart-testing (lint)
+        run: ct lint --debug --charts ./helm/nessie
+
+      - name: Show pods
+        run: kubectl get pods -A
+
+      - name: Install secrets
+        run: |
+          kubectl create namespace nessie-ns
+          kubectl apply --namespace nessie-ns $(find helm/nessie/ci/fixtures -name "*.yaml" -exec echo -n "-f {} " \;) 
+
+      - name: Run chart-testing (install)
+        run: |
+          echo "Using image: ${DOCKER_IMAGE}"
+          echo "        tag: ${DOCKER_VERSION}"
+
+          ct install \
+            --namespace nessie-ns \
+            --helm-extra-set-args "--set=image.repository=${DOCKER_IMAGE} --set=image.tag=${DOCKER_VERSION}" \
+            --debug --charts ./helm/nessie
+
+  nesqueit:
+    name: CI NesQuEIT
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    # Only run NesQuEIT tests for PRs, if requested. This job can easily run for 30+ minutes.
+    if: github.event_name == 'pull_request' && needs.determine-jobs.outputs.nesqueit == 'true'
+    env:
+      NESSIE_DIR: included-builds/nessie
+      NESSIE_PATCH_REPOSITORY: ''
+      NESSIE_PATCH_BRANCH: ''
+      NESQUEIT_REPOSITORY: projectnessie/query-engine-integration-tests
+      NESQUEIT_BRANCH: main
+      ICEBERG_DIR: included-builds/iceberg
+      ICEBERG_MAIN_REPOSITORY: apache/iceberg
+      ICEBERG_MAIN_BRANCH: main
+      ICEBERG_PATCH_REPOSITORY: snazy/iceberg
+      ICEBERG_PATCH_BRANCH: iceberg-nesqueit
+      SPARK_LOCAL_IP: localhost
+    steps:
+      - name: Prepare Git
+        run: |
+          git config --global user.email "integrations-testing@projectnessie.org"
+          git config --global user.name "Integrations Testing [Bot]"
+
+      - name: Checkout NeQuEIT repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: ${{env.NESQUEIT_REPOSITORY}}
+          ref: ${{env.NESQUEIT_BRANCH}}
+
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
+
+      - name: Setup runner
+        uses: ./.github/actions/setup-runner
+        with:
+          more-memory: 'true'
+
+      - name: Checkout and patch Nessie PR
+        uses: ./.github/actions/patch-git
+        with:
+          name: Nessie
+          local-dir: ${{env.NESSIE_DIR}}
+          main-repository: ${{ env.GITHUB_REPOSITORY }}
+          patch-repository: ${{env.NESSIE_PATCH_REPOSITORY}}
+          patch-branch: ${{env.NESSIE_PATCH_BRANCH}}
+          work-branch: nessie-integration-patched
+
+      - name: Checkout and patch Iceberg
+        uses: ./.github/actions/patch-git
+        with:
+          name: Nessie
+          local-dir: ${{env.ICEBERG_DIR}}
+          main-repository: ${{env.ICEBERG_MAIN_REPOSITORY}}
+          main-branch: ${{env.ICEBERG_MAIN_BRANCH}}
+          patch-repository: ${{env.ICEBERG_PATCH_REPOSITORY}}
+          patch-branch: ${{env.ICEBERG_PATCH_BRANCH}}
+          work-branch: iceberg-integration-patched
+
+      - name: Gradle 9 prereq
+        # Gradle 9 requires a project's directory to exist, even if it's empty.
+        run: mkdir "${{env.ICEBERG_DIR}}/bom"
+
+      - name: Setup JDK
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5
+        with:
+          distribution: 'temurin'
+          # Java 17 or 21 required for Nessie build, Java 17 required for Iceberg build, Java 11 required for Flink & Presto
+          java-version: | 
+            11
+            17
+            21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+        with:
+          cache-read-only: true
+          validate-wrappers: false
+
+      - name: Iceberg Nessie test
+        run: |
+          ./gradlew \
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            :iceberg:iceberg-nessie:test --scan
+
+      - name: Nessie Spark 3.4 / 2.13 Extensions test
+        run: |
+          ./gradlew \
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            -DscalaVersion=2.13 \
+            :nessie:nessie-iceberg:nessie-spark-extensions-3.4_2.13:test \
+            :nessie:nessie-iceberg:nessie-spark-extensions-3.4_2.13:intTest \
+            --continue \
+            --scan
+
+      - name: Nessie Spark 3.5 / 2.13 Extensions test
+        run: |
+          ./gradlew \
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            -DscalaVersion=2.13 \
+            :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:test \
+            :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:intTest \
+            --continue \
+            --scan
+
+      #- name: Publish Nessie + Iceberg to local Maven repo
+      #  run: ./gradlew publishLocal --scan
+      #
+      #- name: Gather locally published versions
+      #  run: |
+      #    NESSIE_VERSION="$(cat included-builds/nessie/version.txt)"
+      #    ICEBERG_VERSION="$(cat included-builds/iceberg/build/iceberg-build.properties | grep '^git.build.version=' | cut -d= -f2)"
+      #    echo "NESSIE_VERSION=${NESSIE_VERSION}" >> ${GITHUB_ENV}
+      #    echo "ICEBERG_VERSION=${ICEBERG_VERSION}" >> ${GITHUB_ENV}
+      #    cat <<! >> $GITHUB_STEP_SUMMARY
+      #    ## Published versions
+      #    | Published Nessie version | Published Iceberg version |
+      #    | ------------------------ | ------------------------- |
+      #    | ${NESSIE_VERSION}        | ${ICEBERG_VERSION}        |
+      #    !
+
+      - name: Tools & Integrations tests
+        run: |
+          ./gradlew 
+            -Dquarkus.custom.version=${{ inputs.quarkusVersion }} -Dquarkus.custom.noEnforcedPlatform=true \
+            intTest --continue --scan

--- a/tools/dockerbuild/build-push-images.sh
+++ b/tools/dockerbuild/build-push-images.sh
@@ -155,7 +155,7 @@ fi
 # Gradle Build
 #
 gh_group "Build Java"
-./gradlew "${GRADLE_PROJECT}:clean" "${GRADLE_PROJECT}:build" -x "${GRADLE_PROJECT}:check"
+./gradlew $CUSTOM_GRADLE_ARGS "${GRADLE_PROJECT}:clean" "${GRADLE_PROJECT}:build" -x "${GRADLE_PROJECT}:check"
 gh_endgroup
 
 if [[ ${LOCAL} == 1 ]] ; then


### PR DESCRIPTION
The added workflow is a copy of `ci.yml` with these changes:
* Everything related to storing the Gradle cache artifacts is removed (no need to store those)
* Add the properties to use a custom Quarkus version - for example `3.30.CR1`