### PR TITLE
Tackle `@Valid` on collection element type warning

### DIFF
--- a/servers/services/src/main/java/org/projectnessie/services/spi/ContentService.java
+++ b/servers/services/src/main/java/org/projectnessie/services/spi/ContentService.java
@@ -93,7 +93,7 @@ public interface ContentService {
               regexp = HASH_OR_RELATIVE_COMMIT_SPEC_REGEX,
               message = HASH_OR_RELATIVE_COMMIT_SPEC_MESSAGE)
           String hashOnRef,
-      @Valid @Size @Size(min = 1) List<ContentKey> keys,
+      @Size @Size(min = 1) List<@Valid ContentKey> keys,
       boolean withDocumentation,
       RequestMeta requestMeta)
       throws NessieNotFoundException;


### PR DESCRIPTION
Hibernate complains, in a warning, that `@Valid` is misplaced.