### PR TITLE
Restore Prometheus metrics endpoint

### DIFF
--- a/gradle/built-uber-dists/LICENSE-BINARY-DIST
+++ b/gradle/built-uber-dists/LICENSE-BINARY-DIST
@@ -454,6 +454,7 @@ io.quarkus:quarkus-jdbc-postgresql
 io.quarkus:quarkus-jsonp
 io.quarkus:quarkus-logging-json
 io.quarkus:quarkus-micrometer
+io.quarkus:quarkus-micrometer-registry-prometheus
 io.quarkus:quarkus-mongodb-client
 io.quarkus:quarkus-mutiny
 io.quarkus:quarkus-mutiny-reactive-streams-operators

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/MeterFilterProvider.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/MeterFilterProvider.java
@@ -38,4 +38,10 @@ public class MeterFilterProvider {
             .map(e -> Tag.of(e.getKey(), e.getValue()))
             .collect(Collectors.toSet()));
   }
+
+  @Produces
+  @Singleton
+  public MeterFilter ignoreServerPortTag() {
+    return MeterFilter.ignoreTags("server.port");
+  }
 }

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -83,7 +83,7 @@ dependencies {
   implementation("io.quarkus:quarkus-security")
   implementation("io.quarkus:quarkus-elytron-security-properties-file")
   implementation("io.quarkus:quarkus-oidc")
-  implementation("io.quarkus:quarkus-micrometer")
+  implementation("io.quarkus:quarkus-micrometer-registry-prometheus")
   implementation("io.quarkus:quarkus-opentelemetry")
   implementation("io.quarkus:quarkus-logging-json")
   implementation(libs.quarkus.logging.sentry)
@@ -202,8 +202,6 @@ dependencies {
   testAnnotationProcessor(project(":nessie-immutables", configuration = "processor"))
   intTestCompileOnly(project(":nessie-immutables"))
   intTestAnnotationProcessor(project(":nessie-immutables", configuration = "processor"))
-
-  testImplementation("io.micrometer:micrometer-registry-prometheus-simpleclient")
 
   intTestImplementation(enforcedPlatform(libs.testcontainers.bom))
   intTestImplementation("io.quarkus:quarkus-test-keycloak-server")


### PR DESCRIPTION
Fixes #12398.

This restores the Prometheus metrics endpoint for the Quarkus server.

The server still had Micrometer enabled, but the Prometheus registry was only present through a test dependency. As a result, packaged server images returned 404 for `/q/metrics`.

This change uses the Quarkus Prometheus Micrometer registry extension at runtime and removes the test-only simpleclient registry dependency.

Verification:
- Reproduced `/q/metrics` returning 404 with published images 0.107.5, 0.107.9, 0.108.0, and `nessie-unstable:latest`
- Confirmed 0.107.4 returns 200 for `/q/metrics`
- Applied the same change to the `nessie-0.108.0` tag, rebuilt locally, and confirmed `/q/metrics` returns 200
- Built current main with this change and confirmed the packaged app returns 200 for `/q/metrics`
- Ran `:nessie-quarkus:test` with `TestMetricsTags` and `TestMetricsDisabled`
- Ran `:nessie-quarkus:quarkusBuild`
- Ran `:nessie-quarkus:spotlessKotlinGradleCheck`
