### PR TITLE
Fix banned-dependency handling wrt detached/copied configuations

### DIFF
--- a/build-logic/src/main/kotlin/nessie-common-java.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-common-java.gradle.kts
@@ -95,7 +95,7 @@ if (project.hasProperty("release") || project.hasProperty("jarWithGitInfo")) {
   }
 }
 
-configurations.all {
+val bannedDependencies = lazy {
   rootProject
     .file("gradle/banned-dependencies.txt")
     .readText(Charsets.UTF_8)
@@ -103,7 +103,11 @@ configurations.all {
     .lines()
     .map { it.trim() }
     .filterNot { it.isBlank() || it.startsWith("#") }
-    .forEach { line ->
+}
+
+configurations.all {
+  if (state == Configuration.State.UNRESOLVED) {
+    bannedDependencies.value.forEach { line ->
       val idx = line.indexOf(':')
       if (idx == -1) {
         exclude(group = line)
@@ -113,4 +117,5 @@ configurations.all {
         exclude(group = group, module = module)
       }
     }
+  }
 }


### PR DESCRIPTION
Gradle `Configuration`s can only be updated as long as those haven't been resolved ("observed"). Detached or copied `Configuration`s, as it happens during license validation via the used plugin, can already be resolved. Updating those leads to corresponding exceptions and in turn build failures.

This change addresses this by applying the banned dependencies only to unresolved configurations, which is fine here.

This change also unblocks the current Quarkus 3.34.6 upgrade where a _copied_ (think: detached) Gradle `Configuration`, which is already resolved, is attempted to be mutated, which is illegal:
```
Caused by: org.gradle.api.InvalidUserCodeException: Cannot mutate the dependencies of configuration :...:...Copy1' after the configuration was resolved. After a configuration has been observed, it should not be modified.
```