### PR TITLE
Remove superfluous JRE11 check and assumption

### DIFF
--- a/api/client/src/test/java/org/projectnessie/client/http/impl/TestHttpClients.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/impl/TestHttpClients.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -66,31 +65,6 @@ public class TestHttpClients {
 
   @SuppressWarnings("EnumOrdinal")
   static Stream<Arguments> clientByName() {
-
-    if (JRE.currentJre().ordinal() < JRE.JAVA_11.ordinal()) {
-      return Stream.of(
-          arguments(
-              "apachehttp", "org.projectnessie.client.http.impl.apache.ApacheHttpClient", false),
-          arguments(
-              "ApacheHttp", "org.projectnessie.client.http.impl.apache.ApacheHttpClient", false),
-          arguments("http", "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", false),
-          arguments("HTTP", "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", false),
-          arguments(null, "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", false),
-          arguments(
-              "UrlConnection",
-              "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient",
-              false),
-          arguments(
-              "urlconnection",
-              "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient",
-              false),
-          arguments(
-              "urlconnection", "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", true),
-          arguments(null, "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", true),
-          arguments(
-              "apachehttp", "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", true));
-    }
-
     return Stream.of(
         arguments(
             "apachehttp", "org.projectnessie.client.http.impl.apache.ApacheHttpClient", false),

--- a/api/client/src/test/java/org/projectnessie/client/http/impl/jdk11/TestJavaHttpClient.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/impl/jdk11/TestJavaHttpClient.java
@@ -15,28 +15,18 @@
  */
 package org.projectnessie.client.http.impl.jdk11;
 
-import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
 import java.util.function.Consumer;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.JRE;
 import org.projectnessie.client.http.BaseTestHttpClient;
 import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.client.http.impl.HttpRuntimeConfig;
 
 public class TestJavaHttpClient extends BaseTestHttpClient {
-
-  @BeforeAll
-  @SuppressWarnings("EnumOrdinal")
-  public static void checkJava11() {
-    assumeThat(JRE.currentJre()).matches(jre -> jre.ordinal() >= JRE.JAVA_11.ordinal());
-  }
-
   @Override
   protected HttpClient createClient(URI baseUri, Consumer<HttpClient.Builder> customizer) {
     HttpClient.Builder b =


### PR DESCRIPTION
Java 17 is the baseline, so the check is useless.