### PR TITLE
Quarkus 3.35 upgrade preparation

### DIFF
--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -141,6 +141,8 @@ dependencies {
   testFixturesImplementation("com.fasterxml.jackson.core:jackson-annotations")
   testFixturesApi("io.quarkus:quarkus-test-security")
   testFixturesApi("io.quarkus:quarkus-test-oidc-server")
+  testFixturesImplementation("io.quarkus:quarkus-junit-config")
+  testFixturesImplementation("io.quarkus:quarkus-test-common")
   testFixturesImplementation(libs.guava)
   testFixturesImplementation(libs.microprofile.openapi)
   testFixturesImplementation(libs.awaitility)

--- a/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/s3/AbstractAssumeRoleIceberg.java
+++ b/servers/quarkus-server/src/intTest/java/org/projectnessie/server/catalog/s3/AbstractAssumeRoleIceberg.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.vertx.http.HttpServer;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -39,6 +40,7 @@ import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.types.Types;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.minio.MinioContainer;
 import org.projectnessie.server.catalog.Catalogs;
@@ -90,13 +92,21 @@ public abstract class AbstractAssumeRoleIceberg {
 
   private static final Catalogs CATALOGS = new Catalogs();
 
+  static HttpServer httpServer;
+
+  @BeforeAll
+  static void beforeAll(HttpServer httpServer) {
+    AbstractAssumeRoleIceberg.httpServer = httpServer;
+  }
+
   RESTCatalog catalog() {
     return CATALOGS.getCatalog(
         Map.of(
             AwsClientProperties.CLIENT_REGION,
             MinioTestResourceLifecycleManager.TEST_REGION,
             CatalogProperties.WAREHOUSE_LOCATION,
-            minio.s3BucketUri(scheme(), "").toString()));
+            minio.s3BucketUri(scheme(), "").toString()),
+        httpServer);
   }
 
   protected abstract String scheme();

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/authz/TestAuthzMeta.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/authz/TestAuthzMeta.java
@@ -34,6 +34,7 @@ import static org.projectnessie.services.authz.Check.check;
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.vertx.http.HttpServer;
 import jakarta.inject.Inject;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -85,6 +86,8 @@ public class TestAuthzMeta extends BaseClientAuthTest {
 
   HeapStorageBucket heapStorageBucket;
 
+  @Inject HttpServer httpServer;
+
   private static final Catalogs CATALOGS = new Catalogs();
 
   // Cannot use @ExtendWith(SoftAssertionsExtension.class) + @InjectSoftAssertions here, because
@@ -92,7 +95,7 @@ public class TestAuthzMeta extends BaseClientAuthTest {
   protected final SoftAssertions soft = new SoftAssertions();
 
   protected RESTCatalog catalog(Map<String, String> catalogOptions) {
-    return CATALOGS.getCatalog(catalogOptions);
+    return CATALOGS.getCatalog(catalogOptions, httpServer);
   }
 
   @AfterAll

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/TestCommitMetaHeaders.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/TestCommitMetaHeaders.java
@@ -112,7 +112,8 @@ public class TestCommitMetaHeaders {
                 "header.Nessie-Commit-Property-foo",
                 "bar",
                 "header.Nessie-Commit-Property-dog",
-                "Elani"));
+                "Elani"),
+            httpServer);
 
     try (NessieApiV2 api = nessieClientBuilder().build(NessieApiV2.class)) {
       catalog.createNamespace(NS);

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/QuarkusNessieClientResolver.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/QuarkusNessieClientResolver.java
@@ -17,9 +17,8 @@ package org.projectnessie.server;
 
 import static java.lang.String.format;
 
-import io.quarkus.test.common.ListeningAddress;
-import io.quarkus.test.config.ValueRegistryInjector;
 import java.net.URI;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.projectnessie.client.ext.NessieClientResolver;
 
@@ -34,9 +33,9 @@ public class QuarkusNessieClientResolver extends NessieClientResolver {
     // The tricky issue here is that QuarkusNessieClientResolver is used as a JUnit extension and
     // there is no guaranteed order of extension-initialization.
     // We also cannot `@Inject` something into an extension, so we have to rely on the "legacy way"
-    // to get the port.
-    var registry = ValueRegistryInjector.get(extensionContext);
-    var httpPort = registry.get(ListeningAddress.HTTP_PORT);
+    // to get the port..
+    var quarkusHttpPort = ConfigProvider.getConfig().getConfigValue("quarkus.http.port");
+    var httpPort = Integer.parseInt(quarkusHttpPort.getValue());
     return URI.create(format("http://localhost:%d/", httpPort));
   }
 }

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/QuarkusNessieClientResolver.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/QuarkusNessieClientResolver.java
@@ -17,8 +17,9 @@ package org.projectnessie.server;
 
 import static java.lang.String.format;
 
