### PR TITLE
Commit-log should stop at "latest-hash"

### DIFF
--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -460,20 +460,18 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
 
           String hash = logEntry.getCommitMeta().getHash();
 
-          if (!predicate.test(logEntry)) {
-            continue;
-          }
-
           boolean stop = Objects.equals(hash, stopHash);
 
-          logEntry =
-              logEntryOperationsAccessCheck(successfulChecks, failedChecks, endRef, logEntry);
+          if (predicate.test(logEntry)) {
+            logEntry =
+                logEntryOperationsAccessCheck(successfulChecks, failedChecks, endRef, logEntry);
 
-          if (!pagedResponseHandler.addEntry(logEntry)) {
-            if (!stop) {
-              pagedResponseHandler.hasMore(commits.tokenForCurrent());
+            if (!pagedResponseHandler.addEntry(logEntry)) {
+              if (!stop) {
+                pagedResponseHandler.hasMore(commits.tokenForCurrent());
+              }
+              break;
             }
-            break;
           }
 
           if (stop) {

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/BaseTestServiceImpl.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/BaseTestServiceImpl.java
@@ -274,6 +274,17 @@ public abstract class BaseTestServiceImpl {
   protected List<LogEntry> pagedCommitLog(
       String refName, FetchOption fetchOption, String filter, int pageSize, int totalCommits)
       throws NessieNotFoundException {
+    return pagedCommitLog(refName, fetchOption, filter, pageSize, totalCommits, null);
+  }
+
+  protected List<LogEntry> pagedCommitLog(
+      String refName,
+      FetchOption fetchOption,
+      String filter,
+      int pageSize,
+      int totalCommits,
+      String stopAtHash)
+      throws NessieNotFoundException {
 
     List<LogEntry> completeLog = new ArrayList<>();
     String token = null;
@@ -284,7 +295,7 @@ public abstract class BaseTestServiceImpl {
               .getCommitLog(
                   refName,
                   fetchOption,
-                  null,
+                  stopAtHash,
                   null,
                   filter,
                   token,


### PR DESCRIPTION
Assuming that a commit-log request has both a "last-hash", a commit reference to stop at, and a filter expression. Also assume that the filter expression does not match the commit of the "last-hash".

`TreeApiImpl.getCommitLog()` evaluates the filter predicate before evaluating the "stop at" condition, leading to silently skipping the latter condition and scanning the whole commit log.

This change fixes the behavior in `TreeApiImpl.getCommitLog()`. Tests added as well.