### PR TITLE
Quarkus 3.31/Google Secrets Manager: disable by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Upgrade notes
 
+- When using the Google Cloud Secret Manager, you have to explicitly configure
+  `quarkus.google.cloud.secret-manager-enabled=true`.
+
 ### Breaking changes
 
 ### New Features

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -61,6 +61,8 @@ nessie.server.send-stacktrace-to-client=false
 #
 # When using Google Cloud Secret Manager you may have to configure this to 'true'
 quarkus.google.cloud.enable-metadata-server=false
+# When using Google Cloud Secret Manager you have to configure this to 'true'
+quarkus.google.cloud.secret-manager-enabled=false
 # To enable a specific secrets manager consult the documentations for those, more
 # information here: https://projectnessie.org/nessie-latest/configuration/#secrets-manager-settings
 

--- a/tools/server-admin/src/main/resources/application.properties
+++ b/tools/server-admin/src/main/resources/application.properties
@@ -33,6 +33,8 @@ nessie.server.send-stacktrace-to-client=false
 nessie.secrets.type=NONE
 # When using Google Cloud Secret Manager you may have to configure this to 'true'
 quarkus.google.cloud.enable-metadata-server=false
+# When using Google Cloud Secret Manager you have to configure this to 'true'
+quarkus.google.cloud.secret-manager-enabled=false
 # To enable a specific secrets manager consult the documentations for those, more
 # information here: https://projectnessie.org/nessie-latest/configuration/#secrets-manager-settings
 


### PR DESCRIPTION
The Google Secrets Manager is enabled by default, and it provides a SmallRye config-source. If the Google Secrets Manager is not available, Nessie startup will fail, as it does in some integration tests with Quarkus 3.31.

It is not clear, why this starts to fail with 3.31 in some circumstances, but it it nontheless safer to disable it by default.

Such startup failures look like this:
```
  ERROR: Failed to start application
    java.lang.RuntimeException: Failed to start quarkus
    	at io.quarkus.runner.ApplicationImpl.doStart(Unknown Source)
...
    Caused by: java.lang.RuntimeException: java.io.IOException: Your default credentials were not found. To set up Application Default Credentials for your environment, see https://cloud.google.com/docs/authentication/external/set-up-adc.
...
    	at io.smallrye.config.ConfigurableConfigSource.getConfigSources(ConfigurableConfigSource.java:50)
    	at io.smallrye.config.SmallRyeConfig$ConfigSources.mapLateSources(SmallRyeConfig.java:993)
...
    	at io.quarkus.runtime.generated.Config.createRunTimeConfig(Unknown Source)
    	... 9 more
    Caused by: java.io.IOException: Your default credentials were not found. To set up Application Default Credentials for your environment, see https://cloud.google.com/docs/authentication/external/set-up-adc.
    	at com.google.auth.oauth2.DefaultCredentialsProvider.getDefaultCredentials(DefaultCredentialsProvider.java:127)
    	at com.google.auth.oauth2.GoogleCredentials.getApplicationDefault(GoogleCredentials.java:191)
    	at com.google.auth.oauth2.GoogleCredentials.getApplicationDefault(GoogleCredentials.java:163)
    	at io.quarkiverse.googlecloudservices.secretmanager.runtime.config.SecretManagerConfigSource.credentials(SecretManagerConfigSource.java:106)
    	at io.quarkiverse.googlecloudservices.secretmanager.runtime.config.SecretManagerConfigSource.createClient(SecretManagerConfigSource.java:86)
    	... 18 more
```