### PR TITLE
Fix ITBigTablePersis.TablePrefixes execution order issue

### DIFF
--- a/versioned/storage/bigtable/src/intTest/java/org/projectnessie/versioned/storage/bigtable/ITBigTablePersist.java
+++ b/versioned/storage/bigtable/src/intTest/java/org/projectnessie/versioned/storage/bigtable/ITBigTablePersist.java
@@ -83,10 +83,8 @@ public class ITBigTablePersist extends AbstractPersistTests {
         BigtableTableAdminClient adminClientB = requireNonNull(backendB.adminClient());
 
         List<String> expectedTables = List.of();
-        soft.assertThat(adminClientA.listTables())
-            .containsExactlyInAnyOrderElementsOf(expectedTables);
-        soft.assertThat(adminClientB.listTables())
-            .containsExactlyInAnyOrderElementsOf(expectedTables);
+        soft.assertThat(adminClientA.listTables()).containsAll(expectedTables);
+        soft.assertThat(adminClientB.listTables()).containsAll(expectedTables);
 
         // Setup "A"
 
@@ -97,10 +95,8 @@ public class ITBigTablePersist extends AbstractPersistTests {
 
         expectedTables = List.of("instanceA_refs", "instanceA_objs");
 
-        soft.assertThat(adminClientA.listTables())
-            .containsExactlyInAnyOrderElementsOf(expectedTables);
-        soft.assertThat(adminClientB.listTables())
-            .containsExactlyInAnyOrderElementsOf(expectedTables);
+        soft.assertThat(adminClientA.listTables()).containsAll(expectedTables);
+        soft.assertThat(adminClientB.listTables()).containsAll(expectedTables);
 
         soft.assertThat(repoA.repositoryExists()).isFalse();
         repoA.initialize("main");
@@ -116,10 +112,8 @@ public class ITBigTablePersist extends AbstractPersistTests {
         expectedTables =
             List.of("instanceA_refs", "instanceA_objs", "instanceB_refs", "instanceB_objs");
 
-        soft.assertThat(adminClientA.listTables())
-            .containsExactlyInAnyOrderElementsOf(expectedTables);
-        soft.assertThat(adminClientB.listTables())
-            .containsExactlyInAnyOrderElementsOf(expectedTables);
+        soft.assertThat(adminClientA.listTables()).containsAll(expectedTables);
+        soft.assertThat(adminClientB.listTables()).containsAll(expectedTables);
 
         soft.assertThat(repoB.repositoryExists()).isFalse();
         repoB.initialize("main");


### PR DESCRIPTION
The backend database provided by the PersistExtension is reused across test classes. While `Backend`s provide a functionality to setup a schema, there is no functionality to drop a schema.

If the `TablePrefixes` test class is executed after another test class, the tests fail, because the non-prefixed tables `refs` and `objs` already exist.