### PR TITLE
NesQuEIT: attempt to fix OOMs

### DIFF
--- a/build-logic/src/main/kotlin/Utilities.kt
+++ b/build-logic/src/main/kotlin/Utilities.kt
@@ -301,7 +301,7 @@ private class NessieProjects {
 }
 
 /** Utility method to check whether a Quarkus build shall produce the uber-jar. */
-fun Project.quarkusFatJar(): Boolean = hasProperty("uber-jar") || isIncludedInNesQuEIT()
+fun Project.quarkusFatJar(): Boolean = hasProperty("uber-jar")
 
 fun Project.quarkusPackageType(): String = if (quarkusFatJar()) "uber-jar" else "fast-jar"
 


### PR DESCRIPTION
It's possible that Quarkus's "fat jar" (uber jar) build is causeing the OOMs in NesQuEIT. This is an attempt to investigate this.