### PR TITLE
Make spotless-config nicer to Gradle config-cache

### DIFF
--- a/build-logic/src/main/kotlin/nessie-common-base.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-common-base.gradle.kts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import com.diffplug.spotless.LineEnding
+
 plugins { id("com.diffplug.spotless") }
 
 apply<PublishingHelperPlugin>()
@@ -25,6 +27,11 @@ if (
     !System.getProperty("idea.sync.active").toBoolean()
 ) {
   spotless {
+    // Don't use the default (`GIT_ATTRIBUTES_FAST_ALLSAME`) here, because that reads external state
+    // like files, properties, Git attributes. Neither of these is configuration-cache-friendly,
+    // leading to config-cache-rebuilds.
+    lineEndings = LineEnding.UNIX
+
     format("xml") {
       target("src/**/*.xml", "src/**/*.xsd")
       eclipseWtp(com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep.XML)
@@ -76,7 +83,7 @@ if (
       java {
         googleJavaFormat(libsRequiredVersion("googleJavaFormat"))
         licenseHeaderFile(rootProject.file("codestyle/copyright-header-java.txt"))
-        target("src/**/java/**")
+        target("src/**/*.java")
         targetExclude("build/**")
       }
     }


### PR DESCRIPTION
Spotless' default for the line-ending, `GIT_ATTRIBUTES_FAST_ALLSAME`, goes through `GitAttributesLineEndings`, which reads Git-related state: repo config, user/system config, .git/info/attributes, possible global attributes, and probes .gitattributes up parent directories for target files. That file I/O happens while Gradle is fingerprinting task inputs, and in this build it showed up as the opaque input to unknown location has changed. Setting `LineEnding.UNIX` makes the policy a simple serializable constant "\n" and removes the Git-attributes lookup from the Spotless task input.

Using `PLATFORM_NATIVE` would be cache-friendly, but it makes formatter output OS-dependent. That is bad for reproducibility and remote/local cache portability.

`PRESERVE` is defensible but weaker. It avoids Git-attributes lookup, but it preserves whatever line ending the first line of each file currently has. That can allow mixed project state to persist. For this repo, UNIX is the better default: deterministic, cross-platform, and matches typical Java source formatting.