### PR TITLE
Require Java 17 as the minimum Java version for clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -875,8 +875,8 @@ jobs:
     if: github.event_name == 'pull_request' && needs.determine-jobs.outputs.nesqueit == 'true'
     env:
       NESSIE_DIR: included-builds/nessie
-      NESSIE_PATCH_REPOSITORY: ''
-      NESSIE_PATCH_BRANCH: ''
+      NESSIE_PATCH_REPOSITORY: 'snazy/nessie'
+      NESSIE_PATCH_BRANCH: 'integ-bump/iceberg'
       NESQUEIT_REPOSITORY: projectnessie/query-engine-integration-tests
       NESQUEIT_BRANCH: main
       ICEBERG_DIR: included-builds/iceberg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Upgrade notes
 
+* Java minimum version requirement is now Java 17 for all Nessie modules that required Java 11 in earlier Nessie
+  versions. This follows Iceberg's recent change to drop support for Java 11.
+
 ### Breaking changes
 
 ### New Features

--- a/api/client-testextension/build.gradle.kts
+++ b/api/client-testextension/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - JUnit Jupiter Test Extension for Client-Side Tests" }
 

--- a/api/client/build.gradle.kts
+++ b/api/client/build.gradle.kts
@@ -16,7 +16,7 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Client" }
 
@@ -102,7 +102,6 @@ tasks.named("jandex") { enabled = false }
 
 val jacksonTestVersions =
   setOf(
-    "2.13.4", // Spark 3.3
     "2.14.2", // Spark 3.4
     "2.15.2", // Spark 3.5
     // there's been some change from 2.18.2->.3, see #10489 &

--- a/api/model/build.gradle.kts
+++ b/api/model/build.gradle.kts
@@ -20,7 +20,7 @@ import io.smallrye.openapi.gradleplugin.SmallryeOpenApiTask
 import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
-  id("nessie-conventions-java11")
+  id("nessie-conventions-java17")
   alias(libs.plugins.smallrye.openapi)
 }
 

