### PR TITLE
Add jitpack.io repository

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,7 +42,10 @@ dependencyResolutionManagement {
       mavenLocal()
     }
     mavenCentral()
-    maven { url = uri("https://jitpack.io") }
+    maven {
+      url = uri("https://jitpack.io")
+      content { includeModule("com.github.RoaringBitmap.RoaringBitmap", "roaringbitmap") }
+    }
     gradlePluginPortal()
     if (System.getProperty("withApacheSnapshots", "false").toBoolean()) {
       maven {


### PR DESCRIPTION
Due to https://github.com/apache/iceberg/pull/14991 and https://github.com/RoaringBitmap/RoaringBitmap not publishing to Maven Central, we need to declare in the jitpack.io repository.