### PR TITLE
Allow field ID 0 in Iceberg schemas for Paimon compatibility

### DIFF
--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/NessieModelIceberg.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/NessieModelIceberg.java
@@ -1262,7 +1262,6 @@ public class NessieModelIceberg {
 
   public static int icebergSchemaMaxFieldId(IcebergSchema schema) {
     Set<Integer> fieldIds = new HashSet<>();
-    fieldIds.add(INITIAL_COLUMN_ID);
     int max = 0;
     for (IcebergNestedField field : schema.fields()) {
       max = Math.max(max, icebergSchemaMaxFieldId(field, fieldIds));


### PR DESCRIPTION
Remove pre-addition of INITIAL_COLUMN_ID (0) in icebergSchemaMaxFieldId() which incorrectly rejected schemas with field ID 0. This enables Apache Paimon tables (which use 0-based field IDs) to work with Nessie's catalog.

Fixes #11972