### PR TITLE
docs: update outdated eventual consistency wording for cloud object stores

### DIFF
--- a/site/docs/develop/index.md
+++ b/site/docs/develop/index.md
@@ -1,7 +1,7 @@
 # Architecture
 
 Nessie builds on the recent ecosystem developments around table formats. The rise of
-very large metadata and eventually consistent cloud data lakes (S3 specifically) drove
+very large metadata and cloud data lakes (S3 specifically) drove
 the need for an updated model around metadata management. Where consistent directory
 listings in HDFS used to be sufficient, there were many features lacking. This includes
 snapshotting, consistency and fast planning. Apache Iceberg was created to help alleviate
@@ -21,8 +21,10 @@ require a pointer to the active metadata set to function. This pointer allows th
 current schema, files and partitions in the dataset. Iceberg currently relies on the Hive metastore or hdfs to perform
 this role. The requirements for this root pointer store is it must hold (at least) information about the location of the
 current up-to-date metadata file, and it must be able to update this location atomically. In Hive this is accomplished by
-locks and in hdfs by using atomic file swap operations. These operations don’t exist in eventually consistent cloud
-object stores, necessitating a Hive metastore for cloud data lakes. The Nessie system is designed to store the
+locks and in hdfs by using atomic file swap operations. While modern cloud object stores
+(S3 since December 2020, GCS and Azure Blob since launch) provide strong read-after-write
+consistency, they still lack atomic multi-object swap operations, necessitating a Hive
+metastore for cloud data lakes. The Nessie system is designed to store the
 root metadata pointer and perform atomic updates to this pointer, obviating the need for a Hive metastore. Removing the
 need for a Hive metastore simplifies deployment and broadens the reach of tools that can work with Iceberg tables.
 


### PR DESCRIPTION
## Summary

Refreshes `site/docs/develop/index.md` so it no longer describes modern cloud object stores as eventually consistent. AWS S3 has provided strong read-after-write consistency since December 2020, and GCS / Azure Blob have been strongly consistent since launch.

The technical motivation for Nessie is preserved: cloud object stores still lack atomic multi-object swap / rename, which is the real reason a Hive-metastore-like component (or Nessie) is needed. Only the consistency wording is corrected.

## Related Issue

Closes #5349

## Changes

- `site/docs/develop/index.md`
  - Drop the "eventually consistent" qualifier on cloud data lakes (line 4).
  - Replace "eventually consistent cloud object stores" with a statement that distinguishes consistency (now strong) from atomic multi-object operations (still missing).

A wider scan of `site/` showed that all other uses of "consistent" / "consistency" describe Nessie's own guarantees and are accurate; no other docs needed updating.

## How to Verify

1. Render the docs locally:
   ```bash
   pip install -r site/requirements.txt
   mkdocs serve -f site/mkdocs.yml
   ```
2. Open the Architecture page (`/develop/`) and confirm:
   - It no longer claims S3 is eventually consistent.
   - It still explains why Nessie (rather than raw S3) is needed — i.e. atomic multi-object operations are missing.

## References

- AWS S3 strong consistency announcement (Dec 2020): https://aws.amazon.com/s3/consistency/
- GCS consistency model: https://cloud.google.com/storage/docs/consistency
- Azure Blob storage consistency: https://learn.microsoft.com/azure/storage/blobs/concurrency

## Checklist

- [x] DCO sign-off
- [x] No unrelated changes
- [x] Only docs touched; no build / test impact