### PR TITLE
GC tool: add --jdbc-pool-max-size option

### DIFF
--- a/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/JdbcOptions.java
+++ b/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/JdbcOptions.java
@@ -59,6 +59,15 @@ public class JdbcOptions {
   int fetchSize = 100;
 
   @CommandLine.Option(
+      names = "--jdbc-pool-max-size",
+      defaultValue = "5",
+      description =
+          "Maximum JDBC connection pool size, defaults to 5. The sweep/expire phase holds one "
+              + "streaming connection plus one per --expiry-parallelism worker, so set this to at "
+              + "least --expiry-parallelism + 1 to avoid connection-acquisition timeouts.")
+  int poolMaxSize = 5;
+
+  @CommandLine.Option(
       names = "--jdbc-schema",
       description =
           "How to create the database schema. "
@@ -69,6 +78,7 @@ public class JdbcOptions {
     AgroalJdbcDataSourceProvider.Builder jdbcDsBuilder =
         AgroalJdbcDataSourceProvider.builder()
             .jdbcUrl(url)
+            .poolMaxSize(poolMaxSize)
             .usernamePasswordCredentials(user, password);
     properties.forEach(jdbcDsBuilder::putJdbcProperties);
     AgroalJdbcDataSourceProvider dataSourceProvider = jdbcDsBuilder.build();

--- a/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/JdbcOptions.java
+++ b/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/JdbcOptions.java
@@ -78,7 +78,7 @@ public class JdbcOptions {
     AgroalJdbcDataSourceProvider.Builder jdbcDsBuilder =
         AgroalJdbcDataSourceProvider.builder()
             .jdbcUrl(url)
-            .poolMaxSize(poolMaxSize)
+            .poolMaxSize(Math.max(2, poolMaxSize))
             .usernamePasswordCredentials(user, password);
     properties.forEach(jdbcDsBuilder::putJdbcProperties);
     AgroalJdbcDataSourceProvider dataSourceProvider = jdbcDsBuilder.build();


### PR DESCRIPTION
## What

Adds a `--jdbc-pool-max-size` CLI option to the `nessie-gc` tool, wired to `AgroalJdbcDataSourceProvider.Builder.poolMaxSize`. Defaults to `5`, so existing behaviour is unchanged.

## Why

The GC tool's JDBC contents store uses `AgroalJdbcDataSourceProvider`, whose connection pool is hardcoded to `maxSize = 5` and isn't exposed by any CLI flag (`--jdbc-properties` only reaches the JDBC driver, not the Agroal pool).

The `sweep`/`expire` phase holds **`1 + --expiry-parallelism`** connections concurrently — one streaming the content IDs for the whole sweep, plus one per parallel worker while it lists that content's files. So the default `--expiry-parallelism=4` already reaches the pool ceiling (`1 + 4 = 5`); raising parallelism beyond that gives no speedup and eventually fails with:

```
java.sql.SQLException: Sorry, acquisition timeout!
```

Measured on an isolated Nessie + Postgres + MinIO setup (40 tables):

| expiry-parallelism | pool | result |
|---|---|---|
| 8 (stock) | 5 | no speedup vs p=4 |
| 16 (stock) | 5 | crash (acquisition timeout) |
| 16 | 17 | ~3× faster |
| 32 | 33 | ~4× faster |

## Change

`--jdbc-pool-max-size` (default `5`) → `AgroalJdbcDataSourceProvider.builder().poolMaxSize(...)`. The option help text notes it should be set to at least `--expiry-parallelism + 1`.
