### PR TITLE
Jackson 3 slice - api/model

### DIFF
--- a/api/model/build.gradle.kts
+++ b/api/model/build.gradle.kts
@@ -31,6 +31,10 @@ dependencies {
   implementation("com.fasterxml.jackson.core:jackson-databind")
   implementation("com.fasterxml.jackson.core:jackson-annotations")
 
+  compileOnly(platform(libs.jackson3.bom))
+  compileOnly("tools.jackson.core:jackson-core")
+  compileOnly("tools.jackson.core:jackson-databind")
+
   // javax/jakarta
   compileOnly(libs.jakarta.ws.rs.api)
   compileOnly(libs.javax.ws.rs)
@@ -118,6 +122,30 @@ testing {
         implementation.add(project())
         implementation.add(platform(libs.jetty.bom))
         implementation.add("org.eclipse.jetty:jetty-http")
+        compileOnly(libs.microprofile.openapi)
+      }
+
+      targets {
+        all {
+          testTask.configure {
+            usesService(
+              gradle.sharedServices.registrations.named("testParallelismConstraint").get().service
+            )
+          }
+          tasks.named("test").configure { dependsOn(testTask) }
+        }
+      }
+    }
+
+    register("testJackson3", JvmTestSuite::class.java) {
+      useJUnitJupiter(libsRequiredVersion("junit"))
+
+      dependencies {
+        implementation.add(project())
+        implementation.add(platform(libs.jackson3.bom))
+        implementation.add("tools.jackson.core:jackson-databind")
+        implementation.add(platform(libs.junit.bom))
+        implementation.add(libs.assertj.core)
         compileOnly(libs.microprofile.openapi)
       }
 

--- a/api/model/src/main/java/org/projectnessie/api/v1/params/Merge.java
+++ b/api/model/src/main/java/org/projectnessie/api/v1/params/Merge.java
@@ -37,7 +37,9 @@ import org.projectnessie.model.Validation;
     })
 @Value.Immutable
 @JsonSerialize(as = ImmutableMerge.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableMerge.class)
 @JsonDeserialize(as = ImmutableMerge.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableMerge.class)
 public interface Merge extends BaseMergeTransplant {
 
   @NotBlank

--- a/api/model/src/main/java/org/projectnessie/api/v1/params/NamespaceUpdate.java
+++ b/api/model/src/main/java/org/projectnessie/api/v1/params/NamespaceUpdate.java
@@ -24,7 +24,9 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableNamespaceUpdate.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableNamespaceUpdate.class)
 @JsonDeserialize(as = ImmutableNamespaceUpdate.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableNamespaceUpdate.class)
 public abstract class NamespaceUpdate {
 
   @Nullable

--- a/api/model/src/main/java/org/projectnessie/api/v1/params/Transplant.java
+++ b/api/model/src/main/java/org/projectnessie/api/v1/params/Transplant.java
@@ -38,7 +38,9 @@ import org.projectnessie.model.Validation;
     })
 @Value.Immutable
 @JsonSerialize(as = ImmutableTransplant.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableTransplant.class)
 @JsonDeserialize(as = ImmutableTransplant.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableTransplant.class)
 public interface Transplant extends BaseMergeTransplant {
 
   @NotNull

--- a/api/model/src/main/java/org/projectnessie/api/v2/params/Merge.java
+++ b/api/model/src/main/java/org/projectnessie/api/v2/params/Merge.java
@@ -69,7 +69,9 @@ import org.projectnessie.model.Validation;
     })
 @Value.Immutable
 @JsonSerialize(as = ImmutableMerge.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableMerge.class)
 @JsonDeserialize(as = ImmutableMerge.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableMerge.class)
 public interface Merge extends BaseMergeTransplant {
 
   @Override

--- a/api/model/src/main/java/org/projectnessie/api/v2/params/Transplant.java
+++ b/api/model/src/main/java/org/projectnessie/api/v2/params/Transplant.java
@@ -62,7 +62,9 @@ import org.projectnessie.model.Validation;
     })
 @Value.Immutable
 @JsonSerialize(as = ImmutableTransplant.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableTransplant.class)
 @JsonDeserialize(as = ImmutableTransplant.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableTransplant.class)
 public interface Transplant extends BaseMergeTransplant {
 
   @Override

--- a/api/model/src/main/java/org/projectnessie/error/ContentKeyErrorDetails.java
+++ b/api/model/src/main/java/org/projectnessie/error/ContentKeyErrorDetails.java
@@ -26,7 +26,9 @@ import org.projectnessie.model.ContentKey;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableContentKeyErrorDetails.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableContentKeyErrorDetails.class)
 @JsonDeserialize(as = ImmutableContentKeyErrorDetails.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableContentKeyErrorDetails.class)
 @JsonTypeName(ContentKeyErrorDetails.TYPE)
 public interface ContentKeyErrorDetails extends NessieErrorDetails {
 

--- a/api/model/src/main/java/org/projectnessie/error/ErrorCode.java
+++ b/api/model/src/main/java/org/projectnessie/error/ErrorCode.java
@@ -84,4 +84,15 @@ public enum ErrorCode {
       return name != null ? ErrorCode.parse(name) : null;
     }
   }
+
+  public static final class Deserializer3
+      extends tools.jackson.databind.ValueDeserializer<ErrorCode> {
+    @Override
+    public ErrorCode deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+        throws tools.jackson.core.JacksonException {
+      String name = p.readValueAs(String.class);
+      return name != null ? ErrorCode.parse(name) : null;
+    }
+  }
 }

