### PR TITLE
Remove Minio handling from Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -213,20 +213,6 @@
       ],
     },
 
-    // Special versioning for Minio
-    {
-      matchManagers: [
-        'dockerfile',
-        'devcontainer',
-        'docker-compose',
-      ],
-      versioning: 'regex:^RELEASE\\.(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})T(?<build>\\d{2})-(?<revision>\\d{2})-\\d{2}Z',
-      matchPackageNames: [
-        '/^quay.io/minio/minio/',
-      ],
-      // see https://docs.renovatebot.com/modules/versioning/#regular-expression-versioning
-      // see https://github.com/renovatebot/renovate/issues/2438
-    },
     {
       groupName: 'Quarkus Platform and Group',
       matchManagers: [


### PR DESCRIPTION
As there will be no more Minio releases, we can safely remove the Minio configuration.