+import io.quarkus.test.common.ListeningAddress;
+import io.quarkus.test.config.ValueRegistryInjector;
 import java.net.URI;
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.projectnessie.client.ext.NessieClientResolver;
 
@@ -33,9 +34,9 @@ public class QuarkusNessieClientResolver extends NessieClientResolver {
     // The tricky issue here is that QuarkusNessieClientResolver is used as a JUnit extension and
     // there is no guaranteed order of extension-initialization.
     // We also cannot `@Inject` something into an extension, so we have to rely on the "legacy way"
-    // to get the port..
-    var quarkusHttpPort = ConfigProvider.getConfig().getConfigValue("quarkus.http.port");
-    var httpPort = Integer.parseInt(quarkusHttpPort.getValue());
+    // to get the port.
+    var registry = ValueRegistryInjector.get(extensionContext);
+    var httpPort = registry.get(ListeningAddress.HTTP_PORT);
     return URI.create(format("http://localhost:%d/", httpPort));
   }
 }

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/AbstractIcebergCatalogTests.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/AbstractIcebergCatalogTests.java
@@ -113,7 +113,7 @@ public abstract class AbstractIcebergCatalogTests extends CatalogTests<RESTCatal
 
   @Override
   protected RESTCatalog catalog() {
-    return CATALOGS.getCatalog(catalogOptions());
+    return CATALOGS.getCatalog(catalogOptions(), AbstractIcebergCatalogTests.httpServer);
   }
 
   protected Map<String, String> catalogOptions() {

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/AbstractIcebergViewCatalogTests.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/AbstractIcebergViewCatalogTests.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.rest.RESTCatalog;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.projectnessie.client.NessieClientBuilder;
 import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.model.Branch;
@@ -34,9 +35,16 @@ public abstract class AbstractIcebergViewCatalogTests extends ViewCatalogTests<R
 
   private static final Catalogs CATALOGS = new Catalogs();
 
+  protected static HttpServer httpServer;
+
+  @BeforeAll
+  public static void beforeAll(HttpServer httpServer) {
+    AbstractIcebergViewCatalogTests.httpServer = httpServer;
+  }
+
   @Override
   protected RESTCatalog catalog() {
-    return CATALOGS.getCatalog(catalogOptions());
+    return CATALOGS.getCatalog(catalogOptions(), httpServer);
   }
 
   protected Map<String, String> catalogOptions() {

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/Catalogs.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/Catalogs.java
@@ -17,6 +17,7 @@ package org.projectnessie.server.catalog;
 
 import static java.lang.String.format;
 
+import io.quarkus.vertx.http.HttpServer;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -25,18 +26,15 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.rest.HTTPClient;
 import org.apache.iceberg.rest.RESTCatalog;
-import org.eclipse.microprofile.config.ConfigProvider;
 
 public class Catalogs implements AutoCloseable {
   private final Map<Map<String, String>, RESTCatalog> catalogs = new HashMap<>();
 
-  public RESTCatalog getCatalog(Map<String, String> options) {
+  public RESTCatalog getCatalog(Map<String, String> options, HttpServer httpServer) {
     // normalize
     options = new TreeMap<>(options);
 
-    var quarkusHttpPort = ConfigProvider.getConfig().getConfigValue("quarkus.http.port");
-    var httpPort = Integer.parseInt(quarkusHttpPort.getValue());
-    var serverBaseUri = URI.create(format("http://localhost:%d/", httpPort));
+    var serverBaseUri = URI.create(format("http://localhost:%d/", httpServer.getPort()));
 
     return catalogs.computeIfAbsent(
         options,


### PR DESCRIPTION
Need to update a few places where the Quarkus http server port is required.

While at it, this change also uses the officially supported path via `io.quarkus.vertx.http.HttpServer` instead of `ConfigProvider`, because the latter will eventually only yield the _statically_ configured values in all cases, not the effective runtime values.