### PR TITLE
Errorprone: fix use of assertj .as()

### DIFF
--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/CatalogTests.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/CatalogTests.java
@@ -916,9 +916,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Set<String> expectedMetadataFileLocations =
         ReachableFileUtil.metadataFileLocations(table, false);
     assertThat(actualMetadataFileLocations)
+        .as("Should have one metadata file")
         .hasSameElementsAs(expectedMetadataFileLocations)
-        .hasSize(1)
-        .as("Should have one metadata file");
+        .hasSize(1);
   }
 
   @Test


### PR DESCRIPTION
Preparation for #11829