### PR TITLE
Let quarkus-build index com.azure:azure-json

### DIFF
--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -395,6 +395,8 @@ quarkus.index-dependency.protobuf.group-id=com.google.protobuf
 quarkus.index-dependency.protobuf.artifact-id=protobuf-java
 quarkus.index-dependency.avro.group-id=org.apache.avro
 quarkus.index-dependency.avro.artifact-id=avro
+quarkus.index-dependency.azure-json.group-id=com.azure
+quarkus.index-dependency.azure-json.artifact-id=azure-json
 
 quarkus.arc.ignored-split-packages=\
   org.projectnessie.jaxrs.tests,\


### PR DESCRIPTION
... to prevent unnecessary warnings during test executions