--- a/build-logic/src/main/kotlin/Utilities.kt
+++ b/build-logic/src/main/kotlin/Utilities.kt
@@ -358,19 +358,14 @@ fun Project.useSparkScalaVersionsForProject(
  * Get the newest Java LTS version that is lower than or equal to the currently running Java
  * version.
  *
- * For Spark 3.2, this is always Java 11. For Spark 3.3 and 3.4, this is Java 17 when running the
- * build on Java 17 or newer, otherwise Java 11.
+ * Always yields Java 17.
  */
 fun javaVersionForSpark(sparkMajorVersion: String): Int {
   val currentJavaVersion = JavaVersion.current().majorVersion.toInt()
   return when (sparkMajorVersion) {
     "3.3",
     "3.4",
-    "3.5" ->
-      when {
-        currentJavaVersion >= 17 -> 17
-        else -> 11
-      }
+    "3.5" -> 17
     else ->
       throw IllegalArgumentException(
         "Do not know which Java version Spark $sparkMajorVersion supports"

--- a/build-logic/src/main/kotlin/nessie-conventions-java17.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-conventions-java17.gradle.kts
@@ -18,4 +18,4 @@
 
 plugins { id("nessie-common-java") }
 
-tasks.withType<JavaCompile>().configureEach { options.release = 11 }
+tasks.withType<JavaCompile>().configureEach { options.release = 17 }

--- a/build-logic/src/main/kotlin/nessie-conventions-spark.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-conventions-spark.gradle.kts
@@ -22,11 +22,11 @@ plugins {
   id("nessie-scala")
 }
 
-tasks.withType<JavaCompile>().configureEach { options.release = 11 }
+tasks.withType<JavaCompile>().configureEach { options.release = 17 }
 
 tasks.withType<ScalaCompile>().configureEach {
-  options.release = 11
-  scalaCompileOptions.additionalParameters.add("-release:11")
-  sourceCompatibility = "11"
-  targetCompatibility = "11"
+  options.release = 17
+  scalaCompileOptions.additionalParameters.add("-release:17")
+  sourceCompatibility = "17"
+  targetCompatibility = "17"
 }

--- a/catalog/files/api/build.gradle.kts
+++ b/catalog/files/api/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Catalog - Files API" }
 

--- a/catalog/files/impl/build.gradle.kts
+++ b/catalog/files/impl/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-java11")
+  id("nessie-conventions-java17")
   alias(libs.plugins.jmh)
 }
 

--- a/catalog/format/iceberg-bench/build.gradle.kts
+++ b/catalog/format/iceberg-bench/build.gradle.kts
@@ -18,7 +18,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
   id("com.gradleup.shadow")
-  id("nessie-conventions-java11")
+  id("nessie-conventions-java17")
   alias(libs.plugins.jmh)
 }
 

--- a/catalog/format/iceberg-fixturegen/build.gradle.kts
+++ b/catalog/format/iceberg-fixturegen/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 description = "Nessie - Catalog - Iceberg table format fixtures"
 

--- a/catalog/format/iceberg/build.gradle.kts
+++ b/catalog/format/iceberg/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 description = "Nessie - Catalog - Iceberg table format"
 

--- a/catalog/model/build.gradle.kts
+++ b/catalog/model/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Catalog - Schema Model" }
 

--- a/catalog/secrets/api/build.gradle.kts
+++ b/catalog/secrets/api/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Catalog - Secrets API" }
 

--- a/catalog/secrets/aws/build.gradle.kts
+++ b/catalog/secrets/aws/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 extra["maven.name"] = "Nessie - Catalog - Secrets AWS"
 

--- a/catalog/secrets/azure/build.gradle.kts
+++ b/catalog/secrets/azure/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 extra["maven.name"] = "Nessie - Catalog - Secrets Azure"
 

--- a/catalog/secrets/cache/build.gradle.kts
+++ b/catalog/secrets/cache/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 extra["maven.name"] = "Nessie - Catalog - Secrets Cache"
 

--- a/catalog/secrets/gcs/build.gradle.kts
+++ b/catalog/secrets/gcs/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 extra["maven.name"] = "Nessie - Catalog - Secrets GCS"
 

--- a/catalog/secrets/smallrye/build.gradle.kts
+++ b/catalog/secrets/smallrye/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 extra["maven.name"] = "Nessie - Catalog - Secrets Cache"
 

--- a/catalog/secrets/vault/build.gradle.kts
+++ b/catalog/secrets/vault/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 extra["maven.name"] = "Nessie - Catalog - Secrets Vault"
 

--- a/catalog/service/common/build.gradle.kts
+++ b/catalog/service/common/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Catalog - Service Common" }
 

--- a/catalog/service/config/build.gradle.kts
+++ b/catalog/service/config/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Catalog - Service Common" }
 

--- a/catalog/service/impl/build.gradle.kts
+++ b/catalog/service/impl/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Catalog - Service Implementation" }
 

--- a/catalog/service/rest/build.gradle.kts
+++ b/catalog/service/rest/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Catalog - REST Service" }
 

--- a/catalog/service/transfer/build.gradle.kts
+++ b/catalog/service/transfer/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Catalog - Transfer Related" }
 

--- a/cli/cli/build.gradle.kts
+++ b/cli/cli/build.gradle.kts
@@ -18,7 +18,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
-  id("nessie-conventions-java11")
+  id("nessie-conventions-java17")
   id("nessie-shadow-jar")
   id("nessie-license-report")
 }

--- a/cli/grammar/build.gradle.kts
+++ b/cli/grammar/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-java11")
+  id("nessie-conventions-java17")
   alias(libs.plugins.jmh)
 }
 

--- a/compatibility/common/build.gradle.kts
+++ b/compatibility/common/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Backward Compatibility - Common" }
 

