### PR TITLE
Adapt CacheInvalidationSender + test to dynamic Quarkus management port

### DIFF
--- a/servers/quarkus-distcache/src/main/java/org/projectnessie/server/distcache/CacheInvalidationSender.java
+++ b/servers/quarkus-distcache/src/main/java/org/projectnessie/server/distcache/CacheInvalidationSender.java
@@ -52,7 +52,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.projectnessie.nessie.networktools.AddressResolver;
 import org.projectnessie.quarkus.config.QuarkusStoreConfig;
 import org.projectnessie.quarkus.providers.ServerInstanceId;
@@ -74,7 +74,6 @@ public class CacheInvalidationSender implements DistributedCacheInvalidation {
   private final AddressResolver addressResolver;
 
   private final List<String> serviceNames;
-  private final int httpPort;
   private final String invalidationUri;
   private final long requestTimeout;
 
@@ -85,15 +84,14 @@ public class CacheInvalidationSender implements DistributedCacheInvalidation {
   private boolean triggered;
   private final String token;
 
+  private int quarkusManagementPort;
+
   /** Contains the IPv4/6 addresses resolved from {@link #serviceNames}. */
   private volatile List<String> resolvedAddresses = emptyList();
 
   @Inject
   public CacheInvalidationSender(
-      Vertx vertx,
-      QuarkusStoreConfig config,
-      @ConfigProperty(name = "quarkus.management.port") int httpPort,
-      @ServerInstanceId String serverInstanceId) {
+      Vertx vertx, QuarkusStoreConfig config, @ServerInstanceId String serverInstanceId) {
     this.vertx = vertx;
 
     this.addressResolver = new AddressResolver(vertx);
@@ -104,7 +102,6 @@ public class CacheInvalidationSender implements DistributedCacheInvalidation {
             .toMillis();
     this.httpClient = vertx.createHttpClient();
     this.serviceNames = config.cacheInvalidationServiceNames().orElse(emptyList());
-    this.httpPort = httpPort;
     this.invalidationUri = config.cacheInvalidationUri() + "?sender=" + serverInstanceId;
     this.serviceNameLookupIntervalMillis =
         config.cacheInvalidationServiceNameLookupInterval().toMillis();
@@ -188,7 +185,7 @@ public class CacheInvalidationSender implements DistributedCacheInvalidation {
     try {
       invalidations.add(invalidation);
 
-      if (!triggered) {
+      if (!triggered && quarkusManagementPort() != 0) {
         LOGGER.trace("Triggered invalidation submission");
         vertx.executeBlocking(this::sendInvalidations);
         triggered = true;
@@ -200,6 +197,7 @@ public class CacheInvalidationSender implements DistributedCacheInvalidation {
 
   private Void sendInvalidations() {
     List<CacheInvalidation> batch = new ArrayList<>(batchSize);
+    var httpPort = quarkusManagementPort();
     try {
       while (true) {
         lock.lock();
@@ -213,7 +211,7 @@ public class CacheInvalidationSender implements DistributedCacheInvalidation {
         } finally {
           lock.unlock();
         }
-        submit(batch, resolvedAddresses);
+        submit(batch, resolvedAddresses, httpPort);
         batch = new ArrayList<>(batchSize);
       }
     } finally {
@@ -233,9 +231,18 @@ public class CacheInvalidationSender implements DistributedCacheInvalidation {
   }
 
   @VisibleForTesting
+  int quarkusManagementPort() {
+    if (quarkusManagementPort == 0) {
+      quarkusManagementPort =
+          ConfigProvider.getConfig().getValue("quarkus.management.port", Integer.class);
+    }
+    return quarkusManagementPort;
+  }
+
+  @VisibleForTesting
   @SuppressWarnings("Slf4jDoNotLogMessageOfExceptionExplicitly")
   List<Future<Map.Entry<HttpClientResponse, Buffer>>> submit(
-      List<CacheInvalidation> batch, List<String> resolvedAddresses) {
+      List<CacheInvalidation> batch, List<String> resolvedAddresses, int httpPort) {
     LOGGER.trace("Submitting {} invalidations", batch.size());
 
     String json;

--- a/servers/quarkus-distcache/src/test/java/org/projectnessie/server/distcache/TestCacheInvalidationSender.java
+++ b/servers/quarkus-distcache/src/test/java/org/projectnessie/server/distcache/TestCacheInvalidationSender.java
@@ -102,7 +102,7 @@ public class TestCacheInvalidationSender {
 
     soft.assertThatThrownBy(
             () ->
-                new CacheInvalidationSender(vertx, config, 80, senderId) {
+                new CacheInvalidationSender(vertx, config, senderId) {
                   @Override
                   Future<List<String>> resolveServiceNames(List<String> serviceNames) {
                     return failedFuture(new RuntimeException("foo"));
@@ -110,7 +110,7 @@ public class TestCacheInvalidationSender {
 
                   @Override
                   List<Future<Map.Entry<HttpClientResponse, Buffer>>> submit(
-                      List<CacheInvalidation> batch, List<String> resolvedAddresses) {
+                      List<CacheInvalidation> batch, List<String> resolvedAddresses, int httpPort) {
                     soft.fail("Not expected");
                     return null;
                   }
@@ -145,7 +145,7 @@ public class TestCacheInvalidationSender {
 
     try {
       CacheInvalidationSender sender =
-          new CacheInvalidationSender(vertx, config, 80, senderId) {
+          new CacheInvalidationSender(vertx, config, senderId) {
             @Override
             Future<List<String>> resolveServiceNames(List<String> serviceNames) {
               try {
@@ -171,10 +171,15 @@ public class TestCacheInvalidationSender {
 
             @Override
             List<Future<Map.Entry<HttpClientResponse, Buffer>>> submit(
-                List<CacheInvalidation> batch, List<String> resolvedAddresses) {
+                List<CacheInvalidation> batch, List<String> resolvedAddresses, int httpPort) {
               submitResolvedAddresses.set(resolvedAddresses);
               submittedSemaphore.release();
               return null;
+            }
+
+            @Override
+            int quarkusManagementPort() {
+              return 42;
             }
           };
 
@@ -244,7 +249,7 @@ public class TestCacheInvalidationSender {
         buildConfig(tokens, Optional.empty(), Duration.ofSeconds(10), Duration.ofSeconds(10));
 
     CacheInvalidationSender sender =
-        new CacheInvalidationSender(vertx, config, 80, senderId) {
+        new CacheInvalidationSender(vertx, config, senderId) {
           @Override
           Future<List<String>> resolveServiceNames(List<String> serviceNames) {
             return succeededFuture(List.of());
@@ -252,7 +257,7 @@ public class TestCacheInvalidationSender {
 
           @Override
           List<Future<Map.Entry<HttpClientResponse, Buffer>>> submit(
-              List<CacheInvalidation> batch, List<String> resolvedAddresses) {
+              List<CacheInvalidation> batch, List<String> resolvedAddresses, int httpPort) {
             soft.fail("Not expected");
             return null;
           }
@@ -290,7 +295,7 @@ public class TestCacheInvalidationSender {
 
     Semaphore sem = new Semaphore(0);
     CacheInvalidationSender sender =
-        new CacheInvalidationSender(vertx, config, 80, senderId) {
+        new CacheInvalidationSender(vertx, config, senderId) {
           @Override
           Future<List<String>> resolveServiceNames(List<String> serviceNames) {
             return succeededFuture(resolvedServiceNames);
@@ -298,9 +303,14 @@ public class TestCacheInvalidationSender {
 
           @Override
           List<Future<Map.Entry<HttpClientResponse, Buffer>>> submit(
-              List<CacheInvalidation> batch, List<String> resolvedAddresses) {
+              List<CacheInvalidation> batch, List<String> resolvedAddresses, int httpPort) {
             sem.release(1);
             return null;
+          }
+
+          @Override
+          int quarkusManagementPort() {
+            return 42;
           }
         };
 
@@ -309,7 +319,7 @@ public class TestCacheInvalidationSender {
     invalidation.accept(senderSpy);
     assertThat(sem.tryAcquire(30, TimeUnit.SECONDS)).isTrue();
 
-    verify(senderSpy).submit(singletonList(expected), resolvedServiceNames);
+    verify(senderSpy).submit(singletonList(expected), resolvedServiceNames, 42);
   }
 
   @Test
@@ -329,7 +339,7 @@ public class TestCacheInvalidationSender {
     Semaphore sem = new Semaphore(0);
     Queue<CacheInvalidation> received = new ConcurrentLinkedQueue<>();
     CacheInvalidationSender sender =
-        new CacheInvalidationSender(vertx, config, 80, senderId) {
+        new CacheInvalidationSender(vertx, config, senderId) {
           @Override
           Future<List<String>> resolveServiceNames(List<String> serviceNames) {
             return succeededFuture(resolvedServiceNames);
@@ -337,12 +347,17 @@ public class TestCacheInvalidationSender {
 
           @Override
           List<Future<Map.Entry<HttpClientResponse, Buffer>>> submit(
-              List<CacheInvalidation> batch, List<String> resolvedAddresses) {
+              List<CacheInvalidation> batch, List<String> resolvedAddresses, int httpPort) {
             received.addAll(batch);
             soft.assertThat(resolvedAddresses)
                 .containsExactlyInAnyOrderElementsOf(resolvedServiceNames);
             sem.release(batch.size());
             return null;
+          }
+
+          @Override
+          int quarkusManagementPort() {
+            return 42;
           }
         };
 
@@ -402,7 +417,7 @@ public class TestCacheInvalidationSender {
       URI uri = receiver.getUri();
 
       CacheInvalidationSender sender =
-          new CacheInvalidationSender(vertx, config, uri.getPort(), senderId) {
+          new CacheInvalidationSender(vertx, config, senderId) {
             @Override
             Future<List<String>> resolveServiceNames(List<String> serviceNames) {
               return succeededFuture(List.of(uri.getHost()));
@@ -411,7 +426,9 @@ public class TestCacheInvalidationSender {
 
       CompletableFuture<Void> future =
           CompletableFuture.allOf(
-              sender.submit(singletonList(expected), singletonList(uri.getHost())).stream()
+              sender
+                  .submit(singletonList(expected), singletonList(uri.getHost()), uri.getPort())
+                  .stream()
                   .map(Future::toCompletionStage)
                   .map(CompletionStage::toCompletableFuture)
                   .toArray(CompletableFuture[]::new));
@@ -460,7 +477,7 @@ public class TestCacheInvalidationSender {
       URI uri = receiver.getUri();
 
       CacheInvalidationSender sender =
-          new CacheInvalidationSender(vertx, config, uri.getPort(), senderId) {
+          new CacheInvalidationSender(vertx, config, senderId) {
             @Override
             Future<List<String>> resolveServiceNames(List<String> serviceNames) {
               return succeededFuture(List.of(uri.getHost()));
@@ -468,7 +485,7 @@ public class TestCacheInvalidationSender {
           };
 
       CompletableFuture<?> future =
-          Future.all(sender.submit(expected, singletonList(uri.getHost())))
+          Future.all(sender.submit(expected, singletonList(uri.getHost()), uri.getPort()))
               .toCompletionStage()
               .toCompletableFuture();
 
@@ -511,7 +528,7 @@ public class TestCacheInvalidationSender {
       URI uri = receiver.getUri();
 
       CacheInvalidationSender sender =
-          new CacheInvalidationSender(vertx, config, uri.getPort(), senderId) {
+          new CacheInvalidationSender(vertx, config, senderId) {
             @Override
             Future<List<String>> resolveServiceNames(List<String> serviceNames) {
               return succeededFuture(List.of(uri.getHost()));
@@ -520,7 +537,7 @@ public class TestCacheInvalidationSender {
 
       CompletableFuture<Void> future =
           CompletableFuture.allOf(
-              sender.submit(expected, singletonList(uri.getHost())).stream()
+              sender.submit(expected, singletonList(uri.getHost()), uri.getPort()).stream()
                   .map(Future::toCompletionStage)
                   .map(CompletionStage::toCompletableFuture)
                   .toArray(CompletableFuture[]::new));

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestCacheInvalidation.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestCacheInvalidation.java
@@ -45,6 +45,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.SoftAssertions;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -100,11 +101,8 @@ public class TestCacheInvalidation {
     AtomicReference<String> body = new AtomicReference<>();
     AtomicReference<URI> reqUri = new AtomicReference<>();
 
-    // Although the "real" management server binds to the expected random port, as exposed via the
-    // 'quarkus.management.port' system property, the configuration value that is passed to
-    // CacheInvalidationSender's c'tor is 9000. Since we expect that all instances listen to the
-    // same port, we have to bind our "test server" below to port 9000.
-    int managementPort = 9000; // Integer.getInteger("quarkus.management.port");
+    int managementPort =
+        ConfigProvider.getConfig().getValue("quarkus.management.port", Integer.class);
 
     Semaphore sem = new Semaphore(0);
     try (HttpTestServer ignored =


### PR DESCRIPTION
In recent Quarkus versions, we cannot use both a dynamic HTTP port and a static management port. OTOH, being able to eventually use a dynamic management port is good.

The downside however is, that the `CacheInvalidationSender` needs to queue invalidation messages as long as the `quarkus.management.port' configuration value yields `0` (which is only the case for tests BTW). The test needed to be adapted as well, mostly with an initial "test" that drains the queued invalidations.