### PR TITLE
Enforce scala-lang version

### DIFF
--- a/build-logic/src/main/kotlin/Utilities.kt
+++ b/build-logic/src/main/kotlin/Utilities.kt
@@ -133,13 +133,17 @@ fun ModuleDependency.withSparkExcludes(): ModuleDependency {
 }
 
 fun DependencyHandlerScope.forScala(scalaVersion: String) {
+  forScala(scalaVersion, "implementation")
+}
+
+fun DependencyHandlerScope.forScala(scalaVersion: String, configName: String) {
   // Note: Quarkus contains Scala dependencies since 2.9.0
-  add("implementation", "org.scala-lang:scala-library:$scalaVersion!!")
-  add("implementation", "org.scala-lang:scala-reflect:$scalaVersion!!")
+  add(configName, "org.scala-lang:scala-library:$scalaVersion!!")
+  add(configName, "org.scala-lang:scala-reflect:$scalaVersion!!")
   if (scalaVersion.startsWith("2.12")) {
     // We only need this dependency for Scala 2.12, which does not have
     // scala.jdk.CollectionConverters, but the deprecated JavaConverters.
-    add("implementation", "org.scala-lang.modules:scala-collection-compat_2.12:2.12.0")
+    add(configName, "org.scala-lang.modules:scala-collection-compat_2.12:2.12.0")
   }
 }
 

