### PR TITLE
Fixes S3Exception/AccessDeniedExcepiton assertion

### DIFF
--- a/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/s3/AbstractAssumeRoleIceberg.java
+++ b/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/s3/AbstractAssumeRoleIceberg.java
@@ -190,7 +190,8 @@ public abstract class AbstractAssumeRoleIceberg {
     // Attempts to create files blocked by the server side IAM policy, breaks the createTable() call
     assertThatThrownBy(() -> catalog.createTable(TableIdentifier.of(ns, "table1"), schema))
         .isInstanceOf(ForbiddenException.class)
-        .hasMessageContaining("S3Exception: Access Denied")
+        // Exception depends on the AWSSDK version
+        .hasMessageMatching(".*(S3Exception|AccessDeniedException): Access Denied.*")
         // make sure the error comes from the Catalog Server
         .hasStackTraceContaining("org.apache.iceberg.rest.HTTPClient");
   }


### PR DESCRIPTION
Newer AWSSDK versions now throw a specialized AccessDeniedExcepiton, instead of a generic S3Exception. This unblocks #12070