### PR TITLE
Remove jitpack.io repo

### DIFF
--- a/gradle/banned-dependencies.txt
+++ b/gradle/banned-dependencies.txt
@@ -8,3 +8,7 @@
 com.github.pjfanning:jersey-json
 javax.annotation:javax.annotation-api
 javax.servlet:javax.servlet-api
+
+# See https://github.com/RoaringBitmap/RoaringBitmap/issues/749, should only use org.roaringbitmap:RoaringBitmap
+com.github.RoaringBitmap.RoaringBitmap
+org.roaringbitmap:roaringbitmap

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,10 +42,6 @@ dependencyResolutionManagement {
       mavenLocal()
     }
     mavenCentral()
-    maven {
-      url = uri("https://jitpack.io")
-      content { includeModule("com.github.RoaringBitmap.RoaringBitmap", "roaringbitmap") }
-    }
     gradlePluginPortal()
     if (System.getProperty("withApacheSnapshots", "false").toBoolean()) {
       // This is a hack to let Renovate _not_ query the Apache snapshot repository for all


### PR DESCRIPTION
This change effectively reverts #11951 and bans the affected dependency `com.github.RoaringBitmap.RoaringBitmap:roaringbitmap`.