### PR TITLE
Add --plain / -P alias for the --non-ansi CLI option

### DIFF
--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/cli/NessieCliImpl.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/cli/NessieCliImpl.java
@@ -91,6 +91,7 @@ public class NessieCliImpl extends BaseNessieCli implements Callable<Integer> {
   public static final String OPTION_KEEP_RUNNING = "--keep-running";
   public static final String OPTION_CONTINUE_ON_ERROR = "--continue-on-error";
   public static final String OPTION_NON_ANSI = "--non-ansi";
+  public static final String OPTION_PLAIN = "--plain";
 
   public static final String HISTORY_FILE_DEFAULT = "~/.nessie/nessie-cli.history";
   public static final AttributedStyle STYLE_ERROR_HIGHLIGHT = STYLE_ERROR.italic().bold();
@@ -114,9 +115,11 @@ public class NessieCliImpl extends BaseNessieCli implements Callable<Integer> {
   private CommandsToRun commandsToRun;
 
   @Option(
-      names = OPTION_NON_ANSI,
+      names = {"-P", OPTION_PLAIN, OPTION_NON_ANSI},
       description = {
-        "Allows disabling the (default) ANSI mode. Disabling ANSI support can be useful in non-interactive scripts."
+        "Use plain output mode: disable ANSI mode and bypass jline cursor control.",
+        "Required for shell redirection (>) and pipes (|) in non-interactive runs (-c, -s).",
+        OPTION_NON_ANSI + " is kept as an alias for backwards compatibility."
       },
       defaultValue = "false")
   private boolean dumbTerminal;


### PR DESCRIPTION
## What

Add `--plain` (long) and `-P` (short) as aliases for the existing
`--non-ansi` option of `nessie-cli`, as discussed in #10865.

## Why

`--non-ansi` already produces output that's safe to redirect or pipe,
but the name doesn't surface that as a workaround. Anyone hitting the
redirect bug is more likely to search for "plain output" than for
"ANSI". The new aliases make the existing behavior discoverable
without breaking anything.

## How

- New constant `OPTION_PLAIN = "--plain"` in `NessieCliImpl`.
- `@Option` `names` extended to `{"-P", "--plain", "--non-ansi"}` on
  the same `dumbTerminal` field.
- Description updated to spell out the redirection / pipe use case.

Same field, same code path. 5 lines changed.

## Verification

Built locally with `:nessie-cli:shadowJar` (GraalVM 21.0.11) and ran
the resulting jar against a few redirect / pipe scenarios:

| Scenario | Exit | Size | ANSI escapes |
|---|---|---|---|
| `--plain -c "EXIT" > file` | 0 | 2731 B | 0 |
| `-P -c "EXIT" > file` | 0 | 2731 B | 0 |
| `--non-ansi -c "EXIT" > file` (regression) | 0 | 2731 B | 0 |
| `--plain -c "EXIT" \| head` | 0 | 38 lines | 0 |
| `--plain -s -` (stdin script) | 0 | 2731 B | 0 |
| `--plain --quiet -c "EXIT" > file` | 0 | 0 B | 0 |

Identical output across all three names — the only diff is the
`startup took N ms` line in the banner.

## One thing I noticed

Without any of these flags, redirecting `-c` / `-s` actually crashes
rather than silently producing an empty file:

```
java.lang.IllegalStateException: Unable to create a terminal
  at org.jline.terminal.TerminalBuilder.doBuild(...)
  at org.projectnessie.nessie.cli.cli.NessieCliImpl.call(NessieCliImpl.java:189)
```

jline can't load any terminal provider (FFM / jansi / JNA) when stdout
is not a TTY. This PR doesn't change that path — it just makes the
workaround discoverable. Let me know if it's worth a follow-up to fall
back to a plain `PrintWriter` automatically in non-interactive mode.

## Tests

No new tests — the change is a picocli alias on an existing field, and
the option-parsing path is already covered. Happy to add one if you'd
like.

Relates to #10865
