### PR TITLE
Migrate to nmcp Central Portal publishing

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -131,9 +131,9 @@ jobs:
         #    https://central.sonatype.org/publish/publish-portal-api/#uploading-a-deployment-bundle
         run: |
           # 2 Retries - to mitigate "HTTP/502 Bad Gateway" issues
-          ./gradlew publishAggregateMavenCentralDeployment -Prelease -Puber-jar --no-scan --stacktrace || \
-            ./gradlew publishAggregateMavenCentralDeployment -Prelease -Puber-jar --no-scan --stacktrace || \
-            ./gradlew publishAggregateMavenCentralDeployment -Prelease -Puber-jar --no-scan --stacktrace
+          ./gradlew publishAggregationToCentralPortal -Prelease -Puber-jar --no-scan --stacktrace || \
+            ./gradlew publishAggregationToCentralPortal -Prelease -Puber-jar --no-scan --stacktrace || \
+            ./gradlew publishAggregationToCentralPortal -Prelease -Puber-jar --no-scan --stacktrace
 
       - name: Generate changelog
         run: ./gradlew --no-scan --quiet --console=plain getChangelog --no-header --no-links > "${ARTIFACTS}/nessie-changelog-${RELEASE_VERSION}.md"

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -43,7 +43,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.OSSRH_ACCESS_ID }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_TOKEN }}
-        run: ./gradlew --no-scan publishAggregateMavenCentralDeployment -Prelease -Puber-jar
+        run: ./gradlew --no-scan publishAggregationToCentralPortalSnapshots -Prelease -Puber-jar
 
   publish-images:
     name: Publish Images

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-import io.github.zenhelix.gradle.plugin.MavenCentralUploaderPlugin.Companion.MAVEN_CENTRAL_PORTAL_NAME
-import io.github.zenhelix.gradle.plugin.extension.MavenCentralUploaderExtension
-import io.github.zenhelix.gradle.plugin.extension.PublishingType
-import io.github.zenhelix.gradle.plugin.task.PublishBundleMavenCentralTask
-import io.github.zenhelix.gradle.plugin.task.ZipDeploymentTask
 import java.time.Duration
-import org.gradle.api.publish.plugins.PublishingPlugin.PUBLISH_TASK_GROUP
-import org.gradle.kotlin.dsl.mavenCentralPortal
 import org.jetbrains.changelog.date
 import org.jetbrains.gradle.ext.settings
 import org.jetbrains.gradle.ext.taskTriggers
@@ -29,7 +22,7 @@ import org.jetbrains.gradle.ext.taskTriggers
 plugins {
   eclipse
   id("nessie-conventions-root")
-  alias(libs.plugins.maven.central.publish)
+  alias(libs.plugins.nmcp)
   alias(libs.plugins.jetbrains.changelog)
 }
 
