### PR TITLE
Fix IntelliJ import

### DIFF
--- a/gc/gc-iceberg-inttest/build.gradle.kts
+++ b/gc/gc-iceberg-inttest/build.gradle.kts
@@ -23,7 +23,7 @@ tasks.withType<JavaCompile>().configureEach { options.release = 17 }
 
 publishingHelper { mavenName = "Nessie - GC - Integration tests" }
 
-val sparkScala = useSparkScalaVersionsForProject("3.5", "2.12")
+val sparkScala = useSparkScalaVersionsForProject("3.5", "2.13")
 
 dependencies {
   implementation(libs.hadoop.client)

--- a/gc/gc-tool-inttest/build.gradle.kts
+++ b/gc/gc-tool-inttest/build.gradle.kts
@@ -23,7 +23,7 @@ tasks.withType<JavaCompile>().configureEach { options.release = 17 }
 
 publishingHelper { mavenName = "Nessie - GC - CLI integration test" }
 
-val sparkScala = useSparkScalaVersionsForProject("3.4", "2.12")
+val sparkScala = useSparkScalaVersionsForProject("3.4", "2.13")
 
 dnsjavaDowngrade()
 

--- a/integrations/spark-scala.properties
+++ b/integrations/spark-scala.properties
@@ -24,5 +24,5 @@ sparkVersions=4.0,3.5,3.4
 
 sparkVersion-3.4-scalaVersions=2.13,2.12
 sparkVersion-3.5-scalaVersions=2.13,2.12
-sparkVersion-3.5-scalaVersions=2.12,2.13
+sparkVersion-3.5-scalaVersions=2.13,2.12
 sparkVersion-4.0-scalaVersions=2.13


### PR DESCRIPTION
After #12126, Scala 2.13 became the default version used during IntelliJ/Gradle syncs. The corresponding config file however mentioned 2.12 as the first and therefore "only" Scala version to sync, which breaks the IDE with "no such project" errors.