--- a/compatibility/compatibility-tests/build.gradle.kts
+++ b/compatibility/compatibility-tests/build.gradle.kts
@@ -16,7 +16,7 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Backward Compatibility - Tests" }
 

--- a/compatibility/jersey/build.gradle.kts
+++ b/compatibility/jersey/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Backward Compatibility - Jersey" }
 

--- a/events/api/build.gradle.kts
+++ b/events/api/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Events - API" }
 

--- a/events/service/build.gradle.kts
+++ b/events/service/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Events - Service" }
 

--- a/events/spi/build.gradle.kts
+++ b/events/spi/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Events - SPI" }
 

--- a/gc/gc-base-tests/build.gradle.kts
+++ b/gc/gc-base-tests/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - GC - Base Implementation Tests" }
 

--- a/gc/gc-base/build.gradle.kts
+++ b/gc/gc-base/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - GC - Base Implementation" }
 

--- a/gc/gc-iceberg-files/build.gradle.kts
+++ b/gc/gc-iceberg-files/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - GC - Iceberg FileIO connector" }
 

--- a/gc/gc-iceberg-inttest/build.gradle.kts
+++ b/gc/gc-iceberg-inttest/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
   alias(libs.plugins.nessie.run)
 }
 
-tasks.withType<JavaCompile>().configureEach { options.release = 11 }
+tasks.withType<JavaCompile>().configureEach { options.release = 17 }
 
 publishingHelper { mavenName = "Nessie - GC - Integration tests" }
 

--- a/gc/gc-iceberg-mock/build.gradle.kts
+++ b/gc/gc-iceberg-mock/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - GC - Mocked Iceberg data for tests" }
 

--- a/gc/gc-iceberg/build.gradle.kts
+++ b/gc/gc-iceberg/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - GC - Iceberg content functionality" }
 

--- a/gc/gc-repository-jdbc/build.gradle.kts
+++ b/gc/gc-repository-jdbc/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - GC - JDBC live-contents-set persistence" }
 

--- a/gc/gc-tool-inttest/build.gradle.kts
+++ b/gc/gc-tool-inttest/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
   alias(libs.plugins.nessie.run)
 }
 
-tasks.withType<JavaCompile>().configureEach { options.release = 11 }
+tasks.withType<JavaCompile>().configureEach { options.release = 17 }
 
 publishingHelper { mavenName = "Nessie - GC - CLI integration test" }
 

--- a/gc/gc-tool/build.gradle.kts
+++ b/gc/gc-tool/build.gradle.kts
@@ -18,7 +18,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
   id("com.gradleup.shadow")
-  id("nessie-conventions-java11")
+  id("nessie-conventions-java17")
   id("nessie-shadow-jar")
   id("nessie-license-report")
 }

--- a/servers/jax-rs-testextension/build.gradle.kts
+++ b/servers/jax-rs-testextension/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - JUnit Jupiter Test Extension" }
 

--- a/servers/jax-rs-tests/build.gradle.kts
+++ b/servers/jax-rs-tests/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - REST-API Tests" }
 

--- a/servers/rest-common/build.gradle.kts
+++ b/servers/rest-common/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - REST Common" }
 

--- a/servers/rest-services/build.gradle.kts
+++ b/servers/rest-services/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - REST Services" }
 

--- a/servers/services-config/build.gradle.kts
+++ b/servers/services-config/build.gradle.kts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Services Config" }

--- a/servers/services/build.gradle.kts
+++ b/servers/services/build.gradle.kts
@@ -16,7 +16,7 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Services" }
 

--- a/servers/store-proto/build.gradle.kts
+++ b/servers/store-proto/build.gradle.kts
@@ -19,7 +19,7 @@ import com.google.protobuf.gradle.ProtobufExtension
 import com.google.protobuf.gradle.ProtobufExtract
 
 plugins {
-  id("nessie-conventions-java11")
+  id("nessie-conventions-java17")
   alias(libs.plugins.protobuf)
 }
 