@@ -62,148 +55,20 @@ tasks.named<Wrapper>("wrapper").configure { distributionType = Wrapper.Distribut
 //    ORG_GRADLE_PROJECT_sonatypeUsername
 //    ORG_GRADLE_PROJECT_sonatypePassword
 // Gradle targets:
-//    publishAggregateMavenCentralDeployment
-//    (zipAggregateMavenCentralDeployment to just generate the single, aggregated deployment zip)
+//    publishAggregationToCentralPortal
+//    publishAggregationToCentralPortalSnapshots
 // Ref: Maven Central Publisher API:
 //    https://central.sonatype.org/publish/publish-portal-api/#uploading-a-deployment-bundle
-mavenCentralPortal {
-  credentials {
+nmcpAggregation {
+  centralPortal {
     username.value(provider { System.getenv("ORG_GRADLE_PROJECT_sonatypeUsername") })
     password.value(provider { System.getenv("ORG_GRADLE_PROJECT_sonatypePassword") })
+    publishingType = if (System.getenv("CI") != null) "AUTOMATIC" else "USER_MANAGED"
+    publishingTimeout = Duration.ofMinutes(120)
+    validationTimeout = Duration.ofMinutes(120)
+    publicationName = "${project.name}-$version"
   }
-
-  deploymentName = "${project.name}-$version"
-
-  if (version.toString().endsWith("-SNAPSHOT")) {
-    baseUrl.set("https://central.sonatype.com/repository/maven-snapshots/")
-  }
-
-  // publishingType
-  //   AUTOMATIC = fully automatic release
-  //   USER_MANAGED = user has to manually publish/drop
-  publishingType =
-    if (System.getenv("CI") != null) PublishingType.AUTOMATIC else PublishingType.USER_MANAGED
-  // baseUrl = "https://central.sonatype.com"
-  uploader {
-    // 2 seconds * 3600 = 7200 seconds = 2hrs
-    delayRetriesStatusCheck = Duration.ofSeconds(2)
-    maxRetriesStatusCheck = 3600
-
-    aggregate {
-      // Aggregate submodules into a single archive
-      modules = true
-      // Aggregate publications into a single archive for each module
-      modulePublications = true
-    }
-  }
-}
-
-// The following code aggregates the publishable parts of every module into a single zip.
-// This is necessary to have an "atomic" release of all modules.
-
-val mavenCentralDeploymentZipAggregation by configurations.creating
-
-mavenCentralDeploymentZipAggregation.isTransitive = true
-
-val zipAggregateMavenCentralDeployment by
-  tasks.registering(Zip::class) {
-    group = PUBLISH_TASK_GROUP
-    description = "Generates the aggregated Maven publication zip file."
-
-    inputs.files(mavenCentralDeploymentZipAggregation)
-    from(mavenCentralDeploymentZipAggregation.map { zipTree(it) })
-    // archiveFileName = mavenCentralPortal.deploymentName.orElse(project.name)
-    destinationDirectory.set(layout.buildDirectory.dir("aggregatedDistribution"))
-    doLast { logger.lifecycle("Built aggregated distribution ${archiveFile.get()}") }
-  }
-
-val publishAggregateMavenCentralDeployment by
-  tasks.registering(PublishBundleMavenCentralTask::class) {
-    group = PUBLISH_TASK_GROUP
-    description =
-      "Publishes the aggregated Maven publications $MAVEN_CENTRAL_PORTAL_NAME repository."
-
-    val task = this
-
-    dependsOn(zipAggregateMavenCentralDeployment)
-    inputs.file(zipAggregateMavenCentralDeployment.flatMap { it.archiveFile })
-
-    project.extensions.configure<MavenCentralUploaderExtension> {
-      val ext = this
-      task.baseUrl.set(ext.baseUrl)
-      task.credentials.set(
-        ext.credentials.username.flatMap { username ->
-          ext.credentials.password.map { password ->
-            io.github.zenhelix.gradle.plugin.client.model.Credentials.UsernamePasswordCredentials(
-              username,
-              password,
-            )
-          }
-        }
-      )
-
-      task.publishingType.set(
-        ext.publishingType.map {
-          when (it) {
-            PublishingType.AUTOMATIC ->
-              io.github.zenhelix.gradle.plugin.client.model.PublishingType.AUTOMATIC
-            PublishingType.USER_MANAGED ->
-              io.github.zenhelix.gradle.plugin.client.model.PublishingType.USER_MANAGED
-          }
-        }
-      )
-      task.deploymentName.set(ext.deploymentName)
-
-      task.maxRetriesStatusCheck.set(ext.uploader.maxRetriesStatusCheck)
-      task.delayRetriesStatusCheck.set(ext.uploader.delayRetriesStatusCheck)
-
-      task.zipFile.set(zipAggregateMavenCentralDeployment.flatMap { it.archiveFile })
-    }
-  }
-
-// Configure the 'io.github.zenhelix.maven-central-publish' plugin to all projects
-allprojects.forEach { p ->
-  p.pluginManager.withPlugin("maven-publish") {
-    p.pluginManager.apply("io.github.zenhelix.maven-central-publish")
-    p.extensions.configure<MavenCentralUploaderExtension> {
-      val aggregatedMavenCentralDeploymentZipPart by p.configurations.creating
-      aggregatedMavenCentralDeploymentZipPart.description = "Maven central publication zip"
-      val aggregatedMavenCentralDeploymentZipPartElements by p.configurations.creating
-      aggregatedMavenCentralDeploymentZipPartElements.description =
-        "Elements for the Maven central publication zip"
-      aggregatedMavenCentralDeploymentZipPartElements.isCanBeResolved = false
-      aggregatedMavenCentralDeploymentZipPartElements.extendsFrom(
-        aggregatedMavenCentralDeploymentZipPart
-      )
-      aggregatedMavenCentralDeploymentZipPartElements.attributes {
-        attribute(
-          Usage.USAGE_ATTRIBUTE,
-          project.getObjects().named(Usage::class.java, "publication"),
-        )
-      }
-
-      val aggregatemavenCentralDeployment by
-        p.tasks.registering {
-          val zip = p.tasks.findByName("zipDeploymentMavenPublication") as ZipDeploymentTask
-          dependsOn(zip)
-          outputs.file(zip.archiveFile.get().asFile)
-        }
-
-      val artifact =
-        p.artifacts.add(
-          aggregatedMavenCentralDeploymentZipPart.name,
-          aggregatemavenCentralDeployment,
-        ) {
-          builtBy(aggregatemavenCentralDeployment)
-        }
-      aggregatedMavenCentralDeploymentZipPart.outgoing.artifact(artifact)
-
-      rootProject.dependencies.add(
-        mavenCentralDeploymentZipAggregation.name,
-        rootProject.dependencies.project(p.path, aggregatedMavenCentralDeploymentZipPart.name),
-      )
-    }
-  }
+  publishAllProjectsProbablyBreakingProjectIsolation()
 }
 
 val buildToolIntegrationGradle by

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -158,8 +158,8 @@ zstd-jni = { module = "com.github.luben:zstd-jni", version = "1.5.7-6" }
 [plugins]
 gatling = { id = "io.gatling.gradle", version = "3.14.9" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
-maven-central-publish = { id = "io.github.zenhelix.maven-central-publish", version = "0.8.0" }
 nessie-run = { id = "org.projectnessie", version = "0.32.7" }
+nmcp = { id = "com.gradleup.nmcp.aggregation", version = "1.3.0" }
 protobuf = { id = "com.google.protobuf", version = "0.9.5" }
 quarkus = { id = "io.quarkus", version.ref = "quarkusPlugin" }
 quarkus-extension = { id = "io.quarkus.extension", version.ref = "quarkusPlugin" }


### PR DESCRIPTION
Publishing plugin at https://github.com/GradleUp/nmcp (MIT license).

This plugin has frequent releases and looks actively maintained. Should also bring back snapshot publishing, and it supports "aggregated" publications out of the box.