### PR TITLE
Trino-testing-container: defensive result rows copy

### DIFF
--- a/testing/trino-container/src/main/java/org/projectnessie/nessie/testing/trino/TrinoResultsImpl.java
+++ b/testing/trino-container/src/main/java/org/projectnessie/nessie/testing/trino/TrinoResultsImpl.java
@@ -55,15 +55,16 @@ final class TrinoResultsImpl extends AbstractIterator<List<Object>> implements T
       QueryError error;
       while (client.isRunning()) {
         results = client.currentStatusInfo();
+        var data = new ArrayList<List<Object>>();
+        client.currentRows().forEach(data::add);
         error = results.getError();
         if (error != null) {
           throw error.getFailureInfo().toException();
         }
-        Iterable<List<Object>> data = client.currentRows();
 
         client.advance();
 
-        if (data != null) {
+        if (!data.isEmpty()) {
           currentPage = data.iterator();
           break;
         } else {


### PR DESCRIPTION
Adds an eager (defensive) copy of the current rows to the Trino testing container client when fetching query results.

This unblocks #12248