### PR TITLE
Preserve SQL representations when importing Iceberg views

### DIFF
--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/NessieModelIceberg.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/NessieModelIceberg.java
@@ -540,6 +540,10 @@ public class NessieModelIceberg {
         .icebergDefaultCatalog(currentVersion.defaultCatalog())
         .icebergNamespace(currentVersion.defaultNamespace().levels())
         .icebergVersionSummary(currentVersion.summary())
+        .representations(
+            currentVersion.representations().stream()
+                .map(NessieModelIceberg::icebergViewRepresentationToNessie)
+                .collect(Collectors.toList()))
         .snapshotCreatedTimestamp(now())
         .lastUpdatedTimestamp(lastUpdatedTimestamp);
 

--- a/catalog/format/iceberg/src/test/java/org/projectnessie/catalog/formats/iceberg/nessie/TestNessieModelIceberg.java
+++ b/catalog/format/iceberg/src/test/java/org/projectnessie/catalog/formats/iceberg/nessie/TestNessieModelIceberg.java
@@ -32,6 +32,7 @@ import static org.projectnessie.catalog.formats.iceberg.meta.IcebergSchema.INITI
 import static org.projectnessie.catalog.formats.iceberg.meta.IcebergSortField.sortField;
 import static org.projectnessie.catalog.formats.iceberg.meta.IcebergSortOrder.INITIAL_SORT_ORDER_ID;
 import static org.projectnessie.catalog.formats.iceberg.meta.IcebergTableMetadata.INITIAL_PARTITION_ID;
+import static org.projectnessie.catalog.formats.iceberg.meta.IcebergViewRepresentation.IcebergSQLViewRepresentation.icebergSqlViewRepresentation;
 import static org.projectnessie.catalog.formats.iceberg.nessie.NessieModelIceberg.collectFieldsByIcebergId;
 import static org.projectnessie.catalog.formats.iceberg.nessie.NessieModelIceberg.icebergPartitionSpecToNessie;
 import static org.projectnessie.catalog.formats.iceberg.nessie.NessieModelIceberg.icebergSchemaToNessieSchema;
@@ -59,6 +60,7 @@ import static org.projectnessie.catalog.formats.iceberg.types.IcebergType.timest
 import static org.projectnessie.catalog.model.id.NessieIdHasher.nessieIdHasher;
 import static org.projectnessie.catalog.model.schema.NessieNullOrder.NULLS_LAST;
 import static org.projectnessie.catalog.model.schema.NessieSortDirection.ASC;
+import static org.projectnessie.catalog.model.snapshot.NessieViewRepresentation.NessieViewSQLRepresentation.nessieViewSQLRepresentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
@@ -1280,6 +1282,43 @@ public class TestNessieModelIceberg {
     soft.assertThat(snap4.icebergLocation()).isEqualTo(location3);
     soft.assertThat(snap4.additionalKnownLocations())
         .containsExactlyInAnyOrder(location1, location2);
+  }
+
+  @Test
+  public void icebergViewSnapshotToNessiePreservesRepresentations() {
+    String uuid = UUID.randomUUID().toString();
+    String sql = "SELECT id, name FROM ns.view_source";
+
+    IcebergViewVersion version =
+        IcebergViewVersion.builder()
+            .versionId(1)
+            .timestampMs(1L)
+            .schemaId(1)
+            .defaultNamespace(IcebergNamespace.EMPTY_ICEBERG_NAMESPACE)
+            .addRepresentation(icebergSqlViewRepresentation(sql, "DremioSQL"))
+            .build();
+    IcebergViewMetadata metadata =
+        IcebergViewMetadata.builder()
+            .location("s3://bucket/views/v/metadata/00000.metadata.json")
+            .viewUuid(uuid)
+            .formatVersion(2)
+            .currentVersionId(1)
+            .addVersions(version)
+            .build();
+    NessieView view =
+        NessieView.builder()
+            .tableFormat(TableFormat.ICEBERG)
+            .nessieContentId(uuid)
+            .icebergUuid(uuid)
+            .createdTimestamp(Instant.EPOCH)
+            .build();
+
+    NessieViewSnapshot snapshot =
+        NessieModelIceberg.icebergViewSnapshotToNessie(
+            NessieId.randomNessieId(), null, view, metadata);
+
+    soft.assertThat(snapshot.representations())
+        .containsExactly(nessieViewSQLRepresentation(sql, "DremioSQL"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes #12504.

When Nessie imports an Iceberg view from a metadata location, it builds a Nessie view snapshot from the current Iceberg view version. That path copied the version id, namespace, default catalog, and summary, but did not copy the view representations.

As a result, REST `GET view` could return an empty `versions[].representations` list even when the original Iceberg view metadata file contains a SQL representation.

This change carries the current version's representations into the Nessie snapshot using the existing Iceberg-to-Nessie representation mapper.

## Testing

- `./gradlew :nessie-catalog-format-iceberg:test --tests org.projectnessie.catalog.formats.iceberg.nessie.TestNessieModelIceberg.icebergViewSnapshotToNessiePreservesRepresentations`
- `./gradlew :nessie-catalog-format-iceberg:test --tests org.projectnessie.catalog.formats.iceberg.nessie.TestNessieModelIceberg`
- `./gradlew :nessie-catalog-format-iceberg:spotlessCheck`
