### PR TITLE
Allow setting environment variables for the Gradle invocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ __pycache__/
 
 # Spark / Hive
 metastore_db/
+
+/.env

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -308,6 +308,7 @@ tasks.named<Wrapper>("wrapper") {
     val insertAtLine =
       scriptLines.indexOf("# Use the maximum available, or set MAX_FD != -1 to use that value.")
     scriptLines.add(insertAtLine, "")
+    scriptLines.add(insertAtLine, $$"[ -f \"${APP_HOME}/.env\" ] && . \"${APP_HOME}/.env\"")
     scriptLines.add(insertAtLine, $$". \"${APP_HOME}/gradle/gradlew-include.sh\"")
 
     scriptFile.writeText(scriptLines.joinToString("\n"))

--- a/gradlew
+++ b/gradlew
@@ -88,6 +88,7 @@ APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
 APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
+[ -f "${APP_HOME}/.env" ] && . "${APP_HOME}/.env"
 . "${APP_HOME}/gradle/gradlew-include.sh"
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.


### PR DESCRIPTION
This allows creating a `.env` file and for example enable the Gradle configuration cache via
```
GRADLE_OPTS='-Dorg.gradle.configuration-cache=true'
```