### PR TITLE
CI/NesQuEIT: Use Java 17 to run NesQuEIT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -935,7 +935,7 @@ jobs:
         with:
           distribution: 'temurin'
           # Java 17 or 21 required for Nessie build, Java 17 required for Iceberg build, Java 11 required for Flink & Presto
-          java-version: | 
+          java-version: |
             11
             17
             21


### PR DESCRIPTION
Iceberg just dropped support for Java 11 and requires Java 17 as the minimum now.