--- a/servers/store/build.gradle.kts
+++ b/servers/store/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Server - Store" }
 

--- a/site/docs/downloads/index.md
+++ b/site/docs/downloads/index.md
@@ -92,7 +92,7 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
 
 === "Standalone Jar"
 
-    Requires Java 11, Java 21 recommended.
+    Requires Java 17, Java 21 recommended.
 
     ```bash
     curl -L -o nessie-cli-{{ versions.nessie }}.jar \
@@ -125,7 +125,7 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
 
 === "Standalone Jar"
 
-    Requires Java 11, Java 21 recommended.
+    Requires Java 17, Java 21 recommended.
 
     ```bash
     curl -L -o nessie-gc-{{ versions.nessie }}.jar \

--- a/site/in-dev/gc.md
+++ b/site/in-dev/gc.md
@@ -9,7 +9,7 @@ periodically to keep the repository clean and to avoid unnecessary storage costs
 
 ## Requirements
 
-The Nessie GC tool is distributed as an uber-jar and requires Java 11 or later to be available on
+The Nessie GC tool is distributed as an uber-jar and requires Java 17 or later to be available on
 the host where it is running.
 
 It is also available as a Docker image, see below for more information.

--- a/site/in-dev/index-release.md
+++ b/site/in-dev/index-release.md
@@ -92,7 +92,7 @@ The main Nessie server serves the Nessie repository using the Iceberg REST API a
 
 === "Standalone Jar"
 
