### PR TITLE
Testing/Vault: set `SKIP_SETCAP=true`

### DIFF
--- a/catalog/secrets/vault/src/intTest/java/org/projectnessie/catalog/secrets/vault/ITVaultSecretsProvider.java
+++ b/catalog/secrets/vault/src/intTest/java/org/projectnessie/catalog/secrets/vault/ITVaultSecretsProvider.java
@@ -68,6 +68,7 @@ public class ITVaultSecretsProvider {
                   .build()
                   .dockerImageName(null)
                   .asCompatibleSubstituteFor("vault"))
+          .withEnv("SKIP_SETCAP", "true")
           .withLogConsumer(c -> LOGGER.info("[VAULT] {}", c.getUtf8StringWithoutLineEnding()))
           .withVaultToken(VAULT_ROOT_TOKEN);
 

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/secrets/VaultTestResourceLifecycleManager.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/secrets/VaultTestResourceLifecycleManager.java
@@ -92,6 +92,7 @@ public class VaultTestResourceLifecycleManager implements QuarkusTestResourceLif
                     .dockerImageName(null)
                     .asCompatibleSubstituteFor("vault"))
             .withLogConsumer(c -> LOGGER.info("[VAULT] {}", c.getUtf8StringWithoutLineEnding()))
+            .withEnv("SKIP_SETCAP", "true")
             .withVaultToken(VAULT_ROOT_TOKEN)
             .withInitCommand("auth enable userpass");
 


### PR DESCRIPTION
Newer Vault container images fail to start locally (Podman) and in CI (GitHub) with the error message:
```
ERROR tc.docker.io/hashicorp/vault:2.0.0 -
        Log output from the failed container:
unable to set CAP_SETFCAP effective capability: Operation not permitted
```

This change adds a setting to skip this one, as it's irrelevant for testing, unblocking #12327.