### PR TITLE
Client-integration-tests: use fully qualified Authelia version

### DIFF
--- a/api/client/src/intTest/resources/org/projectnessie/client/auth/oauth2/Dockerfile-authelia-version
+++ b/api/client/src/intTest/resources/org/projectnessie/client/auth/oauth2/Dockerfile-authelia-version
@@ -1,3 +1,3 @@
 # Dockerfile to provide the image name and tag to a test.
 # Version is managed by Renovate - do not edit.
-FROM authelia/authelia:4.39
+FROM authelia/authelia:4.39.16


### PR DESCRIPTION
'4.39' is a "moving tag". Something in Authelia changed from 4.39.16 to 4.39.17 that breaks the `ITOAuth2ClientAuthelia` during the invocation of ".well-knowns". The test failure shows up in unrelated version-bump PRs. This change is not about fixing the changes in 4.39.17, but to have a consistent version to test against.