### PR TITLE
Fix Helm CRD fixture install with Helm 4.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -844,8 +844,12 @@ jobs:
       - name: Install fixtures
         run: |
           # Install Gateway API CRDs
-          helm template eg oci://docker.io/envoyproxy/gateway-crds-helm \
+          helm pull oci://docker.io/envoyproxy/gateway-crds-helm \
             --version v1.7.0 \
+            --untar \
+            --untardir "$RUNNER_TEMP/helm-charts"
+
+          helm template eg "$RUNNER_TEMP/helm-charts/gateway-crds-helm" \
             --set crds.gatewayAPI.enabled=true \
             --set crds.gatewayAPI.channel=standard \
             --set crds.envoyGateway.enabled=false \


### PR DESCRIPTION
Helm 4.2.2 can emit OCI pull status output while templating an OCI chart. The CI fixture setup piped `helm template oci://...` directly into `kubectl apply -f -`, so that non-manifest output could be interpreted as a Kubernetes document and fail validation with missing apiVersion/kind.

Pull the Envoy Gateway CRD chart first, then render the local chart directory and pipe only the rendered manifests to kubectl. This keeps the fixture setup compatible with Helm 4.2.2 without changing the Nessie Helm chart itself.