### PR TITLE
feat(helm): add priority class support

### DIFF
--- a/helm/nessie/README.md
+++ b/helm/nessie/README.md
@@ -319,6 +319,7 @@ ct install --charts ./helm/nessie --namespace nessie-ns --debug
 | podDisruptionBudget | object | `{"enabled":false,"policy":{}}` | Add a PodDisruptionBudget. See https://kubernetes.io/docs/tasks/run-application/configure-pdb/. |
 | podLabels | object | `{}` | Additional Labels to apply to nessie pods. |
 | podSecurityContext | object | `{"fsGroup":10001,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the nessie pod. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/. |
+| priorityClassName | string | `""` | The priority class name to associate with Nessie pods. Leave empty to keep the default priority. |
 | readinessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":10}` | Configures the readiness probe for nessie pods. |
 | readinessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the probe to be considered failed after having succeeded. Minimum value is 1. |
 | readinessProbe.initialDelaySeconds | int | `5` | Number of seconds after the container has started before readiness probes are initiated. Minimum value is 0. |

--- a/helm/nessie/templates/deployment.yaml
+++ b/helm/nessie/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
         {{- tpl (toYaml .Values.imagePullSecrets) . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "nessie.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ tpl .Values.priorityClassName . | quote }}
+      {{- end }}
       securityContext:
         {{- tpl (toYaml .Values.podSecurityContext) . | nindent 8 }}
       {{- if .Values.extraInitContainers }}

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -924,6 +924,9 @@ autoscaling:
   # -- Optional; set to zero or empty to disable.
   targetMemoryUtilizationPercentage:
 
+# -- The priority class name to associate with Nessie pods. Leave empty to keep the default priority.
+priorityClassName: ""
+
 # -- Node labels which must match for the nessie pod to be scheduled on that node. See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
 nodeSelector:
   {}


### PR DESCRIPTION
Closes #11688
 
### Summary

- add a priorityClassName value to values.yaml, defaulting to empty and documented via helm-docs

- render the field in `nessie/helm/nessie/templates/deployment.yaml` when set so that operators can align Nessie pods with cluster PriorityClasses

- regenerate the chart README using helm-docs

### Testing
`helm-docs --chart-search-root=helm`
`helm template nessie -n nessie-ns helm/nessie --debug`