--- a/api/model/src/main/java/org/projectnessie/error/GenericErrorDetails.java
+++ b/api/model/src/main/java/org/projectnessie/error/GenericErrorDetails.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -35,7 +36,11 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonSerialize(using = GenericErrorDetails.GenericTypeSerializer.class)
+@tools.jackson.databind.annotation.JsonSerialize(
+    using = GenericErrorDetails.GenericTypeSerializer3.class)
 @JsonDeserialize(using = GenericErrorDetails.GenericTypeDeserializer.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    using = GenericErrorDetails.GenericTypeDeserializer3.class)
 public abstract class GenericErrorDetails implements NessieErrorDetails {
   @Override
   @Value.Parameter(order = 1)
@@ -86,6 +91,76 @@ public abstract class GenericErrorDetails implements NessieErrorDetails {
         type = "UNKNOWN_ERROR_DETAILS";
       }
       return GenericErrorDetails.errorUnknownType(type.toString(), all);
+    }
+  }
+
+  static final class GenericTypeSerializer3
+      extends tools.jackson.databind.ValueSerializer<GenericErrorDetails> {
+
+    @Override
+    public void serializeWithType(
+        GenericErrorDetails value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers,
+        tools.jackson.databind.jsontype.TypeSerializer typeSer)
+        throws tools.jackson.core.JacksonException {
+      gen.writeStartObject();
+      gen.writeStringProperty("type", value.getType());
+      for (Map.Entry<String, Object> entry : value.getAttributes().entrySet()) {
+        gen.writePOJOProperty(entry.getKey(), entry.getValue());
+      }
+      gen.writeEndObject();
+    }
+
+    @Override
+    public void serialize(
+        GenericErrorDetails value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  static final class GenericTypeDeserializer3
+      extends tools.jackson.databind.ValueDeserializer<GenericErrorDetails> {
+
+    @Override
+    public GenericErrorDetails deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+        throws tools.jackson.core.JacksonException {
+      if (p.currentToken() == tools.jackson.core.JsonToken.START_OBJECT) {
+        return fromMap(p.readValueAs(Map.class));
+      }
+
+      Map<String, Object> all = new LinkedHashMap<>();
+      Object type = p.getTypeId();
+      for (tools.jackson.core.JsonToken token = p.currentToken();
+          token == tools.jackson.core.JsonToken.PROPERTY_NAME;
+          token = p.nextToken()) {
+        String fieldName = p.currentName();
+        p.nextToken();
+        Object value = p.readValueAs(Object.class);
+        if ("type".equals(fieldName)) {
+          type = value;
+        } else {
+          all.put(fieldName, value);
+        }
+      }
+
+      if (type == null) {
+        type = "UNKNOWN_ERROR_DETAILS";
+      }
+      return GenericErrorDetails.errorUnknownType(type.toString(), all);
+    }
+
+    private GenericErrorDetails fromMap(Map<?, ?> all) {
+      Map<String, Object> attributes = new LinkedHashMap<>();
+      all.forEach((key, value) -> attributes.put(key.toString(), value));
+      Object type = attributes.remove("type");
+      if (type == null) {
+        type = "UNKNOWN_ERROR_DETAILS";
+      }
+      return GenericErrorDetails.errorUnknownType(type.toString(), attributes);
     }
   }
 

--- a/api/model/src/main/java/org/projectnessie/error/Jackson3NessieErrorDetailsTypeIdResolver.java
+++ b/api/model/src/main/java/org/projectnessie/error/Jackson3NessieErrorDetailsTypeIdResolver.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.error;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import tools.jackson.databind.DatabindContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.jsontype.impl.TypeIdResolverBase;
+
+/** Dynamic {@link NessieErrorDetails} object (de)serialization for <em>Jackson 3</em>. */
+public final class Jackson3NessieErrorDetailsTypeIdResolver extends TypeIdResolverBase {
+
+  private JavaType baseType;
+
+  public Jackson3NessieErrorDetailsTypeIdResolver() {}
+
+  @Override
+  public void init(JavaType bt) {
+    baseType = bt;
+  }
+
+  @Override
+  public String idFromValue(DatabindContext context, Object value) {
+    return getId(value);
+  }
+
+  @Override
+  public String idFromValueAndType(DatabindContext context, Object value, Class<?> suggestedType) {
+    return getId(value);
+  }
+
+  @Override
+  public JsonTypeInfo.Id getMechanism() {
+    return JsonTypeInfo.Id.CUSTOM;
+  }
+
+  private String getId(Object value) {
+    if (value instanceof NessieErrorDetails details) {
+      return details.getType();
+    }
+
+    return null;
+  }
+
+  @Override
+  public JavaType typeFromId(DatabindContext context, String id) {
+    Class<? extends NessieErrorDetails> asType =
+        switch (id) {
+          case ReferenceConflicts.TYPE -> ReferenceConflicts.class;
+          case ContentKeyErrorDetails.TYPE -> ContentKeyErrorDetails.class;
+          default -> GenericErrorDetails.class;
+        };
+    if (baseType.getRawClass().isAssignableFrom(asType)) {
+      return context.constructSpecializedType(baseType, asType);
+    }
+
+    // This is rather a "test-only" code path, but it might happen in real life as well, when
+    // calling the ObjectMapper with a "too specific" type and not just NessieErrorDetails.class.
+    // So we can get here for example, if the baseType (induced by the type passed to ObjectMapper),
+    // is GenericErrorDetails.class, but the type is a "well known" type like
+    // ReferenceConflicts.class.
+    @SuppressWarnings("unchecked")
+    Class<? extends NessieErrorDetails> concrete =
+        (Class<? extends NessieErrorDetails>) baseType.getRawClass();
+    return context.constructSpecializedType(baseType, concrete);
+  }
+}

--- a/api/model/src/main/java/org/projectnessie/error/NessieError.java
+++ b/api/model/src/main/java/org/projectnessie/error/NessieError.java
@@ -34,7 +34,9 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @JsonSerialize(as = ImmutableNessieError.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableNessieError.class)
 @JsonDeserialize(as = ImmutableNessieError.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableNessieError.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface NessieError {
 
@@ -53,6 +55,7 @@ public interface NessieError {
   /** Nessie-specific error code. */
   @Value.Default
   @JsonDeserialize(using = ErrorCode.Deserializer.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(using = ErrorCode.Deserializer3.class)
   default ErrorCode getErrorCode() {
     return ErrorCode.UNKNOWN;
   }

--- a/api/model/src/main/java/org/projectnessie/error/NessieErrorDetails.java
+++ b/api/model/src/main/java/org/projectnessie/error/NessieErrorDetails.java
@@ -36,6 +36,8 @@ import org.immutables.value.Value;
     },
     discriminatorProperty = "type")
 @JsonTypeIdResolver(NessieErrorDetailsTypeIdResolver.class)
+@tools.jackson.databind.annotation.JsonTypeIdResolver(
+    Jackson3NessieErrorDetailsTypeIdResolver.class)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, property = "type", visible = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface NessieErrorDetails {

--- a/api/model/src/main/java/org/projectnessie/error/ReferenceConflicts.java
+++ b/api/model/src/main/java/org/projectnessie/error/ReferenceConflicts.java
@@ -28,7 +28,9 @@ import org.projectnessie.model.Conflict;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableReferenceConflicts.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableReferenceConflicts.class)
 @JsonDeserialize(as = ImmutableReferenceConflicts.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableReferenceConflicts.class)
 @JsonTypeName(ReferenceConflicts.TYPE)
 public interface ReferenceConflicts extends NessieErrorDetails {
   String TYPE = "REFERENCE_CONFLICTS";

--- a/api/model/src/main/java/org/projectnessie/model/Branch.java
+++ b/api/model/src/main/java/org/projectnessie/model/Branch.java
@@ -29,7 +29,9 @@ import org.immutables.value.Value;
 @Value.Immutable
 @Schema(type = SchemaType.OBJECT, title = "Branch")
 @JsonSerialize(as = ImmutableBranch.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableBranch.class)
 @JsonDeserialize(as = ImmutableBranch.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableBranch.class)
 @JsonTypeName("BRANCH")
 public interface Branch extends Reference {
 

--- a/api/model/src/main/java/org/projectnessie/model/CommitMeta.java
+++ b/api/model/src/main/java/org/projectnessie/model/CommitMeta.java
@@ -50,7 +50,10 @@ import org.projectnessie.model.ser.Views;
     // Smallrye does neither support JsonFormat nor javax.validation.constraints.Pattern :(
     properties = {@SchemaProperty(name = "hash", pattern = Validation.HASH_REGEX)})
 @JsonSerialize(as = ImmutableCommitMeta.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableCommitMeta.class)
 @JsonDeserialize(using = CommitMetaDeserializer.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    using = CommitMeta.Jackson3CommitMetaDeserializer.class)
 public abstract class CommitMeta {
 
   /**
@@ -124,14 +127,18 @@ public abstract class CommitMeta {
   @Nullable
   @jakarta.annotation.Nullable
   @JsonSerialize(using = InstantSerializer.class)
+  @tools.jackson.databind.annotation.JsonSerialize(using = Jackson3InstantSerializer.class)
   @JsonDeserialize(using = InstantDeserializer.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(using = Jackson3InstantDeserializer.class)
   public abstract Instant getCommitTime();
 
   /** Original commit time in UTC. Set by the server. */
   @Nullable
   @jakarta.annotation.Nullable
   @JsonSerialize(using = InstantSerializer.class)
+  @tools.jackson.databind.annotation.JsonSerialize(using = Jackson3InstantSerializer.class)
   @JsonDeserialize(using = InstantDeserializer.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(using = Jackson3InstantDeserializer.class)
   public abstract Instant getAuthorTime();
 
   /**
@@ -267,7 +274,80 @@ public abstract class CommitMeta {
 
     @Override
     public Instant deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-      return Instant.parse(p.getText());
+      return Instant.parse(p.getValueAsString());
+    }
+  }
+
+  public static class Jackson3InstantSerializer
+      extends tools.jackson.databind.ValueSerializer<Instant> {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_INSTANT;
+
+    @Override
+    public void serialize(
+        Instant value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext provider)
+        throws tools.jackson.core.JacksonException {
+      gen.writeString(FORMATTER.format(value));
+    }
+  }
+
+  public static class Jackson3InstantDeserializer
+      extends tools.jackson.databind.ValueDeserializer<Instant> {
+    @Override
+    public Instant deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+        throws tools.jackson.core.JacksonException {
+      return Instant.parse(p.getValueAsString());
+    }
+  }
+
+  public static class Jackson3CommitMetaDeserializer
+      extends tools.jackson.databind.ValueDeserializer<CommitMeta> {
+    private static final tools.jackson.databind.ObjectMapper MAPPER =
+        tools.jackson.databind.json.JsonMapper.builder().build();
+
+    private void toArray(
+        tools.jackson.databind.node.ObjectNode node, String singleAttr, String arrayAttr) {
+      if (!node.has(arrayAttr)) {
+        tools.jackson.databind.node.ArrayNode array = node.withArray(arrayAttr);
+        if (node.has(singleAttr)) {
+          tools.jackson.databind.JsonNode value = node.get(singleAttr);
+          if (!value.isNull()) {
+            array.add(value);
+          }
+        }
+      }
+      node.remove(singleAttr);
+    }
+
+    private void toMapOfLists(
+        tools.jackson.databind.node.ObjectNode node, String singleAttr, String arrayAttr) {
+      if (!node.has(arrayAttr)) {
+        tools.jackson.databind.node.ObjectNode mapOfLists = node.putObject(arrayAttr);
+        if (node.has(singleAttr) && node.get(singleAttr).isObject()) {
+          tools.jackson.databind.node.ObjectNode map =
+              (tools.jackson.databind.node.ObjectNode) node.get(singleAttr);
+          for (Map.Entry<String, tools.jackson.databind.JsonNode> entry : map.properties()) {
+            mapOfLists.putArray(entry.getKey()).add(entry.getValue());
+          }
+        }
+      }
+      node.remove(singleAttr);
+    }
+
+    @Override
+    public CommitMeta deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+        throws tools.jackson.core.JacksonException {
+      tools.jackson.databind.node.ObjectNode node =
+          p.readValueAs(tools.jackson.databind.node.ObjectNode.class);
+      toArray(node, "author", "authors");
+      toArray(node, "signedOffBy", "allSignedOffBy");
+      toMapOfLists(node, "properties", "allProperties");
+      org.projectnessie.model.ser.CommitMetaSer value =
+          MAPPER.convertValue(node, org.projectnessie.model.ser.CommitMetaSer.class);
+      return CommitMeta.builder().from(value).build();
     }
   }
 }

--- a/api/model/src/main/java/org/projectnessie/model/CommitResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/CommitResponse.java
@@ -31,7 +31,9 @@ import org.projectnessie.model.ser.Views;
 @Schema(type = SchemaType.OBJECT, title = "Commit Response")
 @Value.Immutable
 @JsonSerialize(as = ImmutableCommitResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableCommitResponse.class)
 @JsonDeserialize(as = ImmutableCommitResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableCommitResponse.class)
 public interface CommitResponse {
 
   static ImmutableCommitResponse.Builder builder() {
@@ -87,7 +89,9 @@ public interface CommitResponse {
 
   @Value.Immutable
   @JsonSerialize(as = ImmutableAddedContent.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableAddedContent.class)
   @JsonDeserialize(as = ImmutableAddedContent.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableAddedContent.class)
   interface AddedContent {
     @NotNull
     @jakarta.validation.constraints.NotNull

--- a/api/model/src/main/java/org/projectnessie/model/Conflict.java
+++ b/api/model/src/main/java/org/projectnessie/model/Conflict.java
@@ -39,13 +39,16 @@ import org.immutables.value.Value;
     })
 @Value.Immutable
 @JsonSerialize(as = ImmutableConflict.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableConflict.class)
 @JsonDeserialize(as = ImmutableConflict.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableConflict.class)
 @JsonIgnoreProperties(
     // need to ignore unknown properties as this type can be used in `ReferenceConflicts`
     ignoreUnknown = true)
 public interface Conflict {
   @Value.Parameter(order = 1)
   @JsonDeserialize(using = ConflictType.Deserializer.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(using = ConflictType.Deserializer3.class)
   ConflictType conflictType();
 
   @Value.Parameter(order = 2)
@@ -124,6 +127,23 @@ public interface Conflict {
       @Override
       public ConflictType deserialize(JsonParser p, DeserializationContext ctxt)
           throws IOException {
+        String name = p.readValueAs(String.class);
+        return ConflictType.parse(name);
+      }
+    }
+
+    public static final class Deserializer3
+        extends tools.jackson.databind.ValueDeserializer<ConflictType> {
+
+      @Override
+      public ConflictType getNullValue(tools.jackson.databind.DeserializationContext ctxt) {
+        return UNKNOWN;
+      }
+
+      @Override
+      public ConflictType deserialize(
+          tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+          throws tools.jackson.core.JacksonException {
         String name = p.readValueAs(String.class);
         return ConflictType.parse(name);
       }

--- a/api/model/src/main/java/org/projectnessie/model/Content.java
+++ b/api/model/src/main/java/org/projectnessie/model/Content.java
@@ -30,6 +30,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
 import org.projectnessie.model.types.ContentTypeIdResolver;
 import org.projectnessie.model.types.ContentTypes;
+import org.projectnessie.model.types.Jackson3ContentTypeIdResolver;
 
 /** Base class for an object stored within Nessie. */
 @Schema(
@@ -52,11 +53,14 @@ import org.projectnessie.model.types.ContentTypes;
     },
     discriminatorProperty = "type")
 @JsonTypeIdResolver(ContentTypeIdResolver.class)
+@tools.jackson.databind.annotation.JsonTypeIdResolver(Jackson3ContentTypeIdResolver.class)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, property = "type", visible = true)
 public abstract class Content {
 
   @JsonDeserialize(using = Util.ContentTypeDeserializer.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(using = Util.ContentTypeDeserializer3.class)
   @JsonSerialize(using = Util.ContentTypeSerializer.class)
+  @tools.jackson.databind.annotation.JsonSerialize(using = Util.ContentTypeSerializer3.class)
   @Schema(
       type = SchemaType.STRING,
       description =

--- a/api/model/src/main/java/org/projectnessie/model/ContentKey.java
+++ b/api/model/src/main/java/org/projectnessie/model/ContentKey.java
@@ -37,7 +37,9 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @JsonSerialize(as = ImmutableContentKey.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableContentKey.class)
 @JsonDeserialize(as = ImmutableContentKey.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableContentKey.class)
 public abstract class ContentKey implements Comparable<ContentKey>, Elements {
 
   /** Maximum number of characters in a key. Note: characters can take up to 3 bytes via UTF-8. */

--- a/api/model/src/main/java/org/projectnessie/model/ContentMetadata.java
+++ b/api/model/src/main/java/org/projectnessie/model/ContentMetadata.java
@@ -21,9 +21,11 @@ import javax.validation.constraints.NotEmpty;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.projectnessie.model.metadata.ContentMetadataVariantResolver;
+import org.projectnessie.model.metadata.Jackson3ContentMetadataVariantResolver;
 
 @Schema(type = SchemaType.OBJECT, title = "ContentMetadata", discriminatorProperty = "variant")
 @JsonTypeIdResolver(ContentMetadataVariantResolver.class)
+@tools.jackson.databind.annotation.JsonTypeIdResolver(Jackson3ContentMetadataVariantResolver.class)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, property = "variant", visible = true)
 public interface ContentMetadata {
 

--- a/api/model/src/main/java/org/projectnessie/model/ContentResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/ContentResponse.java
@@ -26,7 +26,9 @@ import org.projectnessie.model.ser.Views;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableContentResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableContentResponse.class)
 @JsonDeserialize(as = ImmutableContentResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableContentResponse.class)
 public interface ContentResponse {
 
   static ImmutableContentResponse.Builder builder() {
@@ -36,6 +38,8 @@ public interface ContentResponse {
   @NotNull
   @jakarta.validation.constraints.NotNull
   @Value.Parameter(order = 1)
+  @tools.jackson.databind.annotation.JsonTypeIdResolver(
+      org.projectnessie.model.types.Jackson3ContentTypeIdResolver.class)
   Content getContent();
 
   /**

--- a/api/model/src/main/java/org/projectnessie/model/DeltaLakeTable.java
+++ b/api/model/src/main/java/org/projectnessie/model/DeltaLakeTable.java
@@ -25,7 +25,9 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableDeltaLakeTable.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableDeltaLakeTable.class)
 @JsonDeserialize(as = ImmutableDeltaLakeTable.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableDeltaLakeTable.class)
 @JsonTypeName("DELTA_LAKE_TABLE")
 public abstract class DeltaLakeTable extends Content {
 

--- a/api/model/src/main/java/org/projectnessie/model/Detached.java
+++ b/api/model/src/main/java/org/projectnessie/model/Detached.java
@@ -36,7 +36,9 @@ import org.immutables.value.Value;
 @Value.Immutable
 @Schema(type = SchemaType.OBJECT, title = "Detached commit hash")
 @JsonSerialize(as = ImmutableDetached.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableDetached.class)
 @JsonDeserialize(as = ImmutableDetached.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableDetached.class)
 @JsonTypeName("DETACHED")
 public interface Detached extends Reference {
 

--- a/api/model/src/main/java/org/projectnessie/model/DiffResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/DiffResponse.java
@@ -28,7 +28,9 @@ import org.projectnessie.model.ser.Views;
 @Schema(type = SchemaType.OBJECT, title = "DiffResponse")
 @Value.Immutable
 @JsonSerialize(as = ImmutableDiffResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableDiffResponse.class)
 @JsonDeserialize(as = ImmutableDiffResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableDiffResponse.class)
 public interface DiffResponse extends PaginatedResponse {
 
   static ImmutableDiffResponse.Builder builder() {
@@ -57,7 +59,9 @@ public interface DiffResponse extends PaginatedResponse {
 
   @Value.Immutable
   @JsonSerialize(as = ImmutableDiffEntry.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableDiffEntry.class)
   @JsonDeserialize(as = ImmutableDiffEntry.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableDiffEntry.class)
   interface DiffEntry {
     @Value.Parameter(order = 1)
     ContentKey getKey();
@@ -66,11 +70,15 @@ public interface DiffResponse extends PaginatedResponse {
     @jakarta.annotation.Nullable
     @Value.Parameter(order = 2)
     @SuppressWarnings("immutables:from")
+    @tools.jackson.databind.annotation.JsonTypeIdResolver(
+        org.projectnessie.model.types.Jackson3ContentTypeIdResolver.class)
     Content getFrom();
 
     @Nullable
     @jakarta.annotation.Nullable
     @Value.Parameter(order = 3)
+    @tools.jackson.databind.annotation.JsonTypeIdResolver(
+        org.projectnessie.model.types.Jackson3ContentTypeIdResolver.class)
     Content getTo();
 
     static DiffEntry diffEntry(ContentKey key, Content from) {

--- a/api/model/src/main/java/org/projectnessie/model/Documentation.java
+++ b/api/model/src/main/java/org/projectnessie/model/Documentation.java
@@ -24,7 +24,9 @@ import org.immutables.value.Value;
 /** Represents documentation for a content object in Nessie. */
 @Value.Immutable
 @JsonSerialize(as = ImmutableDocumentation.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableDocumentation.class)
 @JsonDeserialize(as = ImmutableDocumentation.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableDocumentation.class)
 public interface Documentation {
   static ImmutableDocumentation.Builder builder() {
     return ImmutableDocumentation.builder();

--- a/api/model/src/main/java/org/projectnessie/model/EntriesResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/EntriesResponse.java
@@ -27,7 +27,9 @@ import org.projectnessie.model.ser.Views;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableEntriesResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableEntriesResponse.class)
 @JsonDeserialize(as = ImmutableEntriesResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableEntriesResponse.class)
 public interface EntriesResponse extends PaginatedResponse {
 
   static ImmutableEntriesResponse.Builder builder() {
@@ -49,7 +51,9 @@ public interface EntriesResponse extends PaginatedResponse {
 
   @Value.Immutable
   @JsonSerialize(as = ImmutableEntry.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableEntry.class)
   @JsonDeserialize(as = ImmutableEntry.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableEntry.class)
   interface Entry {
 
     static ImmutableEntry.Builder builder() {
@@ -77,6 +81,8 @@ public interface EntriesResponse extends PaginatedResponse {
     @Value.Parameter(order = 4)
     @Nullable
     @jakarta.annotation.Nullable // for V1 backwards compatibility
+    @tools.jackson.databind.annotation.JsonTypeIdResolver(
+        org.projectnessie.model.types.Jackson3ContentTypeIdResolver.class)
     Content getContent();
 
     @Value.Check

--- a/api/model/src/main/java/org/projectnessie/model/GarbageCollectorConfig.java
+++ b/api/model/src/main/java/org/projectnessie/model/GarbageCollectorConfig.java
@@ -42,7 +42,9 @@ import org.immutables.value.Value;
 @Tag(name = "v2")
 @Value.Immutable
 @JsonSerialize(as = ImmutableGarbageCollectorConfig.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableGarbageCollectorConfig.class)
 @JsonDeserialize(as = ImmutableGarbageCollectorConfig.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableGarbageCollectorConfig.class)
 @JsonTypeName("GARBAGE_COLLECTOR")
 public interface GarbageCollectorConfig extends RepositoryConfig {
 
@@ -93,7 +95,9 @@ public interface GarbageCollectorConfig extends RepositoryConfig {
   @jakarta.annotation.Nullable
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @JsonSerialize(using = Util.DurationSerializer.class)
+  @tools.jackson.databind.annotation.JsonSerialize(using = Util.DurationSerializer3.class)
   @JsonDeserialize(using = Util.DurationDeserializer.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(using = Util.DurationDeserializer3.class)
   Duration getNewFilesGracePeriod();
 
   @Schema(title = "The total number of expected live files for a single content.")
@@ -115,7 +119,9 @@ public interface GarbageCollectorConfig extends RepositoryConfig {
               + "Reference name patterns are regular expressions.")
   @Value.Immutable
   @JsonSerialize(as = ImmutableReferenceCutoffPolicy.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableReferenceCutoffPolicy.class)
   @JsonDeserialize(as = ImmutableReferenceCutoffPolicy.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableReferenceCutoffPolicy.class)
   interface ReferenceCutoffPolicy {
     static ReferenceCutoffPolicy referenceCutoffPolicy(String referenceNamePattern, String policy) {
       return ImmutableReferenceCutoffPolicy.of(referenceNamePattern, policy);

--- a/api/model/src/main/java/org/projectnessie/model/GetMultipleContentsRequest.java
+++ b/api/model/src/main/java/org/projectnessie/model/GetMultipleContentsRequest.java
@@ -27,7 +27,9 @@ import org.immutables.value.Value;
 @Schema(type = SchemaType.OBJECT, title = "GetMultipleContentsRequest")
 @Value.Immutable
 @JsonSerialize(as = ImmutableGetMultipleContentsRequest.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableGetMultipleContentsRequest.class)
 @JsonDeserialize(as = ImmutableGetMultipleContentsRequest.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableGetMultipleContentsRequest.class)
 public interface GetMultipleContentsRequest {
 
   @NotNull

--- a/api/model/src/main/java/org/projectnessie/model/GetMultipleContentsResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/GetMultipleContentsResponse.java
@@ -32,7 +32,9 @@ import org.projectnessie.model.ser.Views;
 @Schema(type = SchemaType.OBJECT, title = "GetMultipleContentsResponse")
 @Value.Immutable
 @JsonSerialize(as = ImmutableGetMultipleContentsResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableGetMultipleContentsResponse.class)
 @JsonDeserialize(as = ImmutableGetMultipleContentsResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableGetMultipleContentsResponse.class)
 public interface GetMultipleContentsResponse {
 
   @NotNull
@@ -62,7 +64,9 @@ public interface GetMultipleContentsResponse {
 
   @Value.Immutable
   @JsonSerialize(as = ImmutableContentWithKey.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableContentWithKey.class)
   @JsonDeserialize(as = ImmutableContentWithKey.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableContentWithKey.class)
   interface ContentWithKey {
 
     @NotNull
@@ -73,6 +77,8 @@ public interface GetMultipleContentsResponse {
     @NotNull
     @jakarta.validation.constraints.NotNull
     @Value.Parameter(order = 2)
+    @tools.jackson.databind.annotation.JsonTypeIdResolver(
+        org.projectnessie.model.types.Jackson3ContentTypeIdResolver.class)
     Content getContent();
 
     @Nullable

--- a/api/model/src/main/java/org/projectnessie/model/GetNamespacesResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/GetNamespacesResponse.java
@@ -26,7 +26,9 @@ import org.projectnessie.model.ser.Views;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableGetNamespacesResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableGetNamespacesResponse.class)
 @JsonDeserialize(as = ImmutableGetNamespacesResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableGetNamespacesResponse.class)
 public interface GetNamespacesResponse {
   @NotNull
   @jakarta.validation.constraints.NotNull

--- a/api/model/src/main/java/org/projectnessie/model/IcebergTable.java
+++ b/api/model/src/main/java/org/projectnessie/model/IcebergTable.java
@@ -55,7 +55,9 @@ import org.projectnessie.model.ser.Views;
             + "field and the previous value of 'IcebergTable' in the 'expectedContent' field.")
 @Value.Immutable
 @JsonSerialize(as = ImmutableIcebergTable.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergTable.class)
 @JsonDeserialize(as = ImmutableIcebergTable.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergTable.class)
 @JsonTypeName("ICEBERG_TABLE")
 public abstract class IcebergTable extends IcebergContent {
 

--- a/api/model/src/main/java/org/projectnessie/model/IcebergView.java
+++ b/api/model/src/main/java/org/projectnessie/model/IcebergView.java
@@ -30,7 +30,9 @@ import org.projectnessie.model.ser.Views;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableIcebergView.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergView.class)
 @JsonDeserialize(as = ImmutableIcebergView.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergView.class)
 @JsonTypeName("ICEBERG_VIEW")
 public abstract class IcebergView extends IcebergContent {
 

--- a/api/model/src/main/java/org/projectnessie/model/IdentifiedContentKey.java
+++ b/api/model/src/main/java/org/projectnessie/model/IdentifiedContentKey.java
@@ -30,7 +30,9 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableIdentifiedContentKey.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIdentifiedContentKey.class)
 @JsonDeserialize(as = ImmutableIdentifiedContentKey.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIdentifiedContentKey.class)
 public interface IdentifiedContentKey {
   @NotNull
   @jakarta.validation.constraints.NotNull
@@ -63,7 +65,9 @@ public interface IdentifiedContentKey {
 
   @Value.Immutable
   @JsonSerialize(as = ImmutableIdentifiedElement.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIdentifiedElement.class)
   @JsonDeserialize(as = ImmutableIdentifiedElement.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIdentifiedElement.class)
   interface IdentifiedElement {
     @Value.Parameter(order = 1)
     String element();

--- a/api/model/src/main/java/org/projectnessie/model/LogResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/LogResponse.java
@@ -31,7 +31,9 @@ import org.projectnessie.model.ser.Views;
 @Value.Immutable
 @Schema(type = SchemaType.OBJECT, title = "LogResponse")
 @JsonSerialize(as = ImmutableLogResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableLogResponse.class)
 @JsonDeserialize(as = ImmutableLogResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableLogResponse.class)
 public interface LogResponse extends PaginatedResponse {
 
   @NotNull
@@ -45,7 +47,9 @@ public interface LogResponse extends PaginatedResponse {
   @Value.Immutable
   @Schema(type = SchemaType.OBJECT, title = "LogEntry")
   @JsonSerialize(as = ImmutableLogEntry.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableLogEntry.class)
   @JsonDeserialize(as = ImmutableLogEntry.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableLogEntry.class)
   interface LogEntry {
     static ImmutableLogEntry.Builder builder() {
       return ImmutableLogEntry.builder();

--- a/api/model/src/main/java/org/projectnessie/model/MergeKeyBehavior.java
+++ b/api/model/src/main/java/org/projectnessie/model/MergeKeyBehavior.java
@@ -27,7 +27,9 @@ import org.projectnessie.model.ser.Views;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableMergeKeyBehavior.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableMergeKeyBehavior.class)
 @JsonDeserialize(as = ImmutableMergeKeyBehavior.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableMergeKeyBehavior.class)
 public interface MergeKeyBehavior {
 
   ContentKey getKey();
@@ -48,6 +50,8 @@ public interface MergeKeyBehavior {
   @JsonView(Views.V2.class)
   @Nullable
   @jakarta.annotation.Nullable
+  @tools.jackson.databind.annotation.JsonTypeIdResolver(
+      org.projectnessie.model.types.Jackson3ContentTypeIdResolver.class)
   Content getExpectedTargetContent();
 
   /**
@@ -65,6 +69,8 @@ public interface MergeKeyBehavior {
   @JsonView(Views.V2.class)
   @Nullable
   @jakarta.annotation.Nullable
+  @tools.jackson.databind.annotation.JsonTypeIdResolver(
+      org.projectnessie.model.types.Jackson3ContentTypeIdResolver.class)
   Content getResolvedContent();
 
   /**
@@ -107,6 +113,8 @@ public interface MergeKeyBehavior {
    */
   @JsonInclude(Include.NON_EMPTY)
   @JsonView(Views.V2.class)
+  @tools.jackson.databind.annotation.JsonTypeIdResolver(
+      org.projectnessie.model.metadata.Jackson3ContentMetadataVariantResolver.class)
   List<ContentMetadata> getMetadata();
 
   static ImmutableMergeKeyBehavior.Builder builder() {

--- a/api/model/src/main/java/org/projectnessie/model/MergeResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/MergeResponse.java
@@ -36,7 +36,9 @@ import org.projectnessie.model.ser.Views;
 @Schema(type = SchemaType.OBJECT, title = "Merge Response")
 @Value.Immutable
 @JsonSerialize(as = ImmutableMergeResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableMergeResponse.class)
 @JsonDeserialize(as = ImmutableMergeResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableMergeResponse.class)
 public interface MergeResponse {
   /** Indicates whether the merge or transplant operation has been applied. */
   @Value.Default
@@ -110,7 +112,9 @@ public interface MergeResponse {
   @Schema(type = SchemaType.OBJECT, title = "Merge Per-Content-Key details")
   @Value.Immutable
   @JsonSerialize(as = ImmutableContentKeyDetails.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableContentKeyDetails.class)
   @JsonDeserialize(as = ImmutableContentKeyDetails.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableContentKeyDetails.class)
   interface ContentKeyDetails {
     ContentKey getKey();
 
@@ -120,6 +124,8 @@ public interface MergeResponse {
     @Deprecated // for removal, #getConflict() is a proper replacement
     @Value.Default
     @JsonDeserialize(using = ContentKeyConflict.Deserializer.class)
+    @tools.jackson.databind.annotation.JsonDeserialize(
+        using = ContentKeyConflict.Deserializer3.class)
     @Schema(deprecated = true, hidden = true)
     @JsonView(Views.V1.class)
     default ContentKeyConflict getConflictType() {
@@ -167,6 +173,17 @@ public interface MergeResponse {
       @Override
       public ContentKeyConflict deserialize(JsonParser p, DeserializationContext ctxt)
           throws IOException {
+        String name = p.readValueAs(String.class);
+        return name != null ? ContentKeyConflict.parse(name) : null;
+      }
+    }
+
+    static final class Deserializer3
+        extends tools.jackson.databind.ValueDeserializer<ContentKeyConflict> {
+      @Override
+      public ContentKeyConflict deserialize(
+          tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+          throws tools.jackson.core.JacksonException {
         String name = p.readValueAs(String.class);
         return name != null ? ContentKeyConflict.parse(name) : null;
       }

--- a/api/model/src/main/java/org/projectnessie/model/Namespace.java
+++ b/api/model/src/main/java/org/projectnessie/model/Namespace.java
@@ -41,7 +41,9 @@ import org.immutables.value.Value.Derived;
  */
 @Value.Immutable
 @JsonSerialize(as = ImmutableNamespace.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableNamespace.class)
 @JsonDeserialize(as = ImmutableNamespace.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableNamespace.class)
 @JsonTypeName("NAMESPACE")
 public abstract class Namespace extends Content implements Elements {
 

--- a/api/model/src/main/java/org/projectnessie/model/NessieConfiguration.java
+++ b/api/model/src/main/java/org/projectnessie/model/NessieConfiguration.java
@@ -29,6 +29,8 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
 import org.projectnessie.model.CommitMeta.InstantDeserializer;
 import org.projectnessie.model.CommitMeta.InstantSerializer;
+import org.projectnessie.model.CommitMeta.Jackson3InstantDeserializer;
+import org.projectnessie.model.CommitMeta.Jackson3InstantSerializer;
 import org.projectnessie.model.ser.Views;
 
 /** configuration object to tell a client how a server is configured. */
@@ -38,7 +40,9 @@ import org.projectnessie.model.ser.Views;
     description = "Configuration object to tell a client how a server is configured.")
 @Value.Immutable
 @JsonSerialize(as = ImmutableNessieConfiguration.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableNessieConfiguration.class)
 @JsonDeserialize(as = ImmutableNessieConfiguration.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableNessieConfiguration.class)
 public abstract class NessieConfiguration {
 
   /**
@@ -121,7 +125,9 @@ public abstract class NessieConfiguration {
   @Nullable
   @jakarta.annotation.Nullable
   @JsonSerialize(using = InstantSerializer.class)
+  @tools.jackson.databind.annotation.JsonSerialize(using = Jackson3InstantSerializer.class)
   @JsonDeserialize(using = InstantDeserializer.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(using = Jackson3InstantDeserializer.class)
   public abstract Instant getRepositoryCreationTimestamp();
 
   /**
@@ -137,7 +143,9 @@ public abstract class NessieConfiguration {
   @Nullable
   @jakarta.annotation.Nullable
   @JsonSerialize(using = InstantSerializer.class)
+  @tools.jackson.databind.annotation.JsonSerialize(using = Jackson3InstantSerializer.class)
   @JsonDeserialize(using = InstantDeserializer.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(using = Jackson3InstantDeserializer.class)
   public abstract Instant getOldestPossibleCommitTimestamp();
 
   /** Additional properties, currently undefined and always empty (not present in JSON). */

--- a/api/model/src/main/java/org/projectnessie/model/Operation.java
+++ b/api/model/src/main/java/org/projectnessie/model/Operation.java
@@ -81,11 +81,15 @@ public interface Operation {
               + "representing a new content object, so without a content-id, in the same commit.")
   @Value.Immutable
   @JsonSerialize(as = ImmutablePut.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutablePut.class)
   @JsonDeserialize(as = ImmutablePut.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutablePut.class)
   @JsonTypeName("PUT")
   interface Put extends Operation {
     @NotNull
     @jakarta.validation.constraints.NotNull
+    @tools.jackson.databind.annotation.JsonTypeIdResolver(
+        org.projectnessie.model.types.Jackson3ContentTypeIdResolver.class)
     Content getContent();
 
     @Nullable
@@ -93,6 +97,8 @@ public interface Operation {
     @Deprecated
     @SuppressWarnings("DeprecatedIsStillUsed")
     @JsonView(Views.V1.class)
+    @tools.jackson.databind.annotation.JsonTypeIdResolver(
+        org.projectnessie.model.types.Jackson3ContentTypeIdResolver.class)
     Content getExpectedContent();
 
     /**
@@ -138,7 +144,9 @@ public interface Operation {
               + "with the current `Content` in the the `value` field. See `Put` operation.")
   @Value.Immutable
   @JsonSerialize(as = ImmutableDelete.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableDelete.class)
   @JsonDeserialize(as = ImmutableDelete.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableDelete.class)
   @JsonTypeName("DELETE")
   interface Delete extends Operation {
 
@@ -149,7 +157,9 @@ public interface Operation {
 
   @Value.Immutable
   @JsonSerialize(as = ImmutableUnchanged.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableUnchanged.class)
   @JsonDeserialize(as = ImmutableUnchanged.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableUnchanged.class)
   @JsonTypeName("UNCHANGED")
   interface Unchanged extends Operation {
 

--- a/api/model/src/main/java/org/projectnessie/model/Operations.java
+++ b/api/model/src/main/java/org/projectnessie/model/Operations.java
@@ -27,7 +27,9 @@ import org.immutables.value.Value;
 @Schema(type = SchemaType.OBJECT, title = "Operations")
 @Value.Immutable
 @JsonSerialize(as = ImmutableOperations.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableOperations.class)
 @JsonDeserialize(as = ImmutableOperations.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableOperations.class)
 public interface Operations {
 
   @NotNull

--- a/api/model/src/main/java/org/projectnessie/model/RefLogResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/RefLogResponse.java
@@ -27,7 +27,9 @@ import org.immutables.value.Value;
 @Value.Immutable
 @Schema(type = SchemaType.OBJECT, title = "RefLogResponse", deprecated = true, hidden = true)
 @JsonSerialize(as = ImmutableRefLogResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableRefLogResponse.class)
 @JsonDeserialize(as = ImmutableRefLogResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableRefLogResponse.class)
 @Deprecated // Not supported since API v2
 public interface RefLogResponse extends PaginatedResponse {
 
@@ -39,7 +41,9 @@ public interface RefLogResponse extends PaginatedResponse {
   @Value.Immutable
   @Schema(type = SchemaType.OBJECT, title = "RefLogResponseEntry", deprecated = true, hidden = true)
   @JsonSerialize(as = ImmutableRefLogResponseEntry.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableRefLogResponseEntry.class)
   @JsonDeserialize(as = ImmutableRefLogResponseEntry.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableRefLogResponseEntry.class)
   @Deprecated // Not supported since API v2
   interface RefLogResponseEntry {
     static ImmutableRefLogResponseEntry.Builder builder() {

--- a/api/model/src/main/java/org/projectnessie/model/ReferenceHistoryResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/ReferenceHistoryResponse.java
@@ -38,7 +38,9 @@ import org.immutables.value.Value;
             + "the commit, for example if the commit object itself or its index information is missing.")
 @Value.Immutable
 @JsonSerialize(as = ImmutableReferenceHistoryResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableReferenceHistoryResponse.class)
 @JsonDeserialize(as = ImmutableReferenceHistoryResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableReferenceHistoryResponse.class)
 public interface ReferenceHistoryResponse {
 
   static ImmutableReferenceHistoryResponse.Builder builder() {

--- a/api/model/src/main/java/org/projectnessie/model/ReferenceHistoryState.java
+++ b/api/model/src/main/java/org/projectnessie/model/ReferenceHistoryState.java
@@ -37,7 +37,9 @@ import org.immutables.value.Value;
             + "the commit, for example if the commit object itself or its index information is missing.")
 @Value.Immutable
 @JsonSerialize(as = ImmutableReferenceHistoryState.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableReferenceHistoryState.class)
 @JsonDeserialize(as = ImmutableReferenceHistoryState.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableReferenceHistoryState.class)
 public interface ReferenceHistoryState {
   @Schema(description = "Nessie commit ID.")
   @Value.Parameter(order = 1)

--- a/api/model/src/main/java/org/projectnessie/model/ReferenceMetadata.java
+++ b/api/model/src/main/java/org/projectnessie/model/ReferenceMetadata.java
@@ -43,7 +43,9 @@ import org.immutables.value.Value;
         """)
 @Value.Immutable
 @JsonSerialize(as = ImmutableReferenceMetadata.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableReferenceMetadata.class)
 @JsonDeserialize(as = ImmutableReferenceMetadata.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableReferenceMetadata.class)
 @JsonTypeName("REFERENCE_METADATA")
 public interface ReferenceMetadata {
 

--- a/api/model/src/main/java/org/projectnessie/model/ReferencesResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/ReferencesResponse.java
@@ -23,7 +23,9 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableReferencesResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableReferencesResponse.class)
 @JsonDeserialize(as = ImmutableReferencesResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableReferencesResponse.class)
 public interface ReferencesResponse extends PaginatedResponse {
 
   static ImmutableReferencesResponse.Builder builder() {

--- a/api/model/src/main/java/org/projectnessie/model/RepositoryConfig.java
+++ b/api/model/src/main/java/org/projectnessie/model/RepositoryConfig.java
@@ -25,6 +25,7 @@ import org.eclipse.microprofile.openapi.annotations.media.DiscriminatorMapping;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.immutables.value.Value;
+import org.projectnessie.model.types.Jackson3RepositoryConfigTypeIdResolver;
 import org.projectnessie.model.types.RepositoryConfigTypeIdResolver;
 import org.projectnessie.model.types.RepositoryConfigTypes;
 
@@ -39,6 +40,7 @@ import org.projectnessie.model.types.RepositoryConfigTypes;
     discriminatorProperty = "type")
 @Tag(name = "v2")
 @JsonTypeIdResolver(RepositoryConfigTypeIdResolver.class)
+@tools.jackson.databind.annotation.JsonTypeIdResolver(Jackson3RepositoryConfigTypeIdResolver.class)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, property = "type", visible = true)
 public interface RepositoryConfig {
 
@@ -53,7 +55,11 @@ public interface RepositoryConfig {
   Type getType();
 
   @JsonDeserialize(using = Util.RepositoryConfigTypeDeserializer.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(
+      using = Util.RepositoryConfigTypeDeserializer3.class)
   @JsonSerialize(using = Util.RepositoryConfigTypeSerializer.class)
+  @tools.jackson.databind.annotation.JsonSerialize(
+      using = Util.RepositoryConfigTypeSerializer3.class)
   @Schema(
       type = SchemaType.STRING,
       name = "RepositoryConfigType",

--- a/api/model/src/main/java/org/projectnessie/model/RepositoryConfigResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/RepositoryConfigResponse.java
@@ -28,9 +28,13 @@ import org.immutables.value.Value;
 @Tag(name = "v2")
 @Value.Immutable
 @JsonSerialize(as = ImmutableRepositoryConfigResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableRepositoryConfigResponse.class)
 @JsonDeserialize(as = ImmutableRepositoryConfigResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableRepositoryConfigResponse.class)
 public interface RepositoryConfigResponse {
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  @tools.jackson.databind.annotation.JsonTypeIdResolver(
+      org.projectnessie.model.types.Jackson3RepositoryConfigTypeIdResolver.class)
   @Schema(
       title = "Repository configuration objects for the requested types.",
       description =

--- a/api/model/src/main/java/org/projectnessie/model/SingleReferenceResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/SingleReferenceResponse.java
@@ -25,7 +25,9 @@ import org.immutables.value.Value;
 @Schema(type = SchemaType.OBJECT, title = "SingleReferenceResponse")
 @Value.Immutable
 @JsonSerialize(as = ImmutableSingleReferenceResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableSingleReferenceResponse.class)
 @JsonDeserialize(as = ImmutableSingleReferenceResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableSingleReferenceResponse.class)
 public interface SingleReferenceResponse {
 
   static ImmutableSingleReferenceResponse.Builder builder() {

--- a/api/model/src/main/java/org/projectnessie/model/Tag.java
+++ b/api/model/src/main/java/org/projectnessie/model/Tag.java
@@ -29,7 +29,9 @@ import org.immutables.value.Value;
 @Value.Immutable
 @Schema(type = SchemaType.OBJECT, title = "Tag")
 @JsonSerialize(as = ImmutableTag.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableTag.class)
 @JsonDeserialize(as = ImmutableTag.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableTag.class)
 @JsonTypeName("TAG")
 public interface Tag extends Reference {
 

--- a/api/model/src/main/java/org/projectnessie/model/UDF.java
+++ b/api/model/src/main/java/org/projectnessie/model/UDF.java
@@ -25,7 +25,9 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableUDF.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableUDF.class)
 @JsonDeserialize(as = ImmutableUDF.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableUDF.class)
 @JsonTypeName("UDF")
 public abstract class UDF extends Content {
 

--- a/api/model/src/main/java/org/projectnessie/model/UpdateRepositoryConfigRequest.java
+++ b/api/model/src/main/java/org/projectnessie/model/UpdateRepositoryConfigRequest.java
@@ -26,11 +26,16 @@ import org.immutables.value.Value;
 @Tag(name = "v2")
 @Value.Immutable
 @JsonSerialize(as = ImmutableUpdateRepositoryConfigRequest.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableUpdateRepositoryConfigRequest.class)
 @JsonDeserialize(as = ImmutableUpdateRepositoryConfigRequest.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    as = ImmutableUpdateRepositoryConfigRequest.class)
 public interface UpdateRepositoryConfigRequest {
   /**
    * The previous value of the updated repository configuration object. This will be {@code null},
    * if the repository configuration was created.
    */
+  @tools.jackson.databind.annotation.JsonTypeIdResolver(
+      org.projectnessie.model.types.Jackson3RepositoryConfigTypeIdResolver.class)
   RepositoryConfig getConfig();
 }

--- a/api/model/src/main/java/org/projectnessie/model/UpdateRepositoryConfigResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/UpdateRepositoryConfigResponse.java
@@ -27,7 +27,10 @@ import org.immutables.value.Value;
 @Tag(name = "v2")
 @Value.Immutable
 @JsonSerialize(as = ImmutableUpdateRepositoryConfigResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableUpdateRepositoryConfigResponse.class)
 @JsonDeserialize(as = ImmutableUpdateRepositoryConfigResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    as = ImmutableUpdateRepositoryConfigResponse.class)
 public interface UpdateRepositoryConfigResponse {
   /**
    * The previous value of the updated repository config. If no previous value for the same
@@ -35,6 +38,8 @@ public interface UpdateRepositoryConfigResponse {
    */
   @Nullable
   @jakarta.annotation.Nullable
+  @tools.jackson.databind.annotation.JsonTypeIdResolver(
+      org.projectnessie.model.types.Jackson3RepositoryConfigTypeIdResolver.class)
   @Schema(
       implementation = RepositoryConfig.class,
       title = "The previous state of the repository configuration object.",

--- a/api/model/src/main/java/org/projectnessie/model/Util.java
+++ b/api/model/src/main/java/org/projectnessie/model/Util.java
@@ -275,6 +275,33 @@ final class Util {
     }
   }
 
+  static final class ContentTypeDeserializer3
+      extends tools.jackson.databind.ValueDeserializer<Content.Type> {
+    @Override
+    public Content.Type deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+        throws tools.jackson.core.JacksonException {
+      String name = p.readValueAs(String.class);
+      return name != null ? ContentTypes.forName(name) : null;
+    }
+  }
+
+  static final class ContentTypeSerializer3
+      extends tools.jackson.databind.ValueSerializer<Content.Type> {
+    @Override
+    public void serialize(
+        Content.Type value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers)
+        throws tools.jackson.core.JacksonException {
+      if (value == null) {
+        gen.writeNull();
+      } else {
+        gen.writeString(value.name());
+      }
+    }
+  }
+
   static final class RepositoryConfigTypeDeserializer
       extends JsonDeserializer<RepositoryConfig.Type> {
     @Override
@@ -290,6 +317,33 @@ final class Util {
     public void serialize(
         RepositoryConfig.Type value, JsonGenerator gen, SerializerProvider serializers)
         throws IOException {
+      if (value == null) {
+        gen.writeNull();
+      } else {
+        gen.writeString(value.name());
+      }
+    }
+  }
+
+  static final class RepositoryConfigTypeDeserializer3
+      extends tools.jackson.databind.ValueDeserializer<RepositoryConfig.Type> {
+    @Override
+    public RepositoryConfig.Type deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+        throws tools.jackson.core.JacksonException {
+      String name = p.readValueAs(String.class);
+      return name != null ? RepositoryConfigTypes.forName(name) : null;
+    }
+  }
+
+  static final class RepositoryConfigTypeSerializer3
+      extends tools.jackson.databind.ValueSerializer<RepositoryConfig.Type> {
+    @Override
+    public void serialize(
+        RepositoryConfig.Type value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers)
+        throws tools.jackson.core.JacksonException {
       if (value == null) {
         gen.writeNull();
       } else {
@@ -326,6 +380,26 @@ final class Util {
     @Override
     public Duration deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
       return Duration.parse(p.getText());
+    }
+  }
+
+  static class DurationSerializer3 extends tools.jackson.databind.ValueSerializer<Duration> {
+    @Override
+    public void serialize(
+        Duration value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext provider)
+        throws tools.jackson.core.JacksonException {
+      gen.writeString(value.toString());
+    }
+  }
+
+  static class DurationDeserializer3 extends tools.jackson.databind.ValueDeserializer<Duration> {
+    @Override
+    public Duration deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+        throws tools.jackson.core.JacksonException {
+      return Duration.parse(p.getString());
     }
   }
 }

--- a/api/model/src/main/java/org/projectnessie/model/metadata/GenericContentMetadata.java
+++ b/api/model/src/main/java/org/projectnessie/model/metadata/GenericContentMetadata.java
@@ -27,12 +27,17 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
 import org.projectnessie.model.ContentMetadata;
 import org.projectnessie.model.metadata.GenericContentMetadataSerialization.GenericContentMetadataDeserializer;
+import org.projectnessie.model.metadata.GenericContentMetadataSerialization.GenericContentMetadataDeserializer3;
 import org.projectnessie.model.metadata.GenericContentMetadataSerialization.GenericContentMetadataSerializer;
+import org.projectnessie.model.metadata.GenericContentMetadataSerialization.GenericContentMetadataSerializer3;
 
 /** Default/fallback representation of unknown content-metadata variants. */
 @Value.Immutable
 @JsonSerialize(using = GenericContentMetadataSerializer.class)
+@tools.jackson.databind.annotation.JsonSerialize(using = GenericContentMetadataSerializer3.class)
 @JsonDeserialize(using = GenericContentMetadataDeserializer.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    using = GenericContentMetadataDeserializer3.class)
 public interface GenericContentMetadata extends ContentMetadata {
 
   @Override

--- a/api/model/src/main/java/org/projectnessie/model/metadata/GenericContentMetadataSerialization.java
+++ b/api/model/src/main/java/org/projectnessie/model/metadata/GenericContentMetadataSerialization.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -67,6 +68,76 @@ public class GenericContentMetadataSerialization {
         variant = "UNKNOWN_VARIANT";
       }
       return GenericContentMetadata.genericContentMetadata(variant.toString(), all);
+    }
+  }
+
+  static final class GenericContentMetadataSerializer3
+      extends tools.jackson.databind.ValueSerializer<GenericContentMetadata> {
+
+    @Override
+    public void serializeWithType(
+        GenericContentMetadata value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers,
+        tools.jackson.databind.jsontype.TypeSerializer typeSer)
+        throws tools.jackson.core.JacksonException {
+      gen.writeStartObject();
+      gen.writeStringProperty("variant", value.getVariant());
+      for (Entry<String, Object> entry : value.getAttributes().entrySet()) {
+        gen.writePOJOProperty(entry.getKey(), entry.getValue());
+      }
+      gen.writeEndObject();
+    }
+
+    @Override
+    public void serialize(
+        GenericContentMetadata value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  static final class GenericContentMetadataDeserializer3
+      extends tools.jackson.databind.ValueDeserializer<GenericContentMetadata> {
+
+    @Override
+    public GenericContentMetadata deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+        throws tools.jackson.core.JacksonException {
+      if (p.currentToken() == tools.jackson.core.JsonToken.START_OBJECT) {
+        return fromMap(p.readValueAs(Map.class));
+      }
+
+      Map<String, Object> all = new LinkedHashMap<>();
+      Object variant = p.getTypeId();
+      for (tools.jackson.core.JsonToken token = p.currentToken();
+          token == tools.jackson.core.JsonToken.PROPERTY_NAME;
+          token = p.nextToken()) {
+        String fieldName = p.currentName();
+        p.nextToken();
+        Object value = p.readValueAs(Object.class);
+        if ("variant".equals(fieldName)) {
+          variant = value;
+        } else {
+          all.put(fieldName, value);
+        }
+      }
+
+      if (variant == null) {
+        variant = "UNKNOWN_VARIANT";
+      }
+      return GenericContentMetadata.genericContentMetadata(variant.toString(), all);
+    }
+
+    private GenericContentMetadata fromMap(Map<?, ?> all) {
+      Map<String, Object> attributes = new LinkedHashMap<>();
+      all.forEach((key, value) -> attributes.put(key.toString(), value));
+      Object variant = attributes.remove("variant");
+      if (variant == null) {
+        variant = "UNKNOWN_VARIANT";
+      }
+      return GenericContentMetadata.genericContentMetadata(variant.toString(), attributes);
     }
   }
 }

--- a/api/model/src/main/java/org/projectnessie/model/metadata/Jackson3ContentMetadataVariantResolver.java
+++ b/api/model/src/main/java/org/projectnessie/model/metadata/Jackson3ContentMetadataVariantResolver.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.metadata;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.projectnessie.model.ContentMetadata;
+import tools.jackson.databind.DatabindContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.jsontype.impl.TypeIdResolverBase;
+
+/** Dynamic {@link ContentMetadata} object (de)serialization for <em>Jackson 3</em>. */
+public final class Jackson3ContentMetadataVariantResolver extends TypeIdResolverBase {
+
+  private JavaType baseType;
+
+  public Jackson3ContentMetadataVariantResolver() {}
+
+  @Override
+  public void init(JavaType bt) {
+    baseType = bt;
+  }
+
+  @Override
+  public String idFromValue(DatabindContext context, Object value) {
+    return getId(value);
+  }
+
+  @Override
+  public String idFromValueAndType(DatabindContext context, Object value, Class<?> suggestedType) {
+    return getId(value);
+  }
+
+  @Override
+  public JsonTypeInfo.Id getMechanism() {
+    return JsonTypeInfo.Id.CUSTOM;
+  }
+
+  private String getId(Object value) {
+    if (value instanceof ContentMetadata contentMetadata) {
+      return contentMetadata.getVariant();
+    }
+
+    return null;
+  }
+
+  @Override
+  public JavaType typeFromId(DatabindContext context, String id) {
+    // Currently there are no specialized ContentMetadata implementations, so this one always
+    // returns GenericContentMetadata.
+    return context.constructSpecializedType(baseType, GenericContentMetadata.class);
+  }
+}

--- a/api/model/src/main/java/org/projectnessie/model/ser/CommitMetaSer.java
+++ b/api/model/src/main/java/org/projectnessie/model/ser/CommitMetaSer.java
@@ -26,5 +26,6 @@ import org.projectnessie.model.CommitMeta;
 @Value.Immutable
 @Value.Style(builder = "builderSer")
 @JsonDeserialize(as = ImmutableCommitMetaSer.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableCommitMetaSer.class)
 @SuppressWarnings("immutables:subtype")
 public abstract class CommitMetaSer extends CommitMeta {}

--- a/api/model/src/main/java/org/projectnessie/model/types/GenericContent.java
+++ b/api/model/src/main/java/org/projectnessie/model/types/GenericContent.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import jakarta.annotation.Nullable;
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -46,7 +47,11 @@ import org.projectnessie.model.Content;
  */
 @Value.Immutable
 @JsonSerialize(using = GenericContent.ContentUnknownTypeSerializer.class)
+@tools.jackson.databind.annotation.JsonSerialize(
+    using = GenericContent.ContentUnknownTypeSerializer3.class)
 @JsonDeserialize(using = GenericContent.ContentUnknownTypeDeserializer.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    using = GenericContent.ContentUnknownTypeDeserializer3.class)
 public abstract class GenericContent extends Content {
 
   @Override
@@ -107,6 +112,86 @@ public abstract class GenericContent extends Content {
       }
       return GenericContent.contentUnknownType(
           type.toString(), id != null ? id.toString() : null, all);
+    }
+  }
+
+  static final class ContentUnknownTypeSerializer3
+      extends tools.jackson.databind.ValueSerializer<GenericContent> {
+
+    @Override
+    public void serializeWithType(
+        GenericContent value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers,
+        tools.jackson.databind.jsontype.TypeSerializer typeSer)
+        throws tools.jackson.core.JacksonException {
+      gen.writeStartObject();
+      gen.writeStringProperty("type", value.getType().name());
+      String id = value.getId();
+      if (id != null) {
+        gen.writeStringProperty("id", id);
+      }
+      for (Entry<String, Object> entry : value.getAttributes().entrySet()) {
+        gen.writePOJOProperty(entry.getKey(), entry.getValue());
+      }
+      gen.writeEndObject();
+    }
+
+    @Override
+    public void serialize(
+        GenericContent value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  static final class ContentUnknownTypeDeserializer3
+      extends tools.jackson.databind.ValueDeserializer<GenericContent> {
+
+    @Override
+    public GenericContent deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+        throws tools.jackson.core.JacksonException {
+      if (p.currentToken() == tools.jackson.core.JsonToken.START_OBJECT) {
+        return fromMap(p.readValueAs(Map.class));
+      }
+
+      Map<String, Object> all = new LinkedHashMap<>();
+      Object type = p.getTypeId();
+      Object id = null;
+      for (tools.jackson.core.JsonToken token = p.currentToken();
+          token == tools.jackson.core.JsonToken.PROPERTY_NAME;
+          token = p.nextToken()) {
+        String fieldName = p.currentName();
+        p.nextToken();
+        Object value = p.readValueAs(Object.class);
+        if ("type".equals(fieldName)) {
+          type = value;
+        } else if ("id".equals(fieldName)) {
+          id = value;
+        } else {
+          all.put(fieldName, value);
+        }
+      }
+
+      if (type == null) {
+        type = "UNKNOWN_CONTENT_TYPE";
+      }
+      return GenericContent.contentUnknownType(
+          type.toString(), id != null ? id.toString() : null, all);
+    }
+
+    private GenericContent fromMap(Map<?, ?> all) {
+      Map<String, Object> attributes = new LinkedHashMap<>();
+      all.forEach((key, value) -> attributes.put(key.toString(), value));
+      Object type = attributes.remove("type");
+      Object id = attributes.remove("id");
+      if (type == null) {
+        type = "UNKNOWN_CONTENT_TYPE";
+      }
+      return GenericContent.contentUnknownType(
+          type.toString(), id != null ? id.toString() : null, attributes);
     }
   }
 

--- a/api/model/src/main/java/org/projectnessie/model/types/GenericRepositoryConfig.java
+++ b/api/model/src/main/java/org/projectnessie/model/types/GenericRepositoryConfig.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import javax.annotation.Nullable;
@@ -46,7 +47,11 @@ import org.projectnessie.model.RepositoryConfig;
  */
 @Value.Immutable
 @JsonSerialize(using = GenericRepositoryConfig.RepositoryConfigUnknownTypeSerializer.class)
+@tools.jackson.databind.annotation.JsonSerialize(
+    using = GenericRepositoryConfig.RepositoryConfigUnknownTypeSerializer3.class)
 @JsonDeserialize(using = GenericRepositoryConfig.RepositoryConfigUnknownTypeDeserializer.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    using = GenericRepositoryConfig.RepositoryConfigUnknownTypeDeserializer3.class)
 public abstract class GenericRepositoryConfig implements RepositoryConfig {
 
   @Override
@@ -100,6 +105,76 @@ public abstract class GenericRepositoryConfig implements RepositoryConfig {
         type = "UNKNOWN_CONTENT_TYPE";
       }
       return GenericRepositoryConfig.repositoryConfigUnknownType(type.toString(), all);
+    }
+  }
+
+  static final class RepositoryConfigUnknownTypeSerializer3
+      extends tools.jackson.databind.ValueSerializer<GenericRepositoryConfig> {
+
+    @Override
+    public void serializeWithType(
+        GenericRepositoryConfig value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers,
+        tools.jackson.databind.jsontype.TypeSerializer typeSer)
+        throws tools.jackson.core.JacksonException {
+      gen.writeStartObject();
+      gen.writeStringProperty("type", value.getType().name());
+      for (Entry<String, Object> entry : value.getAttributes().entrySet()) {
+        gen.writePOJOProperty(entry.getKey(), entry.getValue());
+      }
+      gen.writeEndObject();
+    }
+
+    @Override
+    public void serialize(
+        GenericRepositoryConfig value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  static final class RepositoryConfigUnknownTypeDeserializer3
+      extends tools.jackson.databind.ValueDeserializer<GenericRepositoryConfig> {
+
+    @Override
+    public GenericRepositoryConfig deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+        throws tools.jackson.core.JacksonException {
+      if (p.currentToken() == tools.jackson.core.JsonToken.START_OBJECT) {
+        return fromMap(p.readValueAs(Map.class));
+      }
+
+      Map<String, Object> all = new LinkedHashMap<>();
+      Object type = p.getTypeId();
+      for (tools.jackson.core.JsonToken token = p.currentToken();
+          token == tools.jackson.core.JsonToken.PROPERTY_NAME;
+          token = p.nextToken()) {
+        String fieldName = p.currentName();
+        p.nextToken();
+        Object value = p.readValueAs(Object.class);
+        if ("type".equals(fieldName)) {
+          type = value;
+        } else {
+          all.put(fieldName, value);
+        }
+      }
+
+      if (type == null) {
+        type = "UNKNOWN_CONTENT_TYPE";
+      }
+      return GenericRepositoryConfig.repositoryConfigUnknownType(type.toString(), all);
+    }
+
+    private GenericRepositoryConfig fromMap(Map<?, ?> all) {
+      Map<String, Object> attributes = new LinkedHashMap<>();
+      all.forEach((key, value) -> attributes.put(key.toString(), value));
+      Object type = attributes.remove("type");
+      if (type == null) {
+        type = "UNKNOWN_CONTENT_TYPE";
+      }
+      return GenericRepositoryConfig.repositoryConfigUnknownType(type.toString(), attributes);
     }
   }
 

--- a/api/model/src/main/java/org/projectnessie/model/types/Jackson3ContentTypeIdResolver.java
+++ b/api/model/src/main/java/org/projectnessie/model/types/Jackson3ContentTypeIdResolver.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.projectnessie.model.Content;
+import tools.jackson.databind.DatabindContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.jsontype.impl.TypeIdResolverBase;
+
+/** Dynamic {@link Content} object (de)serialization for <em>Jackson 3</em>. */
+public final class Jackson3ContentTypeIdResolver extends TypeIdResolverBase {
+
+  private JavaType baseType;
+
+  public Jackson3ContentTypeIdResolver() {}
+
+  @Override
+  public void init(JavaType bt) {
+    baseType = bt;
+  }
+
+  @Override
+  public String idFromValue(DatabindContext context, Object value) {
+    return getId(value);
+  }
+
+  @Override
+  public String idFromValueAndType(DatabindContext context, Object value, Class<?> suggestedType) {
+    return getId(value);
+  }
+
+  @Override
+  public JsonTypeInfo.Id getMechanism() {
+    return JsonTypeInfo.Id.CUSTOM;
+  }
+
+  private String getId(Object value) {
+    if (value instanceof Content content) {
+      return content.getType().name();
+    }
+
+    return null;
+  }
+
+  @Override
+  public JavaType typeFromId(DatabindContext context, String id) {
+    Content.Type subType;
+    try {
+      subType = ContentTypes.forName(id);
+    } catch (IllegalArgumentException e) {
+      return context.constructSpecializedType(baseType, GenericContent.class);
+    }
+    Class<? extends Content> asType = subType.type();
+    if (baseType.getRawClass().isAssignableFrom(asType)) {
+      return context.constructSpecializedType(baseType, asType);
+    }
+
+    // This is rather a "test-only" code path, but it might happen in real life as well, when
+    // calling the ObjectMapper with a "too specific" type and not just Content.class.
+    // So we can get here for example, if the baseType (induced by the type passed to ObjectMapper),
+    // is ContentUnknownType.class, but the type is a "well known" type like IcebergTable.class.
+    @SuppressWarnings("unchecked")
+    Class<? extends Content> concrete = (Class<? extends Content>) baseType.getRawClass();
+    return context.constructSpecializedType(baseType, concrete);
+  }
+}

--- a/api/model/src/main/java/org/projectnessie/model/types/Jackson3RepositoryConfigTypeIdResolver.java
+++ b/api/model/src/main/java/org/projectnessie/model/types/Jackson3RepositoryConfigTypeIdResolver.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.projectnessie.model.RepositoryConfig;
+import tools.jackson.databind.DatabindContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.jsontype.impl.TypeIdResolverBase;
+
+/** Dynamic {@link RepositoryConfig} object (de)serialization for <em>Jackson 3</em>. */
+public final class Jackson3RepositoryConfigTypeIdResolver extends TypeIdResolverBase {
+
+  private JavaType baseType;
+
+  public Jackson3RepositoryConfigTypeIdResolver() {}
+
+  @Override
+  public void init(JavaType bt) {
+    baseType = bt;
+  }
+
+  @Override
+  public String idFromValue(DatabindContext context, Object value) {
+    return getId(value);
+  }
+
+  @Override
+  public String idFromValueAndType(DatabindContext context, Object value, Class<?> suggestedType) {
+    return getId(value);
+  }
+
+  @Override
+  public JsonTypeInfo.Id getMechanism() {
+    return JsonTypeInfo.Id.CUSTOM;
+  }
+
+  private String getId(Object value) {
+    if (value instanceof RepositoryConfig repositoryConfig) {
+      return repositoryConfig.getType().name();
+    }
+
+    return null;
+  }
+
+  @Override
+  public JavaType typeFromId(DatabindContext context, String id) {
+    RepositoryConfig.Type subType;
+    try {
+      subType = RepositoryConfigTypes.forName(id);
+    } catch (IllegalArgumentException e) {
+      return context.constructSpecializedType(baseType, GenericRepositoryConfig.class);
+    }
+    Class<? extends RepositoryConfig> asType = subType.type();
+    if (baseType.getRawClass().isAssignableFrom(asType)) {
+      return context.constructSpecializedType(baseType, asType);
+    }
+
+    // This is rather a "test-only" code path, but it might happen in real life as well, when
+    // calling the ObjectMapper with a "too specific" type and not just RepositoryConfig.class.
+    // So we can get here for example, if the baseType (induced by the type passed to ObjectMapper),
+    // is RepositoryConfigUnknownType.class, but the type is a "well known" type like
+    // IcebergTable.class.
+    @SuppressWarnings("unchecked")
+    Class<? extends RepositoryConfig> concrete =
+        (Class<? extends RepositoryConfig>) baseType.getRawClass();
+    return context.constructSpecializedType(baseType, concrete);
+  }
+}

--- a/api/model/src/testJackson3/java/org/projectnessie/model/TestJackson3ModelCompatibility.java
+++ b/api/model/src/testJackson3/java/org/projectnessie/model/TestJackson3ModelCompatibility.java
@@ -1,0 +1,693 @@
+/*
+ * Copyright (C) 2026 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.projectnessie.model.GarbageCollectorConfig.ReferenceCutoffPolicy.referenceCutoffPolicy;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.error.ContentKeyErrorDetails;
+import org.projectnessie.error.ErrorCode;
+import org.projectnessie.error.GenericErrorDetails;
+import org.projectnessie.error.ImmutableNessieError;
+import org.projectnessie.error.NessieError;
+import org.projectnessie.error.NessieErrorDetails;
+import org.projectnessie.error.ReferenceConflicts;
+import org.projectnessie.model.metadata.GenericContentMetadata;
+import org.projectnessie.model.ser.Views;
+import org.projectnessie.model.types.GenericContent;
+import org.projectnessie.model.types.GenericRepositoryConfig;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+class TestJackson3ModelCompatibility {
+
+  private static final ObjectMapper MAPPER =
+      JsonMapper.builder().enable(MapperFeature.DEFAULT_VIEW_INCLUSION).build();
+
+  private static CommitMeta commitMeta() {
+    return CommitMeta.builder()
+        .hash("11223344")
+        .committer("committer@example.com")
+        .author("author@example.com")
+        .signedOffBy("signer@example.com")
+        .message("message")
+        .commitTime(Instant.ofEpochSecond(2))
+        .authorTime(Instant.ofEpochSecond(1))
+        .putProperties("property", "value")
+        .addParentCommitHashes("parent")
+        .build();
+  }
+
+  @Test
+  void contentRoundTripWithKnownType() throws Exception {
+    Content content = IcebergTable.of("metadata.json", 1, 2, 3, 4, "content-id");
+
+    String serialized = MAPPER.writeValueAsString(content);
+    JsonNode serializedAsJson = MAPPER.readValue(serialized, JsonNode.class);
+    assertThat(serializedAsJson.get("type").asString()).isEqualTo("ICEBERG_TABLE");
+    assertThat(serializedAsJson.get("id").asString()).isEqualTo("content-id");
+
+    Content deserialized = MAPPER.readValue(serialized, Content.class);
+    assertThat(deserialized).isEqualTo(content);
+  }
+
+  @Test
+  void contentRoundTripWithRemainingKnownTypes() throws Exception {
+    for (Content content :
+        new Content[] {
+          IcebergView.of("view-id", "view-metadata.json", 1, 2),
+          ImmutableDeltaLakeTable.builder()
+              .id("delta-id")
+              .addMetadataLocationHistory("metadata-1.json")
+              .addCheckpointLocationHistory("checkpoint-1")
+              .lastCheckpoint("checkpoint-1")
+              .build(),
+          Namespace.of(Map.of("owner", "nessie"), "a", "b"),
+          UDF.udf("udf-id", "udf-metadata.json", "version", "signature")
+        }) {
+      String serialized = MAPPER.writeValueAsString(content);
+      Content deserialized = MAPPER.readValue(serialized, Content.class);
+      assertThat(deserialized).isEqualTo(content);
+    }
+  }
+
+  @Test
+  void contentRoundTripWithUnknownType() throws Exception {
+    String json =
+        "{\"type\":\"something-unknown\",\"id\":\"123\",\"a\":\"b\",\"nested\":{\"c\":\"d\"}}";
+
+    Content content = MAPPER.readValue(json, Content.class);
+    assertThat(content).isInstanceOf(GenericContent.class);
+    assertThat(content.getType().name()).isEqualTo("something-unknown");
+    assertThat(content.getId()).isEqualTo("123");
+
+    String serialized = MAPPER.writeValueAsString(content);
+    assertThat(MAPPER.readValue(serialized, JsonNode.class))
+        .isEqualTo(MAPPER.readValue(json, JsonNode.class));
+  }
+
+  @Test
+  void nessieConfigurationUsesJsonViews() throws Exception {
+    NessieConfiguration configuration =
+        ImmutableNessieConfiguration.builder()
+            .defaultBranch("main")
+            .minSupportedApiVersion(1)
+            .maxSupportedApiVersion(2)
+            .actualApiVersion(2)
+            .specVersion("2.0.0")
+            .repositoryCreationTimestamp(Instant.ofEpochSecond(10))
+            .oldestPossibleCommitTimestamp(Instant.ofEpochSecond(9))
+            .additionalProperties(Map.of())
+            .build();
+
+    JsonNode v1 =
+        MAPPER.readValue(
+            MAPPER.writerWithView(Views.V1.class).writeValueAsString(configuration),
+            JsonNode.class);
+    assertThat(v1.has("defaultBranch")).isTrue();
+    assertThat(v1.has("minSupportedApiVersion")).isFalse();
+    assertThat(v1.has("actualApiVersion")).isFalse();
+    assertThat(v1.has("specVersion")).isFalse();
+
+    JsonNode v2 =
+        MAPPER.readValue(
+            MAPPER.writerWithView(Views.V2.class).writeValueAsString(configuration),
+            JsonNode.class);
+    assertThat(v2.get("defaultBranch").asString()).isEqualTo("main");
+    assertThat(v2.get("minSupportedApiVersion").intValue()).isEqualTo(1);
+    assertThat(v2.get("maxSupportedApiVersion").intValue()).isEqualTo(2);
+    assertThat(v2.get("actualApiVersion").intValue()).isEqualTo(2);
+    assertThat(v2.get("specVersion").asString()).isEqualTo("2.0.0");
+    assertThat(v2.get("repositoryCreationTimestamp").asString()).isEqualTo("1970-01-01T00:00:10Z");
+    assertThat(v2.get("oldestPossibleCommitTimestamp").asString())
+        .isEqualTo("1970-01-01T00:00:09Z");
+
+    assertThat(
+            MAPPER.readValue(MAPPER.writeValueAsString(configuration), NessieConfiguration.class))
+        .isEqualTo(configuration);
+  }
+
+  @Test
+  void repositoryConfigRoundTripWithKnownType() throws Exception {
+    RepositoryConfig repositoryConfig =
+        GarbageCollectorConfig.builder()
+            .expectedFileCountPerContent(42)
+            .defaultCutoffPolicy("3")
+            .addPerRefCutoffPolicies(referenceCutoffPolicy("main", "P30D"))
+            .newFilesGracePeriod(Duration.ofMinutes(5))
+            .build();
+
+    String serialized = MAPPER.writeValueAsString(repositoryConfig);
+    JsonNode serializedAsJson = MAPPER.readValue(serialized, JsonNode.class);
+    assertThat(serializedAsJson.get("type").asString()).isEqualTo("GARBAGE_COLLECTOR");
+    assertThat(serializedAsJson.get("expectedFileCountPerContent").intValue()).isEqualTo(42);
+    assertThat(serializedAsJson.get("newFilesGracePeriod").asString()).isEqualTo("PT5M");
+
+    RepositoryConfig deserialized = MAPPER.readValue(serialized, RepositoryConfig.class);
+    assertThat(deserialized).isEqualTo(repositoryConfig);
+  }
+
+  @Test
+  void repositoryConfigRoundTripWithUnknownType() throws Exception {
+    String json = "{\"type\":\"something-unknown\",\"a\":\"b\",\"nested\":{\"c\":\"d\"}}";
+
+    RepositoryConfig repositoryConfig = MAPPER.readValue(json, RepositoryConfig.class);
+    assertThat(repositoryConfig).isInstanceOf(GenericRepositoryConfig.class);
+    assertThat(repositoryConfig.getType().name()).isEqualTo("something-unknown");
+
+    String serialized = MAPPER.writeValueAsString(repositoryConfig);
+    assertThat(MAPPER.readValue(serialized, JsonNode.class))
+        .isEqualTo(MAPPER.readValue(json, JsonNode.class));
+  }
+
+  @Test
+  void errorDetailsRoundTripWithKnownType() throws Exception {
+    NessieErrorDetails errorDetails =
+        ReferenceConflicts.referenceConflicts(
+            Conflict.conflict(
+                Conflict.ConflictType.UNEXPECTED_HASH, ContentKey.of("a", "b"), "message"));
+
+    String serialized = MAPPER.writeValueAsString(errorDetails);
+    JsonNode serializedAsJson = MAPPER.readValue(serialized, JsonNode.class);
+    assertThat(serializedAsJson.get("type").asString()).isEqualTo("REFERENCE_CONFLICTS");
+
+    NessieErrorDetails deserialized = MAPPER.readValue(serialized, NessieErrorDetails.class);
+    assertThat(deserialized).isEqualTo(errorDetails);
+
+    ContentKeyErrorDetails contentKeyErrorDetails =
+        ContentKeyErrorDetails.contentKeyErrorDetails(ContentKey.of("a", "b"));
+    assertThat(
+            MAPPER.readValue(
+                MAPPER.writeValueAsString(contentKeyErrorDetails), NessieErrorDetails.class))
+        .isEqualTo(contentKeyErrorDetails);
+  }
+
+  @Test
+  void errorDetailsRoundTripWithUnknownType() throws Exception {
+    String json = "{\"type\":\"something-unknown\",\"a\":\"b\",\"nested\":{\"c\":\"d\"}}";
+
+    NessieErrorDetails errorDetails = MAPPER.readValue(json, NessieErrorDetails.class);
+    assertThat(errorDetails).isInstanceOf(GenericErrorDetails.class);
+    assertThat(errorDetails.getType()).isEqualTo("something-unknown");
+
+    String serialized = MAPPER.writeValueAsString(errorDetails);
+    assertThat(MAPPER.readValue(serialized, JsonNode.class))
+        .isEqualTo(MAPPER.readValue(json, JsonNode.class));
+  }
+
+  @Test
+  void polymorphicFallbackRequiresTypeId() {
+    assertThatThrownBy(() -> MAPPER.readValue("{\"id\":\"123\",\"a\":\"b\"}", Content.class))
+        .isInstanceOf(tools.jackson.databind.exc.InvalidTypeIdException.class)
+        .hasMessageContaining("missing type id property 'type'");
+
+    assertThatThrownBy(() -> MAPPER.readValue("{\"a\":\"b\"}", RepositoryConfig.class))
+        .isInstanceOf(tools.jackson.databind.exc.InvalidTypeIdException.class)
+        .hasMessageContaining("missing type id property 'type'");
+
+    assertThatThrownBy(() -> MAPPER.readValue("{\"a\":\"b\"}", NessieErrorDetails.class))
+        .isInstanceOf(tools.jackson.databind.exc.InvalidTypeIdException.class)
+        .hasMessageContaining("missing type id property 'type'");
+  }
+
+  @Test
+  void nessieErrorRoundTrip() throws Exception {
+    NessieErrorDetails details =
+        ReferenceConflicts.referenceConflicts(
+            Conflict.conflict(
+                Conflict.ConflictType.UNEXPECTED_HASH, ContentKey.of("a", "b"), "message"));
+    NessieError error =
+        ImmutableNessieError.builder()
+            .message("message")
+            .errorCode(ErrorCode.REFERENCE_CONFLICT)
+            .status(409)
+            .reason("Conflict")
+            .serverStackTrace("server-stack")
+            .clientProcessingError("client-processing")
+            .errorDetails(details)
+            .build();
+
+    String serialized = MAPPER.writeValueAsString(error);
+    JsonNode serializedAsJson = MAPPER.readValue(serialized, JsonNode.class);
+    assertThat(serializedAsJson.get("errorCode").asString()).isEqualTo("REFERENCE_CONFLICT");
+    assertThat(serializedAsJson.get("errorDetails").get("type").asString())
+        .isEqualTo("REFERENCE_CONFLICTS");
+    assertThat(serializedAsJson.has("clientProcessingError")).isFalse();
+
+    NessieError deserialized = MAPPER.readValue(serialized, NessieError.class);
+    NessieError expected =
+        ImmutableNessieError.builder().from(error).clientProcessingError(null).build();
+    assertThat(deserialized).isEqualTo(expected);
+  }
+
+  @Test
+  void nessieErrorUnknownErrorCodeFallsBackToUnknown() throws Exception {
+    String json =
+        """
+        {
+          "status": 500,
+          "reason": "Internal Server Error",
+          "message": "message",
+          "errorCode": "SOMETHING_NEW"
+        }
+        """;
+
+    NessieError error = MAPPER.readValue(json, NessieError.class);
+    assertThat(error.getErrorCode()).isEqualTo(ErrorCode.UNKNOWN);
+  }
+
+  @Test
+  void referenceRoundTripWithKnownTypes() throws Exception {
+    for (Reference reference :
+        new Reference[] {Branch.of("main", "12345678"), Tag.of("tag", "87654321")}) {
+      String serialized = MAPPER.writeValueAsString(reference);
+      Reference deserialized = MAPPER.readValue(serialized, Reference.class);
+      assertThat(deserialized).isEqualTo(reference);
+    }
+
+    Detached detached = Detached.of("12345678");
+    String serialized = MAPPER.writeValueAsString(detached);
+    JsonNode serializedAsJson = MAPPER.readValue(serialized, JsonNode.class);
+    assertThat(serializedAsJson.get("type").asString()).isEqualTo("DETACHED");
+    assertThat(MAPPER.readValue(serialized, Reference.class)).isEqualTo(detached);
+  }
+
+  @Test
+  void referencesResponseRoundTrip() throws Exception {
+    ReferencesResponse references =
+        ReferencesResponse.builder()
+            .addReferences(Branch.of("main", "12345678"))
+            .addReferences(Tag.of("tag", "87654321"))
+            .token("next-page")
+            .isHasMore(true)
+            .build();
+
+    String serialized = MAPPER.writeValueAsString(references);
+    JsonNode serializedAsJson = MAPPER.readValue(serialized, JsonNode.class);
+    assertThat(serializedAsJson.get("references").get(0).get("type").asString())
+        .isEqualTo("BRANCH");
+    assertThat(serializedAsJson.get("references").get(1).get("type").asString()).isEqualTo("TAG");
+
+    ReferencesResponse deserialized = MAPPER.readValue(serialized, ReferencesResponse.class);
+    assertThat(deserialized).isEqualTo(references);
+  }
+
+  @Test
+  void referenceMetadataRoundTripWithCommitMeta() throws Exception {
+    ReferenceMetadata metadata =
+        ImmutableReferenceMetadata.builder()
+            .numCommitsAhead(1)
+            .numCommitsBehind(2)
+            .commitMetaOfHEAD(commitMeta())
+            .commonAncestorHash("ancestor")
+            .numTotalCommits(3L)
+            .build();
+    Reference reference = Branch.of("main", "12345678", metadata);
+
+    String serialized = MAPPER.writeValueAsString(reference);
+    Reference deserialized = MAPPER.readValue(serialized, Reference.class);
+    assertThat(deserialized).isEqualTo(reference);
+
+    JsonNode serializedAsJson = MAPPER.readValue(serialized, JsonNode.class);
+    assertThat(
+            serializedAsJson.get("metadata").get("commitMetaOfHEAD").get("commitTime").asString())
+        .isEqualTo("1970-01-01T00:00:02Z");
+  }
+
+  @Test
+  void commitMetaAcceptsV1Shape() throws Exception {
+    String json =
+        """
+        {
+          "hash": "11223344",
+          "committer": "committer@example.com",
+          "author": "author@example.com",
+          "signedOffBy": "signer@example.com",
+          "message": "message",
+          "commitTime": "1970-01-01T00:00:02Z",
+          "authorTime": "1970-01-01T00:00:01Z",
+          "properties": {
+            "property": "value"
+          },
+          "parentCommitHashes": ["parent"]
+        }
+        """;
+
+    CommitMeta deserialized = MAPPER.readValue(json, CommitMeta.class);
+    assertThat(deserialized).isEqualTo(commitMeta());
+  }
+
+  @Test
+  void operationsRoundTrip() throws Exception {
+    Operations operations =
+        ImmutableOperations.builder()
+            .commitMeta(commitMeta())
+            .addOperations(
+                Operation.Put.of(
+                    ContentKey.of("table"), IcebergTable.of("metadata.json", 1, 2, 3, 4)))
+            .addOperations(Operation.Delete.of(ContentKey.of("deleted")))
+            .addOperations(Operation.Unchanged.of(ContentKey.of("unchanged")))
+            .build();
+
+    String serialized = MAPPER.writeValueAsString(operations);
+    JsonNode serializedAsJson = MAPPER.readValue(serialized, JsonNode.class);
+    assertThat(serializedAsJson.get("operations").get(0).get("type").asString()).isEqualTo("PUT");
+    assertThat(serializedAsJson.get("operations").get(1).get("type").asString())
+        .isEqualTo("DELETE");
+    assertThat(serializedAsJson.get("operations").get(2).get("type").asString())
+        .isEqualTo("UNCHANGED");
+
+    Operations deserialized = MAPPER.readValue(serialized, Operations.class);
+    assertThat(deserialized).isEqualTo(operations);
+  }
+
+  @Test
+  void commitAndLogResponsesRoundTrip() throws Exception {
+    CommitResponse commitResponse =
+        CommitResponse.builder()
+            .targetBranch(Branch.of("main", "12345678"))
+            .addAddedContents(
+                CommitResponse.AddedContent.addedContent(ContentKey.of("table"), "id"))
+            .build();
+    assertThat(MAPPER.readValue(MAPPER.writeValueAsString(commitResponse), CommitResponse.class))
+        .isEqualTo(commitResponse);
+
+    LogResponse logResponse =
+        LogResponse.builder()
+            .addLogEntries(
+                LogResponse.LogEntry.builder()
+                    .commitMeta(commitMeta())
+                    .operations(
+                        List.of(
+                            Operation.Put.of(
+                                ContentKey.of("table"),
+                                IcebergTable.of("metadata.json", 1, 2, 3, 4))))
+                    .build())
+            .isHasMore(true)
+            .token("next-page")
+            .build();
+    assertThat(MAPPER.readValue(MAPPER.writeValueAsString(logResponse), LogResponse.class))
+        .isEqualTo(logResponse);
+  }
+
+  @Test
+  void mergeResponseRoundTrip() throws Exception {
+    MergeResponse mergeResponse =
+        ImmutableMergeResponse.builder()
+            .wasApplied(true)
+            .wasSuccessful(false)
+            .targetBranch("main")
+            .effectiveTargetHash("12345678")
+            .resultantTargetHash("87654321")
+            .expectedHash("11111111")
+            .addDetails(
+                ImmutableContentKeyDetails.builder()
+                    .key(ContentKey.of("table"))
+                    .mergeBehavior(MergeBehavior.NORMAL)
+                    .conflict(
+                        Conflict.conflict(
+                            Conflict.ConflictType.UNEXPECTED_HASH,
+                            ContentKey.of("table"),
+                            "message"))
+                    .build())
+            .build();
+
+    assertThat(MAPPER.readValue(MAPPER.writeValueAsString(mergeResponse), MergeResponse.class))
+        .isEqualTo(mergeResponse);
+  }
+
+  @Test
+  void contentAndDiffResponsesRoundTrip() throws Exception {
+    Content content = IcebergTable.of("metadata.json", 1, 2, 3, 4, "content-id");
+    Reference reference = Branch.of("main", "12345678");
+    Documentation documentation = Documentation.of("text/plain", "documentation");
+
+    ContentResponse contentResponse = ContentResponse.of(content, reference, documentation);
+    assertThat(MAPPER.readValue(MAPPER.writeValueAsString(contentResponse), ContentResponse.class))
+        .isEqualTo(contentResponse);
+
+    GetMultipleContentsRequest request =
+        GetMultipleContentsRequest.of(ContentKey.of("table"), ContentKey.of("view"));
+    assertThat(
+            MAPPER.readValue(MAPPER.writeValueAsString(request), GetMultipleContentsRequest.class))
+        .isEqualTo(request);
+
+    GetMultipleContentsResponse response =
+        GetMultipleContentsResponse.of(
+            List.of(GetMultipleContentsResponse.ContentWithKey.of(ContentKey.of("table"), content)),
+            reference);
+    assertThat(
+            MAPPER.readValue(
+                MAPPER.writeValueAsString(response), GetMultipleContentsResponse.class))
+        .isEqualTo(response);
+
+    DiffResponse diffResponse =
+        DiffResponse.builder()
+            .addDiffs(DiffResponse.DiffEntry.diffEntry(ContentKey.of("table"), null, content))
+            .effectiveFromReference(reference)
+            .effectiveToReference(Tag.of("tag", "87654321"))
+            .build();
+    assertThat(MAPPER.readValue(MAPPER.writeValueAsString(diffResponse), DiffResponse.class))
+        .isEqualTo(diffResponse);
+  }
+
+  @Test
+  void singleReferenceResponseRoundTrip() throws Exception {
+    SingleReferenceResponse response =
+        SingleReferenceResponse.builder().reference(Branch.of("main", "12345678")).build();
+
+    assertThat(MAPPER.readValue(MAPPER.writeValueAsString(response), SingleReferenceResponse.class))
+        .isEqualTo(response);
+  }
+
+  @Test
+  void namespaceResponseRoundTrip() throws Exception {
+    GetNamespacesResponse response =
+        GetNamespacesResponse.builder()
+            .addNamespaces(Namespace.of("a", "b"))
+            .addNamespaces(Namespace.of(Map.of("owner", "nessie"), "c"))
+            .effectiveReference(Branch.of("main", "12345678"))
+            .build();
+
+    String serialized = MAPPER.writeValueAsString(response);
+    JsonNode serializedAsJson = MAPPER.readValue(serialized, JsonNode.class);
+    assertThat(serializedAsJson.get("namespaces").get(0).get("type").asString())
+        .isEqualTo("NAMESPACE");
+
+    assertThat(MAPPER.readValue(serialized, GetNamespacesResponse.class)).isEqualTo(response);
+  }
+
+  @Test
+  void identifiedContentKeyRoundTrip() throws Exception {
+    IdentifiedContentKey identifiedContentKey =
+        IdentifiedContentKey.identifiedContentKeyFromContent(
+            ContentKey.of("a", "table"),
+            IcebergTable.of("metadata.json", 1, 2, 3, 4, "content-id"),
+            path -> "namespace-id");
+
+    assertThat(
+            MAPPER.readValue(
+                MAPPER.writeValueAsString(identifiedContentKey), IdentifiedContentKey.class))
+        .isEqualTo(identifiedContentKey);
+  }
+
+  @Test
+  void repositoryConfigWrappersRoundTrip() throws Exception {
+    RepositoryConfig repositoryConfig =
+        GarbageCollectorConfig.builder()
+            .expectedFileCountPerContent(42)
+            .defaultCutoffPolicy("3")
+            .build();
+
+    RepositoryConfigResponse response =
+        ImmutableRepositoryConfigResponse.builder().addConfigs(repositoryConfig).build();
+    assertThat(
+            MAPPER.readValue(MAPPER.writeValueAsString(response), RepositoryConfigResponse.class))
+        .isEqualTo(response);
+
+    UpdateRepositoryConfigRequest request =
+        ImmutableUpdateRepositoryConfigRequest.builder().config(repositoryConfig).build();
+    assertThat(
+            MAPPER.readValue(
+                MAPPER.writeValueAsString(request), UpdateRepositoryConfigRequest.class))
+        .isEqualTo(request);
+
+    UpdateRepositoryConfigResponse updateResponse =
+        ImmutableUpdateRepositoryConfigResponse.builder().previous(repositoryConfig).build();
+    assertThat(
+            MAPPER.readValue(
+                MAPPER.writeValueAsString(updateResponse), UpdateRepositoryConfigResponse.class))
+        .isEqualTo(updateResponse);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void referenceHistoryAndRefLogRoundTrip() throws Exception {
+    ReferenceHistoryState state =
+        ReferenceHistoryState.referenceHistoryElement(
+            "12345678", CommitConsistency.COMMIT_CONSISTENT, commitMeta());
+    ReferenceHistoryResponse history =
+        ReferenceHistoryResponse.builder()
+            .reference(Branch.of("main", "12345678"))
+            .current(state)
+            .addPrevious(
+                ReferenceHistoryState.referenceHistoryElement(
+                    "87654321", CommitConsistency.NOT_CHECKED, null))
+            .commitLogConsistency(CommitConsistency.COMMIT_CONSISTENT)
+            .build();
+
+    assertThat(MAPPER.readValue(MAPPER.writeValueAsString(history), ReferenceHistoryResponse.class))
+        .isEqualTo(history);
+
+    RefLogResponse refLog =
+        ImmutableRefLogResponse.builder()
+            .addLogEntries(
+                RefLogResponse.RefLogResponseEntry.builder()
+                    .refLogId("reflog")
+                    .refName("main")
+                    .refType(RefLogResponse.RefLogResponseEntry.BRANCH)
+                    .commitHash("12345678")
+                    .parentRefLogId("parent")
+                    .operationTime(42L)
+                    .operation(RefLogResponse.RefLogResponseEntry.COMMIT)
+                    .addSourceHashes("source")
+                    .build())
+            .isHasMore(true)
+            .token("next-page")
+            .build();
+
+    assertThat(MAPPER.readValue(MAPPER.writeValueAsString(refLog), RefLogResponse.class))
+        .isEqualTo(refLog);
+  }
+
+  @Test
+  void mergeKeyBehaviorRoundTrip() throws Exception {
+    MergeKeyBehavior behavior =
+        MergeKeyBehavior.builder()
+            .key(ContentKey.of("table"))
+            .mergeBehavior(MergeBehavior.FORCE)
+            .expectedTargetContent(IcebergTable.of("metadata.json", 1, 2, 3, 4, "expected"))
+            .resolvedContent(IcebergTable.of("metadata-new.json", 5, 6, 7, 8, "resolved"))
+            .expectedTargetDocumentation(Documentation.of("text/plain", "old"))
+            .resolvedDocumentation(Documentation.of("text/plain", "new"))
+            .addMetadata(
+                GenericContentMetadata.genericContentMetadata("custom", Map.of("key", "value")))
+            .build();
+
+    assertThat(MAPPER.readValue(MAPPER.writeValueAsString(behavior), MergeKeyBehavior.class))
+        .isEqualTo(behavior);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void v1ParamsRoundTrip() throws Exception {
+    String hash = "3e1cfa82";
+    MergeKeyBehavior keyBehavior =
+        MergeKeyBehavior.of(ContentKey.of("merge", "me"), MergeBehavior.NORMAL);
+
+    org.projectnessie.api.v1.params.Merge merge =
+        org.projectnessie.api.v1.params.ImmutableMerge.builder()
+            .fromRefName("main")
+            .fromHash(hash)
+            .keepIndividualCommits(true)
+            .defaultKeyMergeMode(MergeBehavior.FORCE)
+            .isDryRun(false)
+            .isFetchAdditionalInfo(true)
+            .isReturnConflictAsResult(true)
+            .addKeyMergeModes(keyBehavior)
+            .build();
+    assertThat(
+            MAPPER.readValue(
+                MAPPER.writeValueAsString(merge), org.projectnessie.api.v1.params.Merge.class))
+        .isEqualTo(merge);
+
+    org.projectnessie.api.v1.params.Transplant transplant =
+        org.projectnessie.api.v1.params.ImmutableTransplant.builder()
+            .fromRefName("main")
+            .addHashesToTransplant(hash)
+            .keepIndividualCommits(true)
+            .defaultKeyMergeMode(MergeBehavior.DROP)
+            .isDryRun(true)
+            .addKeyMergeModes(keyBehavior)
+            .build();
+    assertThat(
+            MAPPER.readValue(
+                MAPPER.writeValueAsString(transplant),
+                org.projectnessie.api.v1.params.Transplant.class))
+        .isEqualTo(transplant);
+
+    org.projectnessie.api.v1.params.NamespaceUpdate namespaceUpdate =
+        org.projectnessie.api.v1.params.ImmutableNamespaceUpdate.builder()
+            .propertyUpdates(Map.of("owner", "nessie"))
+            .propertyRemovals(Set.of("old-owner"))
+            .build();
+    assertThat(
+            MAPPER.readValue(
+                MAPPER.writeValueAsString(namespaceUpdate),
+                org.projectnessie.api.v1.params.NamespaceUpdate.class))
+        .isEqualTo(namespaceUpdate);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void v2ParamsRoundTrip() throws Exception {
+    String hash = "3e1cfa82";
+    MergeKeyBehavior keyBehavior =
+        MergeKeyBehavior.of(ContentKey.of("merge", "me"), MergeBehavior.NORMAL);
+
+    org.projectnessie.api.v2.params.Merge merge =
+        org.projectnessie.api.v2.params.ImmutableMerge.builder()
+            .fromRefName("main")
+            .fromHash(hash)
+            .message("deprecated-message")
+            .commitMeta(commitMeta())
+            .defaultKeyMergeMode(MergeBehavior.FORCE)
+            .isDryRun(false)
+            .isFetchAdditionalInfo(true)
+            .isReturnConflictAsResult(true)
+            .addKeyMergeModes(keyBehavior)
+            .build();
+    assertThat(
+            MAPPER.readValue(
+                MAPPER.writeValueAsString(merge), org.projectnessie.api.v2.params.Merge.class))
+        .isEqualTo(merge);
+
+    org.projectnessie.api.v2.params.Transplant transplant =
+        org.projectnessie.api.v2.params.ImmutableTransplant.builder()
+            .fromRefName("main")
+            .message("message")
+            .addHashesToTransplant(hash)
+            .addHashesToTransplant("cafebabe~1")
+            .defaultKeyMergeMode(MergeBehavior.DROP)
+            .isDryRun(true)
+            .addKeyMergeModes(keyBehavior)
+            .build();
+    assertThat(
+            MAPPER.readValue(
+                MAPPER.writeValueAsString(transplant),
+                org.projectnessie.api.v2.params.Transplant.class))
+        .isEqualTo(transplant);
+  }
+}


### PR DESCRIPTION
This change adds support for Jackson 3, so API facing types can be (de)serialized with both Jackson 2 and Jackson 3.