### PR TITLE
fix: prune unreferenced schemas from table metadata

### DIFF
--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/NessieModelIceberg.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/NessieModelIceberg.java
@@ -601,6 +601,8 @@ public class NessieModelIceberg {
 
     Map<Integer, NessieSchema> icebergSchemaIdToSchema = new HashMap<>();
 
+    // Populate the schema lookup map from all schemas (needed for snapshot schema resolution),
+    // but only store the current schema in the snapshot to prevent unbounded schema accumulation.
     partsWithV1DefaultPart(iceberg.schemas(), iceberg.schema(), IcebergSchema::schemaId)
         .forEach(
             schema -> {
@@ -610,8 +612,8 @@ public class NessieModelIceberg {
 
               icebergSchemaIdToSchema.put(schema.schemaId(), nessieSchema);
 
-              snapshot.addSchemas(nessieSchema);
               if (isCurrent) {
+                snapshot.addSchemas(nessieSchema);
                 snapshot.currentSchemaId(nessieSchema.id());
               }
             });
@@ -669,12 +671,13 @@ public class NessieModelIceberg {
               // Iceberg
               // snapshots??
               Integer schemaId = currentSnapshot.schemaId();
-              if (schemaId != null) {
-                // TODO this overwrites the "current schema ID" with the schema ID of the current
-                //  snapshot. Is this okay??
-                NessieSchema currentSchema = icebergSchemaIdToSchema.get(schemaId);
-                if (currentSchema != null) {
-                  snapshot.currentSchemaId(currentSchema.id());
+              if (schemaId != null && schemaId != currentSchemaId) {
+                // The snapshot references a different schema than the metadata-level current.
+                // Ensure it is included in the stored schemas.
+                NessieSchema snapshotSchema = icebergSchemaIdToSchema.get(schemaId);
+                if (snapshotSchema != null) {
+                  snapshot.addSchemas(snapshotSchema);
+                  snapshot.currentSchemaId(snapshotSchema.id());
                 }
               }
 
@@ -1062,14 +1065,21 @@ public class NessieModelIceberg {
 
     int currentSchemaId = INITIAL_SCHEMA_ID;
     var allSchemasFieldsById = new HashMap<UUID, NessieField>();
+    NessieId currentNessieSchemaId = nessie.currentSchemaId();
     for (NessieSchema schema : nessie.schemas()) {
       collectFieldsByNessieId(schema, allSchemasFieldsById);
-      IcebergSchema iceberg = nessieSchemaToIcebergSchema(schema);
-      metadata.addSchemas(iceberg);
-      if (schema.id().equals(nessie.currentSchemaId())) {
-        currentSchemaId = schema.icebergId();
-        if (spec.version() == 1) {
-          metadata.schema(iceberg);
+      // When a current schema is set, only include it in the output metadata to avoid unbounded
+      // schema accumulation. Historical schemas are unreachable since Nessie maintains only one
+      // snapshot. When no current schema is set, include all schemas for compatibility.
+      boolean include = currentNessieSchemaId == null || schema.id().equals(currentNessieSchemaId);
+      if (include) {
+        IcebergSchema iceberg = nessieSchemaToIcebergSchema(schema);
+        metadata.addSchemas(iceberg);
+        if (schema.id().equals(currentNessieSchemaId)) {
+          currentSchemaId = schema.icebergId();
+          if (spec.version() == 1) {
+            metadata.schema(iceberg);
+          }
         }
       }
     }

--- a/catalog/format/iceberg/src/test/java/org/projectnessie/catalog/formats/iceberg/nessie/TestNessieModelIceberg.java
+++ b/catalog/format/iceberg/src/test/java/org/projectnessie/catalog/formats/iceberg/nessie/TestNessieModelIceberg.java
@@ -1281,4 +1281,74 @@ public class TestNessieModelIceberg {
         .isThrownBy(() -> NessieModelIceberg.icebergSchemaMaxFieldId(schemaWithDuplicates))
         .withMessageContaining("Duplicate field ID");
   }
+
+  @Test
+  public void importPrunesUnreferencedSchemas() {
+    String uuid = UUID.randomUUID().toString();
+    String location = "s3://mybucket/tables/my/table";
+
+    IcebergSchema schema1 =
+        IcebergSchema.builder()
+            .schemaId(0)
+            .addFields(nestedField(1, "id", false, integerType(), null))
+            .build();
+    IcebergSchema schema2 =
+        IcebergSchema.builder()
+            .schemaId(1)
+            .addFields(
+                nestedField(1, "id", false, integerType(), null),
+                nestedField(2, "name", false, stringType(), null))
+            .build();
+    IcebergSchema schema3 =
+        IcebergSchema.builder()
+            .schemaId(2)
+            .addFields(
+                nestedField(1, "id", false, integerType(), null),
+                nestedField(2, "name", false, stringType(), null),
+                nestedField(3, "value", false, longType(), null))
+            .build();
+
+    IcebergTableMetadata metadata =
+        IcebergTableMetadata.builder()
+            .location(location)
+            .tableUuid(uuid)
+            .formatVersion(2)
+            .lastUpdatedMs(1L)
+            .lastColumnId(3)
+            .currentSchemaId(2)
+            .addSchemas(schema1, schema2, schema3)
+            .currentSnapshotId(-1L)
+            .build();
+
+    NessieId snapshotId = NessieId.randomNessieId();
+    NessieTable table =
+        NessieTable.builder()
+            .tableFormat(TableFormat.ICEBERG)
+            .nessieContentId(uuid)
+            .icebergUuid(uuid)
+            .createdTimestamp(Instant.EPOCH)
+            .build();
+
+    NessieTableSnapshot nessieSnapshot =
+        NessieModelIceberg.icebergTableSnapshotToNessie(
+            snapshotId, null, table, metadata, IcebergSnapshot::manifestList);
+
+    soft.assertThat(nessieSnapshot.schemas())
+        .as("import should only store the current schema")
+        .hasSize(1);
+
+    IcebergTableMetadata roundTripped =
+        NessieModelIceberg.nessieTableSnapshotToIceberg(
+            nessieSnapshot, Optional.empty(), properties -> {});
+
+    soft.assertThat(roundTripped.schemas())
+        .as("output metadata should only contain the current schema")
+        .hasSize(1);
+    soft.assertThat(roundTripped.currentSchemaId())
+        .as("the current schema ID should match the output schema")
+        .isEqualTo(roundTripped.schemas().get(0).schemaId());
+    soft.assertThat(roundTripped.schemas().get(0).fields())
+        .as("the current schema should have all 3 fields")
+        .hasSize(3);
+  }
 }


### PR DESCRIPTION
Nessie maintains a single snapshot per table per branch, making historical schemas unreachable. Tables with frequent schema evolution can accumulate hundreds of schema versions in the metadata, causing significant metadata bloat.

This change ensures only referenced schemas are included:
- Write path (icebergTableSnapshotToNessie): only store the current schema in NessieTableSnapshot
- Read path (nessieTableSnapshotToIceberg): only include the current schema in metadata output; fall back to including all schemas when no current schema is set for compatibility
- Handle edge case where snapshot references a different schema than the metadata-level current schema

Field mappings from all schemas are still collected internally for partition spec and sort order resolution.