-    Requires Java 11, Java 21 recommended.
+    Requires Java 17, Java 21 recommended.
 
     ```bash
     curl -L -o nessie-cli-::NESSIE_VERSION::.jar \

--- a/tasks/api/build.gradle.kts
+++ b/tasks/api/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-java11")
+  id("nessie-conventions-java17")
   alias(libs.plugins.jmh)
 }
 

--- a/tasks/service/async/build.gradle.kts
+++ b/tasks/service/async/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Tasks - Async" }
 

--- a/tasks/service/impl/build.gradle.kts
+++ b/tasks/service/impl/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Tasks - Service" }
 

--- a/testing/azurite-container/build.gradle.kts
+++ b/testing/azurite-container/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Azurite testcontainer" }
 

--- a/testing/container-spec-helper/build.gradle.kts
+++ b/testing/container-spec-helper/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Container Specification Helper" }
 

--- a/testing/gcs-container/build.gradle.kts
+++ b/testing/gcs-container/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - GCS testcontainer" }
 

--- a/testing/keycloak-container/build.gradle.kts
+++ b/testing/keycloak-container/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Keycloak testcontainer" }
 

--- a/testing/minio-container/build.gradle.kts
+++ b/testing/minio-container/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Minio testcontainer" }
 

--- a/testing/multi-env-test-engine/build.gradle.kts
+++ b/testing/multi-env-test-engine/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Multi-Environment Test Engine" }
 

--- a/testing/nessie-container/build.gradle.kts
+++ b/testing/nessie-container/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Nessie testcontainer" }
 

--- a/testing/object-storage-mock/build.gradle.kts
+++ b/testing/object-storage-mock/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - S3/ADLS/GCS object storage mock" }
 

--- a/testing/trino-container/build.gradle.kts
+++ b/testing/trino-container/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Trino testcontainer" }
 

--- a/tools/content-generator/build.gradle.kts
+++ b/tools/content-generator/build.gradle.kts
@@ -18,7 +18,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
   alias(libs.plugins.nessie.run)
-  id("nessie-conventions-java11")
+  id("nessie-conventions-java17")
   id("nessie-shadow-jar")
   id("nessie-license-report")
 }

--- a/tools/doc-generator/annotations/build.gradle.kts
+++ b/tools/doc-generator/annotations/build.gradle.kts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Annotations for nessie-doc-generator-doclet" }

--- a/tools/doc-generator/doclet/build.gradle.kts
+++ b/tools/doc-generator/doclet/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 extra["maven.name"] =
   "Code to generate markdown documentation files for 'properties' and smallrye-config"

--- a/tools/immutables-std/build.gradle.kts
+++ b/tools/immutables-std/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Build tool - Immutables without javax annotations" }
 

--- a/tools/immutables/build.gradle.kts
+++ b/tools/immutables/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Build tool - Immutables" }
 

--- a/tools/network/build.gradle.kts
+++ b/tools/network/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Network Tools" }
 

--- a/tools/protobuf-relocated/build.gradle.kts
+++ b/tools/protobuf-relocated/build.gradle.kts
@@ -17,7 +17,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-  id("nessie-conventions-java11")
+  id("nessie-conventions-java17")
   id("nessie-shadow-jar")
 }
 

--- a/tools/storage/uri/build.gradle.kts
+++ b/tools/storage/uri/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 dependencies {
   implementation(libs.guava)

--- a/versioned/combined-cs/build.gradle.kts
+++ b/versioned/combined-cs/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Combined Client and Server" }
 

--- a/versioned/spi/build.gradle.kts
+++ b/versioned/spi/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Versioned Store SPI" }
 

--- a/versioned/storage/batching/build.gradle.kts
+++ b/versioned/storage/batching/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - Batching Persist" }
 

--- a/versioned/storage/bigtable-tests/build.gradle.kts
+++ b/versioned/storage/bigtable-tests/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - BigTable - Tests" }
 

--- a/versioned/storage/bigtable/build.gradle.kts
+++ b/versioned/storage/bigtable/build.gradle.kts
@@ -16,7 +16,7 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - BigTable" }
 

--- a/versioned/storage/cache/build.gradle.kts
+++ b/versioned/storage/cache/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - Cache" }
 

--- a/versioned/storage/cassandra-tests/build.gradle.kts
+++ b/versioned/storage/cassandra-tests/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - Apache Cassandra - Tests" }
 

--- a/versioned/storage/cassandra/build.gradle.kts
+++ b/versioned/storage/cassandra/build.gradle.kts
@@ -16,7 +16,7 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - Apache Cassandra" }
 

--- a/versioned/storage/cassandra2-tests/build.gradle.kts
+++ b/versioned/storage/cassandra2-tests/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - Apache Cassandra - Tests" }
 

--- a/versioned/storage/cassandra2/build.gradle.kts
+++ b/versioned/storage/cassandra2/build.gradle.kts
@@ -16,7 +16,7 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - Apache Cassandra" }
 

--- a/versioned/storage/cleanup/build.gradle.kts
+++ b/versioned/storage/cleanup/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - Cleanup unreferenced objects" }
 

--- a/versioned/storage/common-proto/build.gradle.kts
+++ b/versioned/storage/common-proto/build.gradle.kts
@@ -19,7 +19,7 @@ import com.google.protobuf.gradle.ProtobufExtension
 import com.google.protobuf.gradle.ProtobufExtract
 
 plugins {
-  id("nessie-conventions-java11")
+  id("nessie-conventions-java17")
   alias(libs.plugins.protobuf)
 }
 

--- a/versioned/storage/common-serialize/build.gradle.kts
+++ b/versioned/storage/common-serialize/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - Common serialization" }
 

--- a/versioned/storage/common-tests/build.gradle.kts
+++ b/versioned/storage/common-tests/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - Tests" }
 

--- a/versioned/storage/common/build.gradle.kts
+++ b/versioned/storage/common/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-java11")
+  id("nessie-conventions-java17")
   alias(libs.plugins.jmh)
 }
 

--- a/versioned/storage/dynamodb-tests/build.gradle.kts
+++ b/versioned/storage/dynamodb-tests/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - DynamoDB - Tests" }
 

--- a/versioned/storage/dynamodb/build.gradle.kts
+++ b/versioned/storage/dynamodb/build.gradle.kts
@@ -16,7 +16,7 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - DynamoDB" }
 

--- a/versioned/storage/dynamodb2-tests/build.gradle.kts
+++ b/versioned/storage/dynamodb2-tests/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - DynamoDB - Tests" }
 

--- a/versioned/storage/dynamodb2/build.gradle.kts
+++ b/versioned/storage/dynamodb2/build.gradle.kts
@@ -16,7 +16,7 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - DynamoDB" }
 

--- a/versioned/storage/inmemory-tests/build.gradle.kts
+++ b/versioned/storage/inmemory-tests/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - Inmemory - Tests" }
 

--- a/versioned/storage/inmemory/build.gradle.kts
+++ b/versioned/storage/inmemory/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - Inmemory" }
 

--- a/versioned/storage/jdbc-tests/build.gradle.kts
+++ b/versioned/storage/jdbc-tests/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - JDBC - Tests" }
 

--- a/versioned/storage/jdbc/build.gradle.kts
+++ b/versioned/storage/jdbc/build.gradle.kts
@@ -16,7 +16,7 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - JDBC" }
 

--- a/versioned/storage/jdbc2-tests/build.gradle.kts
+++ b/versioned/storage/jdbc2-tests/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - JDBC2 - Tests" }
 

--- a/versioned/storage/jdbc2/build.gradle.kts
+++ b/versioned/storage/jdbc2/build.gradle.kts
@@ -16,7 +16,7 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - JDBC2" }
 

--- a/versioned/storage/mongodb-tests/build.gradle.kts
+++ b/versioned/storage/mongodb-tests/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - MongoDB - Tests" }
 

--- a/versioned/storage/mongodb/build.gradle.kts
+++ b/versioned/storage/mongodb/build.gradle.kts
@@ -16,7 +16,7 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - MongoDB" }
 

--- a/versioned/storage/mongodb2-tests/build.gradle.kts
+++ b/versioned/storage/mongodb2-tests/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - MongoDB2 - Tests" }
 

--- a/versioned/storage/mongodb2/build.gradle.kts
+++ b/versioned/storage/mongodb2/build.gradle.kts
@@ -16,7 +16,7 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - MongoDB2" }
 

--- a/versioned/storage/rocksdb-tests/build.gradle.kts
+++ b/versioned/storage/rocksdb-tests/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - RocksDB - Tests" }
 

--- a/versioned/storage/rocksdb/build.gradle.kts
+++ b/versioned/storage/rocksdb/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - RocksDB" }
 

--- a/versioned/storage/store/build.gradle.kts
+++ b/versioned/storage/store/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - Version Store" }
 

--- a/versioned/storage/testextension/build.gradle.kts
+++ b/versioned/storage/testextension/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Storage - Testextension" }
 

--- a/versioned/tests/build.gradle.kts
+++ b/versioned/tests/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Versioned Store Integration Tests" }
 

--- a/versioned/transfer-proto/build.gradle.kts
+++ b/versioned/transfer-proto/build.gradle.kts
@@ -19,7 +19,7 @@ import com.google.protobuf.gradle.ProtobufExtension
 import com.google.protobuf.gradle.ProtobufExtract
 
 plugins {
-  id("nessie-conventions-java11")
+  id("nessie-conventions-java17")
   alias(libs.plugins.protobuf)
 }
 

--- a/versioned/transfer-related/build.gradle.kts
+++ b/versioned/transfer-related/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Import/Export - Related Objects" }
 

--- a/versioned/transfer/build.gradle.kts
+++ b/versioned/transfer/build.gradle.kts
@@ -16,7 +16,7 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-plugins { id("nessie-conventions-java11") }
+plugins { id("nessie-conventions-java17") }
 
 publishingHelper { mavenName = "Nessie - Import/Export" }
 


### PR DESCRIPTION
This follows Iceberg's recent change to drop Java 11.