### PR TITLE
Add support for `startupProbe` in helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ as necessary. Empty sections will not end in the release notes.
 
 ### New Features
 
+- Helm chart: support for `startupProbe` has been added.
+
 ### Changes
 
 ### Deprecations

--- a/helm/nessie/templates/deployment.yaml
+++ b/helm/nessie/templates/deployment.yaml
@@ -132,6 +132,16 @@ spec:
             {{- tpl (toYaml .Values.extraEnv) . | nindent 12 }}
             {{- end }}
           {{- include "nessie.containerPorts" . | trim | nindent 10 }}
+          startupProbe:
+            httpGet:
+              path: /q/health/started
+              port: {{ .Values.managementService.portName }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            successThreshold: {{ .Values.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
           livenessProbe:
             httpGet:
               path: /q/health/live

--- a/helm/nessie/tests/deployment_test.yaml
+++ b/helm/nessie/tests/deployment_test.yaml
@@ -88,3 +88,134 @@ tests:
             name: sidecar-two
             image: nginx
         template: deployment.yaml
+  - it: should render startupProbe with defaults
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            httpGet:
+              path: /q/health/started
+              port: nessie-mgmt
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 10
+        template: deployment.yaml
+  - it: should apply startupProbe overrides
+    set:
+      startupProbe:
+        initialDelaySeconds: 7
+        periodSeconds: 15
+        successThreshold: 2
+        failureThreshold: 20
+        timeoutSeconds: 5
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            httpGet:
+              path: /q/health/started
+              port: nessie-mgmt
+              scheme: HTTP
+            initialDelaySeconds: 7
+            periodSeconds: 15
+            successThreshold: 2
+            failureThreshold: 20
+            timeoutSeconds: 5
+        template: deployment.yaml
+  - it: should render livenessProbe with defaults
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            httpGet:
+              path: /q/health/live
+              port: nessie-mgmt
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+            timeoutSeconds: 10
+            terminationGracePeriodSeconds: 30
+        template: deployment.yaml
+  - it: should apply livenessProbe overrides
+    set:
+      livenessProbe:
+        initialDelaySeconds: 12
+        periodSeconds: 20
+        successThreshold: 1
+        failureThreshold: 6
+        timeoutSeconds: 4
+        terminationGracePeriodSeconds: 60
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            httpGet:
+              path: /q/health/live
+              port: nessie-mgmt
+              scheme: HTTP
+            initialDelaySeconds: 12
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 6
+            timeoutSeconds: 4
+            terminationGracePeriodSeconds: 60
+        template: deployment.yaml
+  - it: should render readinessProbe with defaults
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            httpGet:
+              path: /q/health/ready
+              port: nessie-mgmt
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+            timeoutSeconds: 10
+        template: deployment.yaml
+  - it: should apply readinessProbe overrides
+    set:
+      readinessProbe:
+        initialDelaySeconds: 8
+        periodSeconds: 15
+        successThreshold: 1
+        failureThreshold: 5
+        timeoutSeconds: 3
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            httpGet:
+              path: /q/health/ready
+              port: nessie-mgmt
+              scheme: HTTP
+            initialDelaySeconds: 8
+            periodSeconds: 15
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 3
+        template: deployment.yaml
+  - it: should point all probes at the management port
+    set:
+      managementService:
+        portName: custom-mgmt
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.port
+          value: custom-mgmt
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: custom-mgmt
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: custom-mgmt
+        template: deployment.yaml

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -1053,6 +1053,19 @@ affinity: {}
 #                values:
 #                  - nessie
 
+# -- Configures the startup probe for nessie pods.
+startupProbe:
+  # -- Number of seconds after the container has started before startup probes are initiated. Minimum value is 0.
+  initialDelaySeconds: 0
+  # -- How often (in seconds) to perform the probe. Minimum value is 1.
+  periodSeconds: 10
+  # -- Minimum consecutive successes for the probe to be considered successful after having failed. Minimum value is 1.
+  successThreshold: 1
+  # -- Minimum consecutive failures for the probe to be considered failed after having succeeded. Minimum value is 1.
+  failureThreshold: 5
+  # -- Number of seconds after which the probe times out. Minimum value is 1.
+  timeoutSeconds: 10
+
 # -- Configures the liveness probe for nessie pods.
 livenessProbe:
   # -- Number of seconds after the container has started before liveness probes are initiated. Minimum value is 0.


### PR DESCRIPTION
Add startupProbe to deployment.yaml template