### PR TITLE
Normalize S3 scheme in IcebergConfigurer writeable derivation (fixes #12426)

### DIFF
--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergConfigurer.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergConfigurer.java
@@ -227,13 +227,24 @@ public class IcebergConfigurer {
     Set<StorageUri> readOnly = new HashSet<>();
     Set<StorageUri> maybeWriteable = writeAccessGranted ? writeable : readOnly;
     StorageUri locationUri = StorageUri.of(tableMetadata.location());
-    (tableMetadata.location().startsWith(warehouseLocation) ? maybeWriteable : readOnly)
+    // Normalize the S3 scheme on both sides of the prefix check so that tables written by
+    // HadoopFileIO (metadata.location prefixed with s3a://) are still classified as writeable
+    // against a warehouse registered with the canonical s3:// scheme. Without this, the
+    // resulting writeable[] is empty and the S3 request signer rejects every PUT/DELETE.
+    String normalizedWarehouseForPrefix = normalizeS3Scheme(warehouseLocation);
+    String normalizedTableLocationForPrefix = normalizeS3Scheme(tableMetadata.location());
+    (normalizedTableLocationForPrefix.startsWith(normalizedWarehouseForPrefix)
+            ? maybeWriteable
+            : readOnly)
         .add(locationUri);
 
     if (!icebergWriteObjectStorage(tableConfig, tableMetadata.properties(), warehouseLocation)) {
       String writeLocation = icebergWriteLocation(tableMetadata.properties());
-      if (writeLocation != null && !writeLocation.startsWith(tableMetadata.location())) {
-        (writeLocation.startsWith(warehouseLocation) ? maybeWriteable : readOnly)
+      if (writeLocation != null
+          && !normalizeS3Scheme(writeLocation).startsWith(normalizedTableLocationForPrefix)) {
+        (normalizeS3Scheme(writeLocation).startsWith(normalizedWarehouseForPrefix)
+                ? maybeWriteable
+                : readOnly)
             .add(StorageUri.of(writeLocation));
       }
     }

--- a/catalog/service/rest/src/test/java/org/projectnessie/catalog/service/rest/TestIcebergConfigurer.java
+++ b/catalog/service/rest/src/test/java/org/projectnessie/catalog/service/rest/TestIcebergConfigurer.java
@@ -21,6 +21,7 @@ import static java.time.temporal.ChronoUnit.DAYS;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.projectnessie.catalog.files.s3.S3Utils.normalizeS3Scheme;
 import static org.projectnessie.catalog.secrets.UnsafePlainTextSecretsManager.unsafePlainTextSecretsProvider;
 import static org.projectnessie.catalog.service.rest.IcebergConfigurer.S3_SIGNER_ENDPOINT;
 import static org.projectnessie.catalog.service.rest.IcebergConfigurer.S3_SIGNER_URI;
@@ -196,7 +197,10 @@ public class TestIcebergConfigurer {
               p -> p.signerSignature().warehouseLocation(),
               p -> p.signerSignature().identifier())
           .containsExactly(
-              signerKey.name(), List.of(loc), warehouseLocation, key.toPathStringEscaped());
+              signerKey.name(),
+              List.of(normalizeS3Scheme(loc)),
+              warehouseLocation,
+              key.toPathStringEscaped());
       soft.assertThat(signPath).doesNotStartWith("/");
       soft.assertThat(signUri).isNotNull();
     } else {
@@ -208,12 +212,32 @@ public class TestIcebergConfigurer {
     ContentKey key = ContentKey.of("foo", "bar");
 
     String s3 = "s3://bucket/path/1/2/3";
+    String s3a = "s3a://bucket/path/1/2/3";
+    String s3n = "s3n://bucket/path/1/2/3";
     String gcs = "gcs://bucket/path/1/2/3";
     String complexPrefix = "main|s3://blah/meep";
     return Stream.of(
         arguments(
             URI.create("http://foo:12434"),
             s3,
+            "main",
+            key,
+            "http://foo:12434/iceberg/",
+            "v1/main/s3sign/"),
+        // Tables written by HadoopFileIO have metadata.location prefixed with s3a:// while the
+        // warehouse is registered with s3://. The writeable derivation must normalize the scheme
+        // on both sides of the prefix check; otherwise the writeable[] returned to the S3 signer
+        // is empty and every PUT/DELETE is rejected.
+        arguments(
+            URI.create("http://foo:12434"),
+            s3a,
+            "main",
+            key,
+            "http://foo:12434/iceberg/",
+            "v1/main/s3sign/"),
+        arguments(
+            URI.create("http://foo:12434"),
+            s3n,
             "main",
             key,
             "http://foo:12434/iceberg/",


### PR DESCRIPTION
## Summary

With the default `HadoopFileIO`, Spark writes `metadata.location` prefixed
with `s3a://`, while the warehouse is registered as `s3://`. The
`startsWith` check in `IcebergConfigurer.icebergConfigPerTable()` is done
on the raw strings, so the scheme mismatch makes the predicate false and
`writeable[]` ends up empty. The S3 signer then rejects every PUT / DELETE
with `HTTP 403 unauthorized signing request`. Reads don't go through the
signer, which is what makes this confusing in practice.

Running both sides of the prefix check through `S3Utils.normalizeS3Scheme`
fixes it. The `StorageUri` values kept in `writeable` / `readOnly` are
left at their original scheme, and the existing normalization in
`configureS3RequestSigningForTable` still produces the canonical form for
the signer payload, so the wire format is unchanged.

Kept this to the call-site fix; the storage-time variant from the issue
is a wider change and probably belongs in a separate PR.

## Related Issue

Fixes #12426

## Changes

- `IcebergConfigurer.java`
  - Normalize `warehouseLocation` once at the top of `icebergConfigPerTable`.
  - Normalize `tableMetadata.location()` and the `icebergWriteLocation`
    path before the `startsWith` checks.
- `TestIcebergConfigurer.java`
  - Add `s3a://` and `s3n://` rows to the existing parameterized test.
  - Compare `signerParams.writeLocations()` against the normalized form
    (what the signer actually receives).

## How to Verify

```bash
./gradlew :nessie-catalog-service-rest:test \
  --tests "org.projectnessie.catalog.service.rest.TestIcebergConfigurer"
```

The new `s3a://` / `s3n://` rows fail on `main` (empty `writeLocations`)
and pass with this change.

## Checklist

- [x] DCO sign-off
- [x] Unit test covers `s3://`, `s3a://`, `s3n://`
- [x] No behavior change for the `s3://`-only path
- [x] No changes to the signer wire format