--- a/gc/gc-iceberg-inttest/build.gradle.kts
+++ b/gc/gc-iceberg-inttest/build.gradle.kts
@@ -57,6 +57,10 @@ dependencies {
 
   implementation(libs.agrona)
 
+  // This is required to resolve varying Scala minor version mismatches,
+  // for example via Spark and its transitive dependencies.
+  forScala(sparkScala.scalaVersion, "intTestImplementation")
+
   intTestImplementation(
     nessieProject("nessie-spark-extensions-basetests_${sparkScala.scalaMajorVersion}")
   )


### PR DESCRIPTION
This change lets the GC integration tests enforce the exact scala version across all dependencies. The difference is that it's enforced from the "outer"/"consuming" project and not from a dependency that can "clash" with version declaration from/via other dependencies like Spark.

This particularly unblocks #11929, which currently fails with
```
Could not determine the dependencies of task ':nessie-gc-iceberg-inttest:intTest'.
> Could not resolve all dependencies for configuration ':nessie-gc-iceberg-inttest:intTestRuntimeClasspath'.
   > Could not resolve org.scala-lang:scala-library:{strictly 2.12.20}.
     Required by:
         project ':nessie-gc-iceberg-inttest' > project :nessie-spark-extensions-basetests_2.12
         project ':nessie-gc-iceberg-inttest' > project :nessie-spark-extensions-3.5_2.12
         project ':nessie-gc-iceberg-inttest' > project :nessie-spark-extensions-base_2.12
      > Cannot find a version of 'org.scala-lang:scala-library' that satisfies the version constraints:
           Dependency path: 'project :nessie-gc-iceberg-inttest' (intTestRuntimeClasspath) --> 'project :nessie-spark-extensions-basetests_2.12' (runtimeElements) --> 'org.scala-lang:scala-library:{strictly 2.12.20}'
           Dependency path: 'project :nessie-gc-iceberg-inttest' (intTestRuntimeClasspath) --> 'project :nessie-spark-extensions-3.5_2.12' (runtimeElements) --> 'org.scala-lang:scala-library:{strictly 2.12.20}'
           Dependency path: 'project :nessie-gc-iceberg-inttest' (intTestRuntimeClasspath) --> 'project :nessie-spark-extensions-base_2.12' (runtimeElements) --> 'org.scala-lang:scala-library:{strictly 2.12.20}'
           Dependency path: 'project :nessie-gc-iceberg-inttest' (intTestRuntimeClasspath) --> 'org.apache.spark:spark-core_2.12:3.5.3' (runtime) --> 'org.scala-lang:scala-library:2.12.18'
           Dependency path: 'project :nessie-gc-iceberg-inttest' (intTestRuntimeClasspath) --> 'project :nessie-spark-extensions-basetests_2.12' (runtimeElements) --> 'org.scala-lang:scala-reflect:2.12.20' (runtime) --> 'org.scala-lang:scala-library:2.12.20'
           Dependency path: 'project :nessie-gc-iceberg-inttest' (intTestRuntimeClasspath) --> 'org.apache.spark:spark-sql_2.12:3.5.3' (runtime) --> 'org.apache.spark:spark-tags_2.12:3.5.3' (runtime) --> 'org.scala-lang:scala-library:2.12.18'
           Dependency path: 'project :nessie-gc-iceberg-inttest' (intTestRuntimeClasspath) --> 'org.apache.spark:spark-core_2.12:3.5.3' (runtime) --> 'com.twitter:chill_2.12:0.10.0' (runtime) --> 'org.scala-lang:scala-library:2.12.14'
           Dependency path: 'project :nessie-gc-iceberg-inttest' (intTestRuntimeClasspath) --> 'org.apache.spark:spark-core_2.12:3.5.3' (runtime) --> 'org.apache.spark:spark-network-common_2.12:3.5.3' (runtime) --> 'org.scala-lang:scala-library:2.12.18'
           Dependency path: 'project :nessie-gc-iceberg-inttest' (intTestRuntimeClasspath) --> 'org.apache.spark:spark-core_2.12:3.5.3' (runtime) --> 'org.scala-lang.modules:scala-xml_2.12:2.1.0' (runtime) --> 'org.scala-lang:scala-library:2.12.15'
           Dependency path: 'project :nessie-gc-iceberg-inttest' (intTestRuntimeClasspath) --> 'org.apache.spark:spark-core_2.12:3.5.3' (runtime) --> 'org.json4s:json4s-jackson_2.12:3.7.0-M11' (runtime) --> 'org.scala-lang:scala-library:2.12.13'
           Dependency path: 'project :nessie-gc-iceberg-inttest' (intTestRuntimeClasspath) --> 'project :nessie-spark-extensions-basetests_2.12' (runtimeElements) --> 'org.scala-lang.modules:scala-collection-compat_2.12:2.13.0' (runtime) --> 'org.scala-lang:scala-library:2.12.19'
           Dependency path: 'project :nessie-gc-iceberg-inttest' (intTestRuntimeClasspath) --> 'org.apache.spark:spark-core_2.12:3.5.3' (runtime) --> 'com.fasterxml.jackson.module:jackson-module-scala_2.12:2.21.0' (runtime) --> 'org.scala-lang:scala-library:2.12.21'
           Dependency path: 'project :nessie-gc-iceberg-inttest' (intTestRuntimeClasspath) --> 'org.apache.spark:spark-core_2.12:3.5.3' (runtime) --> 'org.json4s:json4s-jackson_2.12:3.7.0-M11' (runtime) --> 'org.json4s:json4s-core_2.12:3.7.0-M11' (runtime) --> 'org.scala-lang:scala-library:2.12.13'
           Dependency path: 'project :nessie-gc-iceberg-inttest' (intTestRuntimeClasspath) --> 'org.apache.spark:spark-sql_2.12:3.5.3' (runtime) --> 'org.apache.spark:spark-catalyst_2.12:3.5.3' (runtime) --> 'org.apache.spark:spark-sql-api_2.12:3.5.3' (runtime) --> 'org.scala-lang.modules:scala-parser-combinators_2.12:2.3.0' (runtime) --> 'org.scala-lang:scala-library:2.12.17'
           Dependency path: 'project :nessie-gc-iceberg-inttest' (intTestRuntimeClasspath) --> 'org.apache.spark:spark-core_2.12:3.5.3' (runtime) --> 'org.json4s:json4s-jackson_2.12:3.7.0-M11' (runtime) --> 'org.json4s:json4s-core_2.12:3.7.0-M11' (runtime) --> 'org.json4s:json4s-ast_2.12:3.7.0-M11' (runtime) --> 'org.scala-lang:scala-library:2.12.13'
           Dependency path: 'project :nessie-gc-iceberg-inttest' (intTestRuntimeClasspath) --> 'org.apache.spark:spark-core_2.12:3.5.3' (runtime) --> 'org.json4s:json4s-jackson_2.12:3.7.0-M11' (runtime) --> 'org.json4s:json4s-core_2.12:3.7.0-M11' (runtime) --> 'org.json4s:json4s-scalap_2.12:3.7.0-M11' (runtime) --> 'org.scala-lang:scala-library:2.12.13'
```