### PR TITLE
Adapt Authelia integration tests to 4.39.19

### DIFF
--- a/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2ClientAuthelia.java
+++ b/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2ClientAuthelia.java
@@ -38,56 +38,61 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectnessie.client.http.Status;
 import org.projectnessie.nessie.testing.containerspec.ContainerSpecHelper;
 import org.testcontainers.containers.BindMode;
-import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @ExtendWith(SoftAssertionsExtension.class)
+@SuppressWarnings({"resource", "deprecation"})
 public class ITOAuth2ClientAuthelia {
 
   private static final int NESSIE_CALLBACK_PORT;
+  private static final int DOCKER_HOST_AUTHELIA_PORT;
+
+  @Container static final FixedHostPortGenericContainer<?> AUTHELIA;
 
   static {
-    try (ServerSocket socket = new ServerSocket(0)) {
-      NESSIE_CALLBACK_PORT = socket.getLocalPort();
+    try (ServerSocket s1 = new ServerSocket(0);
+        ServerSocket s2 = new ServerSocket(0)) {
+      NESSIE_CALLBACK_PORT = s1.getLocalPort();
+      DOCKER_HOST_AUTHELIA_PORT = s2.getLocalPort();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
-  }
 
-  @SuppressWarnings("resource")
-  @Container
-  static final GenericContainer<?> AUTHELIA =
-      new GenericContainer<>(
-              ContainerSpecHelper.builder()
-                  .name("authelia")
-                  .containerClass(ITOAuth2ClientAuthelia.class)
-                  .build()
-                  .dockerImageName(null)
-                  .asCompatibleSubstituteFor("authelia/authelia")
-                  .toString())
-          .withExposedPorts(9091)
-          .withEnv("X_AUTHELIA_CONFIG_FILTERS", "template")
-          .withEnv("NESSIE_CALLBACK_PORT", NESSIE_CALLBACK_PORT + "")
-          .withClasspathResourceMapping(
-              "org/projectnessie/client/auth/oauth2/authelia-config.yaml",
-              "/config/configuration.yml",
-              BindMode.READ_ONLY)
-          .withClasspathResourceMapping(
-              "org/projectnessie/client/auth/oauth2/authelia-users.yaml",
-              "/config/users.yml",
-              BindMode.READ_ONLY)
-          .withClasspathResourceMapping(
-              "org/projectnessie/client/auth/oauth2/authelia-key.pem",
-              "/config/key.pem",
-              BindMode.READ_ONLY)
-          .withClasspathResourceMapping(
-              "org/projectnessie/client/auth/oauth2/authelia-cert.pem",
-              "/config/cert.pem",
-              BindMode.READ_ONLY)
-          .waitingFor(Wait.forListeningPort());
+    AUTHELIA =
+        new FixedHostPortGenericContainer<>(
+                ContainerSpecHelper.builder()
+                    .name("authelia")
+                    .containerClass(ITOAuth2ClientAuthelia.class)
+                    .build()
+                    .dockerImageName(null)
+                    .asCompatibleSubstituteFor("authelia/authelia")
+                    .toString())
+            .withFixedExposedPort(DOCKER_HOST_AUTHELIA_PORT, 9091)
+            .withEnv("X_AUTHELIA_CONFIG_FILTERS", "template")
+            .withEnv("NESSIE_CALLBACK_PORT", NESSIE_CALLBACK_PORT + "")
+            .withEnv("DOCKER_HOST_AUTHELIA_PORT", DOCKER_HOST_AUTHELIA_PORT + "")
+            .withClasspathResourceMapping(
+                "org/projectnessie/client/auth/oauth2/authelia-config.yaml",
+                "/config/configuration.yml",
+                BindMode.READ_ONLY)
+            .withClasspathResourceMapping(
+                "org/projectnessie/client/auth/oauth2/authelia-users.yaml",
+                "/config/users.yml",
+                BindMode.READ_ONLY)
+            .withClasspathResourceMapping(
+                "org/projectnessie/client/auth/oauth2/authelia-key.pem",
+                "/config/key.pem",
+                BindMode.READ_ONLY)
+            .withClasspathResourceMapping(
+                "org/projectnessie/client/auth/oauth2/authelia-cert.pem",
+                "/config/cert.pem",
+                BindMode.READ_ONLY)
+            .waitingFor(Wait.forListeningPort());
+  }
 
   private static URI issuerUrl;
 
@@ -95,7 +100,7 @@ public class ITOAuth2ClientAuthelia {
 
   @BeforeAll
   static void beforeAll() {
-    issuerUrl = URI.create("https://127.0.0.1:" + AUTHELIA.getMappedPort(9091));
+    issuerUrl = URI.create("https://127.0.0.1:" + DOCKER_HOST_AUTHELIA_PORT);
   }
 
   @Test

--- a/api/client/src/intTest/resources/org/projectnessie/client/auth/oauth2/Dockerfile-authelia-version
+++ b/api/client/src/intTest/resources/org/projectnessie/client/auth/oauth2/Dockerfile-authelia-version
@@ -1,3 +1,3 @@
 # Dockerfile to provide the image name and tag to a test.
 # Version is managed by Renovate - do not edit.
-FROM authelia/authelia:4.39.16
+FROM authelia/authelia:4.39.19

--- a/api/client/src/intTest/resources/org/projectnessie/client/auth/oauth2/authelia-config.yaml
+++ b/api/client/src/intTest/resources/org/projectnessie/client/auth/oauth2/authelia-config.yaml
@@ -34,7 +34,7 @@ session:
   cookies:
     - name: 'authelia_session'
       domain: '127.0.0.1'
-      authelia_url: 'https://127.0.0.1/whatever'
+      authelia_url: 'https://127.0.0.1:{{ env "DOCKER_HOST_AUTHELIA_PORT" }}'
 
 storage:
   encryption_key: 'you_must_generate_a_random_string_of_more_than_twenty_chars_and_configure_this'


### PR DESCRIPTION
Authelia 4.39.19 now requires a valid `authelia_url` in session cookie config and validates that incoming requests' Host header matches it exactly (including port). Since the test uses Docker with a dynamically mapped port, we pre-allocate a fixed host port and inject it into the Authelia config via its template engine.