### PR TITLE
Fix Iceberg-realm.json so example docker containers can work

### DIFF
--- a/docker/authn-keycloak/config/iceberg-realm.json
+++ b/docker/authn-keycloak/config/iceberg-realm.json
@@ -380,7 +380,7 @@
         "acr.loa.map": "{}",
         "display.on.consent.screen": "false",
         "client.offline.session.max.lifespan": "86400",
-        "client.session.max.lifespan": "1800",
+        "client.session.max.lifespan": "36000",
         "token.response.type.bearer.lower-case": "false",
         "client.session.idle.timeout": "1800"
       },
@@ -540,7 +540,7 @@
         "acr.loa.map": "{}",
         "display.on.consent.screen": "false",
         "client.offline.session.max.lifespan": "86400",
-        "client.session.max.lifespan": "1800",
+        "client.session.max.lifespan": "36000",
         "token.response.type.bearer.lower-case": "false",
         "client.session.idle.timeout": "1800"
       },
@@ -700,7 +700,7 @@
         "acr.loa.map": "{}",
         "display.on.consent.screen": "false",
         "client.offline.session.max.lifespan": "86400",
-        "client.session.max.lifespan": "1800",
+        "client.session.max.lifespan": "36000",
         "token.response.type.bearer.lower-case": "false",
         "client.session.idle.timeout": "1800"
       },


### PR DESCRIPTION
When calling `docker compose up` in the docker/catalog-auth-s3 directory, I got the following error

```
keycloak-1     | 2026-01-20 08:02:06,442 INFO  [com.arjuna.ats.jbossatx] (main) ARJUNA032014: Stopping transaction recovery manager
keycloak-1     | 2026-01-20 08:02:06,671 ERROR [org.keycloak.quarkus.runtime.cli.ExecutionExceptionHandler] (main) ERROR: Failed to start server in (development) mode
keycloak-1     | 2026-01-20 08:02:06,672 ERROR [org.keycloak.quarkus.runtime.cli.ExecutionExceptionHandler] (main) ERROR: Invalid client client1: Client session idle timeout cannot exceed realm SSO session idle timeout.; Client session max lifespan cannot exceed realm SSO session max lifespan.
keycloak-1     | 2026-01-20 08:02:06,672 ERROR [org.keycloak.quarkus.runtime.cli.ExecutionExceptionHandler] (main) For more details run the same command passing the '--verbose' option. Also you can use '--help' to see the details about the usage of the particular command.
```
The key messages being 
- Invalid client client1: Client session idle timeout cannot exceed realm SSO session idle timeout.
-  Client session max lifespan cannot exceed realm SSO session max lifespan.

Modifying the iceberg-realm.json so that `client.session.max.lifespan` matches `ssoSessionMaxLifespan` and `client.session.idle.timeout` matches `ssoSessionIdleTimeout` fixes the issue. 


Unsure how this will affect other docker containers, but I imagine they are suffering from the same issue. Also, this has been an issue for maybe ~3 weeks, and since no one has reported it, I feel this change is pretty safe.