### PR TITLE
Tackle heap issues

### DIFF
--- a/.github/workflows/ci-quarkus-cr.yml
+++ b/.github/workflows/ci-quarkus-cr.yml
@@ -44,10 +44,6 @@ jobs:
       - name: Setup Java, Gradle
         uses: ./.github/actions/dev-tool-java
 
-      # Needed for the Quarkus plugin - can likely go away once we use Quarkus 3 or newer
-      - name: Bump Gradle daemon heap
-        run: sed -i 's/-Xms.*/-Xms6G -Xmx6G -XX:MaxMetaspaceSize=1g \\/' gradle.properties
-
       - name: Prepare Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-prepare
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,6 @@ jobs:
       - name: Setup Java, Gradle
         uses: ./.github/actions/dev-tool-java
 
-      # Needed for the Quarkus plugin - can likely go away once we use Quarkus 3 or newer
-      - name: Bump Gradle daemon heap
-        run: sed -i 's/-Xms.*/-Xms6G -Xmx6G -XX:MaxMetaspaceSize=1g \\/' gradle.properties
-
       - name: Prepare Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-prepare
 

--- a/build-logic/src/main/kotlin/nessie-conventions-quarkus.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-conventions-quarkus.gradle.kts
@@ -16,6 +16,9 @@
 
 // Conventions for project being built for/with Quarkus.
 
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+
 plugins { id("nessie-conventions-java21") }
 
 // This can likely be removed with Quarkus 3.26.3 (or newer)
@@ -27,3 +30,22 @@ listOf("compileJava", "javadoc", "sourcesJar").forEach { name ->
 listOf("compileTestJava", "checkstyleTest", "compileTestJava").forEach { name ->
   tasks.named(name).configure { dependsOn(tasks.named("compileQuarkusTestGeneratedSourcesJava")) }
 }
+
+if (quarkusFatJar()) {
+  val quarkusUberJarBuildLimiter =
+    gradle.sharedServices.registerIfAbsent(
+      "quarkusUberJarBuildLimiter",
+      QuarkusUberJarBuildLimiter::class.java,
+    ) {
+      maxParallelUsages = 1
+    }
+
+  tasks.named("quarkusBuild").configure {
+    // Quarkus' uber-jar assembly can temporarily require a large heap while it repackages
+    // dependency jars. Release publishing builds multiple Quarkus applications in one Gradle
+    // invocation, so serialize only the memory-heavy application packaging step.
+    usesService(quarkusUberJarBuildLimiter)
+  }
+}
+
+abstract class QuarkusUberJarBuildLimiter : BuildService<BuildServiceParameters.None>

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.configuration-cache=false
 #org.gradle.configuration-cache-problems=warn
 # bump the Gradle daemon heap size (you can set even bigger heap sizes as well)
 org.gradle.jvmargs=\
-  -Xms2g -Xmx4g -XX:MaxMetaspaceSize=1g \
+  -Xmx6g -XX:MaxMetaspaceSize=1g \
   -Dfile.encoding=UTF-8 \
   -Duser.language=en -Duser.country=US -Duser.variant= \
   --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -254,6 +254,9 @@ quarkus {
         .toMap()
     }
   )
+  buildForkOptions {
+    maxHeapSize = "4G"
+  }
 }
 
 val quarkusBuild = tasks.named<QuarkusBuild>("quarkusBuild")

--- a/tools/server-admin/build.gradle.kts
+++ b/tools/server-admin/build.gradle.kts
@@ -137,6 +137,9 @@ quarkus {
         .toMap()
     }
   )
+  buildForkOptions {
+    maxHeapSize = "4G"
+  }
 }
 
 val quarkusBuild = tasks.named<QuarkusBuild>("quarkusBuild")


### PR DESCRIPTION
This change primarily tackles the repeated OutOfMemory issues during snapshot publising and also during releases, especially when building the "fat jar" / "uber jar".

The actual Quarkus-build change is twofold:
1. The build-worker process that executes the Quarkus build gets 4G heap (not Java's default)
2. all `quarkusBuild` task executions are serialized (via the quarkus convention plugin)

Additionally, the minimum heap size for the Gradle daemon is removed and the max heap size set to 6G. This removes the requirement in some CI jobs to patch the gradle.properties file.