### PR TITLE
Jackson 3 slice - catalog/format/iceberg

### DIFF
--- a/catalog/format/iceberg/build.gradle.kts
+++ b/catalog/format/iceberg/build.gradle.kts
@@ -42,6 +42,12 @@ dependencies {
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
 
+  compileOnly(platform(libs.jackson3.bom))
+  compileOnly("tools.jackson.core:jackson-core")
+  compileOnly("tools.jackson.core:jackson-databind")
+  runtimeOnly(platform(libs.jackson3.bom))
+  runtimeOnly("tools.jackson.core:jackson-databind")
+
   avroSchemaImplementation(libs.avro)
   avroSchemaImplementation(libs.guava)
   avroSchemaImplementation(libs.slf4j.nop)
@@ -67,6 +73,36 @@ dependencies {
   testFixturesImplementation("com.fasterxml.jackson.core:jackson-annotations")
 
   testFixturesApi("org.apache.iceberg:iceberg-core:$versionIceberg")
+}
+
+testing {
+  suites {
+    register("testJackson3", JvmTestSuite::class.java) {
+      useJUnitJupiter(libsRequiredVersion("junit"))
+
+      dependencies {
+        implementation.add(project())
+        implementation.add(project(":nessie-catalog-model"))
+        implementation.add(platform(libs.jackson3.bom))
+        implementation.add("tools.jackson.core:jackson-databind")
+        compileOnly.add(platform(libs.jackson.bom))
+        compileOnly.add("com.fasterxml.jackson.core:jackson-databind")
+        implementation.add(platform(libs.junit.bom))
+        implementation.add(libs.assertj.core)
+      }
+
+      targets {
+        all {
+          testTask.configure {
+            usesService(
+              gradle.sharedServices.registrations.named("testParallelismConstraint").get().service
+            )
+          }
+          tasks.named("test").configure { dependsOn(testTask) }
+        }
+      }
+    }
+  }
 }
 
 val generateAvroSchemas =

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergBlobMetadata.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergBlobMetadata.java
@@ -27,8 +27,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergBlobMetadata.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergBlobMetadata.class)
 @JsonDeserialize(as = ImmutableIcebergBlobMetadata.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergBlobMetadata.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergBlobMetadata {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergDirection.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergDirection.java
@@ -28,7 +28,11 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(using = IcebergDirection.IcebergDirectionSerializer.class)
+@tools.jackson.databind.annotation.JsonSerialize(
+    using = IcebergDirection.IcebergDirectionSerializer3.class)
 @JsonDeserialize(using = IcebergDirection.IcebergDirectionDeserializer.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    using = IcebergDirection.IcebergDirectionDeserializer3.class)
 public interface IcebergDirection {
   String name();
 
@@ -52,6 +56,33 @@ public interface IcebergDirection {
     public IcebergDirection deserialize(JsonParser p, DeserializationContext ctxt)
         throws IOException {
       String text = p.getText();
+      return switch (text) {
+        case ASC_VALUE -> ASC;
+        case DESC_VALUE -> DESC;
+        default -> ImmutableIcebergDirection.of(text, text);
+      };
+    }
+  }
+
+  class IcebergDirectionSerializer3
+      extends tools.jackson.databind.ValueSerializer<IcebergDirection> {
+    @Override
+    public void serialize(
+        IcebergDirection value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers)
+        throws tools.jackson.core.JacksonException {
+      gen.writeString(value.jsonValue());
+    }
+  }
+
+  class IcebergDirectionDeserializer3
+      extends tools.jackson.databind.ValueDeserializer<IcebergDirection> {
+    @Override
+    public IcebergDirection deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+        throws tools.jackson.core.JacksonException {
+      String text = p.getString();
       return switch (text) {
         case ASC_VALUE -> ASC;
         case DESC_VALUE -> DESC;

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergHistoryEntry.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergHistoryEntry.java
@@ -25,8 +25,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergHistoryEntry.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergHistoryEntry.class)
 @JsonDeserialize(as = ImmutableIcebergHistoryEntry.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergHistoryEntry.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergHistoryEntry {
   static Builder builder() {

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergMetadataLogEntry.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergMetadataLogEntry.java
@@ -25,8 +25,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergMetadataLogEntry.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergMetadataLogEntry.class)
 @JsonDeserialize(as = ImmutableIcebergMetadataLogEntry.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergMetadataLogEntry.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergMetadataLogEntry {
   static Builder builder() {

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergNamespace.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergNamespace.java
@@ -39,8 +39,14 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(using = IcebergNamespace.IcebergNamespaceSerializer.class)
+@tools.jackson.databind.annotation.JsonSerialize(
+    using = IcebergNamespace.IcebergNamespaceSerializer3.class)
 @JsonDeserialize(using = IcebergNamespace.IcebergNamespaceDeserializer.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    using = IcebergNamespace.IcebergNamespaceDeserializer3.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergNamespace {
   @Value.Parameter(order = 1)
@@ -107,6 +113,42 @@ public interface IcebergNamespace {
     public void serialize(
         IcebergNamespace namespace, JsonGenerator gen, SerializerProvider serializers)
         throws IOException {
+      gen.writeStartArray();
+      for (String level : namespace.levels()) {
+        gen.writeString(level);
+      }
+      gen.writeEndArray();
+    }
+  }
+
+  class IcebergNamespaceDeserializer3
+      extends tools.jackson.databind.ValueDeserializer<IcebergNamespace> {
+    @Override
+    public IcebergNamespace deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+        throws tools.jackson.core.JacksonException {
+      checkArgument(p.currentToken() == tools.jackson.core.JsonToken.START_ARRAY);
+      Builder b = builder();
+      while (true) {
+        switch (p.nextToken()) {
+          case VALUE_STRING -> b.addLevel(p.getString());
+          case END_ARRAY -> {
+            return b.build();
+          }
+          default -> throw new IllegalArgumentException("Unexpected token " + p.currentToken());
+        }
+      }
+    }
+  }
+
+  class IcebergNamespaceSerializer3
+      extends tools.jackson.databind.ValueSerializer<IcebergNamespace> {
+    @Override
+    public void serialize(
+        IcebergNamespace namespace,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers)
+        throws tools.jackson.core.JacksonException {
       gen.writeStartArray();
       for (String level : namespace.levels()) {
         gen.writeString(level);

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergNestedField.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergNestedField.java
@@ -33,8 +33,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergNestedField.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergNestedField.class)
 @JsonDeserialize(as = ImmutableIcebergNestedField.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergNestedField.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergNestedField {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergNullOrder.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergNullOrder.java
@@ -28,7 +28,11 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(using = IcebergNullOrder.IcebergNullOrderSerializer.class)
+@tools.jackson.databind.annotation.JsonSerialize(
+    using = IcebergNullOrder.IcebergNullOrderSerializer3.class)
 @JsonDeserialize(using = IcebergNullOrder.IcebergNullOrderDeserializer.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    using = IcebergNullOrder.IcebergNullOrderDeserializer3.class)
 public interface IcebergNullOrder {
   String name();
 
@@ -52,6 +56,33 @@ public interface IcebergNullOrder {
     public IcebergNullOrder deserialize(JsonParser p, DeserializationContext ctxt)
         throws IOException {
       String text = p.getText();
+      return switch (text) {
+        case NULLS_FIRST_VALUE -> NULLS_FIRST;
+        case NULLS_LAST_VALUE -> NULLS_LAST;
+        default -> ImmutableIcebergNullOrder.of(text, text);
+      };
+    }
+  }
+
+  class IcebergNullOrderSerializer3
+      extends tools.jackson.databind.ValueSerializer<IcebergNullOrder> {
+    @Override
+    public void serialize(
+        IcebergNullOrder value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers)
+        throws tools.jackson.core.JacksonException {
+      gen.writeString(value.jsonValue());
+    }
+  }
+
+  class IcebergNullOrderDeserializer3
+      extends tools.jackson.databind.ValueDeserializer<IcebergNullOrder> {
+    @Override
+    public IcebergNullOrder deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+        throws tools.jackson.core.JacksonException {
+      String text = p.getString();
       return switch (text) {
         case NULLS_FIRST_VALUE -> NULLS_FIRST;
         case NULLS_LAST_VALUE -> NULLS_LAST;

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergPartitionField.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergPartitionField.java
@@ -32,8 +32,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergPartitionField.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergPartitionField.class)
 @JsonDeserialize(as = ImmutableIcebergPartitionField.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergPartitionField.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergPartitionField {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergPartitionSpec.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergPartitionSpec.java
@@ -35,8 +35,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergPartitionSpec.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergPartitionSpec.class)
 @JsonDeserialize(as = ImmutableIcebergPartitionSpec.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergPartitionSpec.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergPartitionSpec {
   int INITIAL_SPEC_ID = 0;

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergPartitionStatisticsFile.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergPartitionStatisticsFile.java
@@ -24,8 +24,13 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergPartitionStatisticsFile.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergPartitionStatisticsFile.class)
 @JsonDeserialize(as = ImmutableIcebergPartitionStatisticsFile.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    as = ImmutableIcebergPartitionStatisticsFile.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergPartitionStatisticsFile {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergSchema.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergSchema.java
@@ -31,8 +31,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergSchema.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergSchema.class)
 @JsonDeserialize(as = ImmutableIcebergSchema.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergSchema.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergSchema {
   int INITIAL_SCHEMA_ID = 0;

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergSnapshot.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergSnapshot.java
@@ -34,8 +34,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergSnapshot.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergSnapshot.class)
 @JsonDeserialize(as = ImmutableIcebergSnapshot.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergSnapshot.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergSnapshot {
   static Builder builder() {

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergSnapshotLogEntry.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergSnapshotLogEntry.java
@@ -25,8 +25,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergSnapshotLogEntry.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergSnapshotLogEntry.class)
 @JsonDeserialize(as = ImmutableIcebergSnapshotLogEntry.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergSnapshotLogEntry.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergSnapshotLogEntry {
   static Builder builder() {

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergSnapshotRef.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergSnapshotRef.java
@@ -27,8 +27,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergSnapshotRef.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergSnapshotRef.class)
 @JsonDeserialize(as = ImmutableIcebergSnapshotRef.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergSnapshotRef.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergSnapshotRef {
   static Builder builder() {

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergSortField.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergSortField.java
@@ -28,8 +28,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergSortField.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergSortField.class)
 @JsonDeserialize(as = ImmutableIcebergSortField.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergSortField.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergSortField {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergSortOrder.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergSortOrder.java
@@ -29,8 +29,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergSortOrder.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergSortOrder.class)
 @JsonDeserialize(as = ImmutableIcebergSortOrder.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergSortOrder.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergSortOrder {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergStatisticsFile.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergStatisticsFile.java
@@ -26,8 +26,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergStatisticsFile.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergStatisticsFile.class)
 @JsonDeserialize(as = ImmutableIcebergStatisticsFile.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergStatisticsFile.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergStatisticsFile {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergTableIdentifier.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergTableIdentifier.java
@@ -27,8 +27,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergTableIdentifier.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergTableIdentifier.class)
 @JsonDeserialize(as = ImmutableIcebergTableIdentifier.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergTableIdentifier.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergTableIdentifier {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergTableMetadata.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergTableMetadata.java
@@ -35,8 +35,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergTableMetadata.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergTableMetadata.class)
 @JsonDeserialize(as = ImmutableIcebergTableMetadata.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergTableMetadata.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergTableMetadata {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergViewHistoryEntry.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergViewHistoryEntry.java
@@ -24,8 +24,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergViewHistoryEntry.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergViewHistoryEntry.class)
 @JsonDeserialize(as = ImmutableIcebergViewHistoryEntry.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergViewHistoryEntry.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergViewHistoryEntry {
   long timestampMs();

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergViewMetadata.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergViewMetadata.java
@@ -32,8 +32,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergViewMetadata.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergViewMetadata.class)
 @JsonDeserialize(as = ImmutableIcebergViewMetadata.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergViewMetadata.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergViewMetadata {
   String viewUuid();

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergViewRepresentation.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergViewRepresentation.java
@@ -28,6 +28,8 @@ import org.immutables.value.Value;
 import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
@@ -44,7 +46,10 @@ public interface IcebergViewRepresentation {
   @NessieImmutable
   @JsonTypeName("sql")
   @JsonSerialize(as = ImmutableIcebergSQLViewRepresentation.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergSQLViewRepresentation.class)
   @JsonDeserialize(as = ImmutableIcebergSQLViewRepresentation.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(
+      as = ImmutableIcebergSQLViewRepresentation.class)
   interface IcebergSQLViewRepresentation extends IcebergViewRepresentation {
     String sql();
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergViewVersion.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/meta/IcebergViewVersion.java
@@ -29,8 +29,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergViewVersion.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergViewVersion.class)
 @JsonDeserialize(as = ImmutableIcebergViewVersion.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergViewVersion.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergViewVersion {
   long versionId();

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/metrics/IcebergCommitMetricsResult.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/metrics/IcebergCommitMetricsResult.java
@@ -26,8 +26,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergCommitMetricsResult.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergCommitMetricsResult.class)
 @JsonDeserialize(as = ImmutableIcebergCommitMetricsResult.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergCommitMetricsResult.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergCommitMetricsResult {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/metrics/IcebergCommitReport.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/metrics/IcebergCommitReport.java
@@ -29,8 +29,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 @NessieImmutable
 @JsonTypeName(COMMIT_REPORT_NAME)
 @JsonSerialize(as = ImmutableIcebergCommitReport.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergCommitReport.class)
 @JsonDeserialize(as = ImmutableIcebergCommitReport.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergCommitReport.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergCommitReport extends IcebergMetricsReport {
   String tableName();

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/metrics/IcebergCounterResult.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/metrics/IcebergCounterResult.java
@@ -24,8 +24,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergCounterResult.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergCounterResult.class)
 @JsonDeserialize(as = ImmutableIcebergCounterResult.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergCounterResult.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergCounterResult {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/metrics/IcebergMetricsReport.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/metrics/IcebergMetricsReport.java
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
       name = IcebergMetricsReport.COMMIT_REPORT_NAME),
 })
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergMetricsReport {
   String COMMIT_REPORT_NAME = "commit-report";

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/metrics/IcebergScanMetricsResult.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/metrics/IcebergScanMetricsResult.java
@@ -26,8 +26,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergScanMetricsResult.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergScanMetricsResult.class)
 @JsonDeserialize(as = ImmutableIcebergScanMetricsResult.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergScanMetricsResult.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergScanMetricsResult {
   @Nullable

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/metrics/IcebergScanReport.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/metrics/IcebergScanReport.java
@@ -31,8 +31,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 @NessieImmutable
 @JsonTypeName(SCAN_REPORT_NAME)
 @JsonSerialize(as = ImmutableIcebergScanReport.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergScanReport.class)
 @JsonDeserialize(as = ImmutableIcebergScanReport.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergScanReport.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergScanReport extends IcebergMetricsReport {
   String tableName();

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/metrics/IcebergTimerResult.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/metrics/IcebergTimerResult.java
@@ -33,15 +33,21 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergTimerResult.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergTimerResult.class)
 @JsonDeserialize(as = ImmutableIcebergTimerResult.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergTimerResult.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergTimerResult {
 
   long count();
 
   @JsonSerialize(using = TimeUnitSerializer.class)
+  @tools.jackson.databind.annotation.JsonSerialize(using = TimeUnitSerializer3.class)
   @JsonDeserialize(using = TimeUnitDeserializer.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(using = TimeUnitDeserializer3.class)
   TimeUnit timeUnit();
 
   long totalDuration();
@@ -66,6 +72,26 @@ public interface IcebergTimerResult {
     @Override
     public TimeUnit deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
       return TimeUnit.valueOf(p.getText().toUpperCase(Locale.ROOT));
+    }
+  }
+
+  final class TimeUnitSerializer3 extends tools.jackson.databind.ValueSerializer<TimeUnit> {
+    @Override
+    public void serialize(
+        TimeUnit value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers)
+        throws tools.jackson.core.JacksonException {
+      gen.writeString(value.name().toLowerCase(Locale.ROOT));
+    }
+  }
+
+  final class TimeUnitDeserializer3 extends tools.jackson.databind.ValueDeserializer<TimeUnit> {
+    @Override
+    public TimeUnit deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+        throws tools.jackson.core.JacksonException {
+      return TimeUnit.valueOf(p.getString().toUpperCase(Locale.ROOT));
     }
   }
 }

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCatalogOperation.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCatalogOperation.java
@@ -34,7 +34,9 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 /** Server-side representation of Iceberg metadata updates. */
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergCatalogOperation.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergCatalogOperation.class)
 @JsonDeserialize(as = ImmutableIcebergCatalogOperation.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergCatalogOperation.class)
 public abstract class IcebergCatalogOperation implements CatalogOperation {
   @Override
   public abstract ContentKey getKey();

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCommitTableResponse.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCommitTableResponse.java
@@ -24,8 +24,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergCommitTableResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergCommitTableResponse.class)
 @JsonDeserialize(as = ImmutableIcebergCommitTableResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergCommitTableResponse.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergCommitTableResponse extends IcebergBaseTableResult {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCommitTransactionRequest.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCommitTransactionRequest.java
@@ -28,8 +28,14 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergCommitTransactionRequest.class)
+@tools.jackson.databind.annotation.JsonSerialize(
+    as = ImmutableIcebergCommitTransactionRequest.class)
 @JsonDeserialize(as = ImmutableIcebergCommitTransactionRequest.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    as = ImmutableIcebergCommitTransactionRequest.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergCommitTransactionRequest {
   List<IcebergUpdateTableRequest> tableChanges();

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCommitViewRequest.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCommitViewRequest.java
@@ -27,8 +27,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergCommitViewRequest.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergCommitViewRequest.class)
 @JsonDeserialize(as = ImmutableIcebergCommitViewRequest.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergCommitViewRequest.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergCommitViewRequest extends IcebergUpdateEntityRequest {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergConfigResponse.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergConfigResponse.java
@@ -29,8 +29,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergConfigResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergConfigResponse.class)
 @JsonDeserialize(as = ImmutableIcebergConfigResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergConfigResponse.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergConfigResponse {
   Map<String, String> defaults();

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCreateNamespaceRequest.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCreateNamespaceRequest.java
@@ -28,8 +28,13 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergCreateNamespaceRequest.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergCreateNamespaceRequest.class)
 @JsonDeserialize(as = ImmutableIcebergCreateNamespaceRequest.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    as = ImmutableIcebergCreateNamespaceRequest.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergCreateNamespaceRequest {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCreateNamespaceResponse.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCreateNamespaceResponse.java
@@ -28,8 +28,13 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergCreateNamespaceResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergCreateNamespaceResponse.class)
 @JsonDeserialize(as = ImmutableIcebergCreateNamespaceResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    as = ImmutableIcebergCreateNamespaceResponse.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergCreateNamespaceResponse {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCreateTableRequest.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCreateTableRequest.java
@@ -29,8 +29,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergCreateTableRequest.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergCreateTableRequest.class)
 @JsonDeserialize(as = ImmutableIcebergCreateTableRequest.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergCreateTableRequest.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergCreateTableRequest {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCreateTableResponse.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCreateTableResponse.java
@@ -24,8 +24,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergCreateTableResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergCreateTableResponse.class)
 @JsonDeserialize(as = ImmutableIcebergCreateTableResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergCreateTableResponse.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergCreateTableResponse extends IcebergLoadTableResult {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCreateViewRequest.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergCreateViewRequest.java
@@ -29,8 +29,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergCreateViewRequest.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergCreateViewRequest.class)
 @JsonDeserialize(as = ImmutableIcebergCreateViewRequest.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergCreateViewRequest.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergCreateViewRequest {
   String name();

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergEndpoint.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergEndpoint.java
@@ -31,8 +31,14 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(using = IcebergEndpoint.IcebergEndpointSerializer.class)
+@tools.jackson.databind.annotation.JsonSerialize(
+    using = IcebergEndpoint.IcebergEndpointSerializer3.class)
 @JsonDeserialize(using = IcebergEndpoint.IcebergEndpointDeserializer.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    using = IcebergEndpoint.IcebergEndpointDeserializer3.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergEndpoint {
   String httpMethod();
@@ -55,6 +61,31 @@ public interface IcebergEndpoint {
     @Override
     public IcebergEndpoint deserialize(JsonParser p, DeserializationContext ctxt)
         throws IOException {
+      String val = p.getValueAsString();
+      int i = val.indexOf(' ');
+      String method = val.substring(0, i);
+      String path = val.substring(i + 1);
+      return icebergEndpoint(method, path);
+    }
+  }
+
+  class IcebergEndpointSerializer3 extends tools.jackson.databind.ValueSerializer<IcebergEndpoint> {
+    @Override
+    public void serialize(
+        IcebergEndpoint value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers)
+        throws tools.jackson.core.JacksonException {
+      gen.writeString(value.httpMethod() + " " + value.path());
+    }
+  }
+
+  class IcebergEndpointDeserializer3
+      extends tools.jackson.databind.ValueDeserializer<IcebergEndpoint> {
+    @Override
+    public IcebergEndpoint deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+        throws tools.jackson.core.JacksonException {
       String val = p.getValueAsString();
       int i = val.indexOf(' ');
       String method = val.substring(0, i);

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergError.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergError.java
@@ -29,8 +29,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergError.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergError.class)
 @JsonDeserialize(as = ImmutableIcebergError.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergError.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergError {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergErrorResponse.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergErrorResponse.java
@@ -25,8 +25,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergErrorResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergErrorResponse.class)
 @JsonDeserialize(as = ImmutableIcebergErrorResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergErrorResponse.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergErrorResponse {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergGetNamespaceResponse.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergGetNamespaceResponse.java
@@ -28,8 +28,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergGetNamespaceResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergGetNamespaceResponse.class)
 @JsonDeserialize(as = ImmutableIcebergGetNamespaceResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergGetNamespaceResponse.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergGetNamespaceResponse {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergListNamespacesResponse.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergListNamespacesResponse.java
@@ -29,8 +29,13 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergListNamespacesResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergListNamespacesResponse.class)
 @JsonDeserialize(as = ImmutableIcebergListNamespacesResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    as = ImmutableIcebergListNamespacesResponse.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergListNamespacesResponse {
   @Nullable

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergListTablesResponse.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergListTablesResponse.java
@@ -29,8 +29,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergListTablesResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergListTablesResponse.class)
 @JsonDeserialize(as = ImmutableIcebergListTablesResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergListTablesResponse.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergListTablesResponse {
   @Nullable

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergLoadCredentialsResponse.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergLoadCredentialsResponse.java
@@ -25,8 +25,13 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergLoadCredentialsResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergLoadCredentialsResponse.class)
 @JsonDeserialize(as = ImmutableIcebergLoadCredentialsResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    as = ImmutableIcebergLoadCredentialsResponse.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergLoadCredentialsResponse {
   List<IcebergStorageCredential> storageCredentials();

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergLoadTableResponse.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergLoadTableResponse.java
@@ -24,8 +24,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergLoadTableResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergLoadTableResponse.class)
 @JsonDeserialize(as = ImmutableIcebergLoadTableResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergLoadTableResponse.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergLoadTableResponse extends IcebergLoadTableResult {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergLoadViewResponse.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergLoadViewResponse.java
@@ -28,8 +28,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergLoadViewResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergLoadViewResponse.class)
 @JsonDeserialize(as = ImmutableIcebergLoadViewResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergLoadViewResponse.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergLoadViewResponse {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergMetadataUpdate.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergMetadataUpdate.java
@@ -57,6 +57,8 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 /** Iceberg metadata update objects serialized according to the Iceberg REST Catalog schema. */
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "action")
 @JsonSubTypes({
@@ -127,7 +129,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("upgrade-format-version")
   @JsonSerialize(as = ImmutableUpgradeFormatVersion.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableUpgradeFormatVersion.class)
   @JsonDeserialize(as = ImmutableUpgradeFormatVersion.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableUpgradeFormatVersion.class)
   interface UpgradeFormatVersion extends IcebergMetadataUpdate {
 
     int formatVersion();
@@ -152,7 +156,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("remove-snapshots")
   @JsonSerialize(as = ImmutableRemoveSnapshots.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableRemoveSnapshots.class)
   @JsonDeserialize(as = ImmutableRemoveSnapshots.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableRemoveSnapshots.class)
   interface RemoveSnapshots extends IcebergMetadataUpdate {
 
     List<Long> snapshotIds();
@@ -167,7 +173,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("remove-properties")
   @JsonSerialize(as = ImmutableRemoveProperties.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableRemoveProperties.class)
   @JsonDeserialize(as = ImmutableRemoveProperties.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableRemoveProperties.class)
   interface RemoveProperties extends IcebergMetadataUpdate {
 
     @JsonAlias({"removals", "removed"})
@@ -195,7 +203,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("add-view-version")
   @JsonSerialize(as = ImmutableAddViewVersion.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableAddViewVersion.class)
   @JsonDeserialize(as = ImmutableAddViewVersion.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableAddViewVersion.class)
   interface AddViewVersion extends IcebergMetadataUpdate {
 
     IcebergViewVersion viewVersion();
@@ -226,7 +236,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("set-current-view-version")
   @JsonSerialize(as = ImmutableSetCurrentViewVersion.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableSetCurrentViewVersion.class)
   @JsonDeserialize(as = ImmutableSetCurrentViewVersion.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableSetCurrentViewVersion.class)
   interface SetCurrentViewVersion extends IcebergMetadataUpdate {
 
     long viewVersionId();
@@ -245,7 +257,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("set-statistics")
   @JsonSerialize(as = ImmutableSetStatistics.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableSetStatistics.class)
   @JsonDeserialize(as = ImmutableSetStatistics.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableSetStatistics.class)
   interface SetStatistics extends IcebergMetadataUpdate {
 
     // Becomes deprecated w/ Iceberg 1.8, see https://github.com/apache/iceberg/pull/12010
@@ -266,7 +280,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("remove-statistics")
   @JsonSerialize(as = ImmutableRemoveStatistics.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableRemoveStatistics.class)
   @JsonDeserialize(as = ImmutableRemoveStatistics.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableRemoveStatistics.class)
   interface RemoveStatistics extends IcebergMetadataUpdate {
 
     long snapshotId();
@@ -284,7 +300,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("set-partition-statistics")
   @JsonSerialize(as = ImmutableSetPartitionStatistics.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableSetPartitionStatistics.class)
   @JsonDeserialize(as = ImmutableSetPartitionStatistics.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableSetPartitionStatistics.class)
   interface SetPartitionStatistics extends IcebergMetadataUpdate {
 
     IcebergPartitionStatisticsFile partitionStatistics();
@@ -307,7 +325,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("remove-partition-statistics")
   @JsonSerialize(as = ImmutableRemovePartitionStatistics.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableRemovePartitionStatistics.class)
   @JsonDeserialize(as = ImmutableRemovePartitionStatistics.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableRemovePartitionStatistics.class)
   interface RemovePartitionStatistics extends IcebergMetadataUpdate {
     long snapshotId();
 
@@ -324,7 +344,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("assign-uuid")
   @JsonSerialize(as = ImmutableAssignUUID.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableAssignUUID.class)
   @JsonDeserialize(as = ImmutableAssignUUID.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableAssignUUID.class)
   interface AssignUUID extends IcebergMetadataUpdate {
     String uuid();
 
@@ -348,7 +370,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("add-schema")
   @JsonSerialize(as = ImmutableAddSchema.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableAddSchema.class)
   @JsonDeserialize(as = ImmutableAddSchema.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableAddSchema.class)
   interface AddSchema extends IcebergMetadataUpdate {
     IcebergSchema schema();
 
@@ -374,7 +398,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("remove-schemas")
   @JsonSerialize(as = ImmutableRemoveSchemas.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableRemoveSchemas.class)
   @JsonDeserialize(as = ImmutableRemoveSchemas.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableRemoveSchemas.class)
   interface RemoveSchemas extends IcebergMetadataUpdate {
     Set<Integer> schemaIds();
 
@@ -399,7 +425,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("set-current-schema")
   @JsonSerialize(as = ImmutableSetCurrentSchema.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableSetCurrentSchema.class)
   @JsonDeserialize(as = ImmutableSetCurrentSchema.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableSetCurrentSchema.class)
   interface SetCurrentSchema extends IcebergMetadataUpdate {
     /** ID of the schema to become the current one or {@code -1} to use the last added schema. */
     int schemaId();
@@ -426,7 +454,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("add-spec")
   @JsonSerialize(as = ImmutableAddPartitionSpec.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableAddPartitionSpec.class)
   @JsonDeserialize(as = ImmutableAddPartitionSpec.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableAddPartitionSpec.class)
   interface AddPartitionSpec extends IcebergMetadataUpdate {
     IcebergPartitionSpec spec();
 
@@ -450,7 +480,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("remove-partition-specs")
   @JsonSerialize(as = ImmutableRemovePartitionSpecs.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableRemovePartitionSpecs.class)
   @JsonDeserialize(as = ImmutableRemovePartitionSpecs.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableRemovePartitionSpecs.class)
   interface RemovePartitionSpecs extends IcebergMetadataUpdate {
     List<Integer> specIds();
 
@@ -474,7 +506,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("set-default-spec")
   @JsonSerialize(as = ImmutableSetDefaultPartitionSpec.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableSetDefaultPartitionSpec.class)
   @JsonDeserialize(as = ImmutableSetDefaultPartitionSpec.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableSetDefaultPartitionSpec.class)
   interface SetDefaultPartitionSpec extends IcebergMetadataUpdate {
     /**
      * ID of the partition spec to become the current one or {@code -1} to use the last added
@@ -496,7 +530,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("add-snapshot")
   @JsonSerialize(as = ImmutableAddSnapshot.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableAddSnapshot.class)
   @JsonDeserialize(as = ImmutableAddSnapshot.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableAddSnapshot.class)
   interface AddSnapshot extends IcebergMetadataUpdate {
     IcebergSnapshot snapshot();
 
@@ -583,7 +619,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("add-sort-order")
   @JsonSerialize(as = ImmutableAddSortOrder.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableAddSortOrder.class)
   @JsonDeserialize(as = ImmutableAddSortOrder.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableAddSortOrder.class)
   interface AddSortOrder extends IcebergMetadataUpdate {
     IcebergSortOrder sortOrder();
 
@@ -612,7 +650,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("set-default-sort-order")
   @JsonSerialize(as = ImmutableSetDefaultSortOrder.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableSetDefaultSortOrder.class)
   @JsonDeserialize(as = ImmutableSetDefaultSortOrder.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableSetDefaultSortOrder.class)
   interface SetDefaultSortOrder extends IcebergMetadataUpdate {
 
     /**
@@ -635,7 +675,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("set-location")
   @JsonSerialize(as = ImmutableSetLocation.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableSetLocation.class)
   @JsonDeserialize(as = ImmutableSetLocation.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableSetLocation.class)
   interface SetLocation extends IcebergMetadataUpdate {
     String location();
 
@@ -669,7 +711,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("set-properties")
   @JsonSerialize(as = ImmutableSetProperties.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableSetProperties.class)
   @JsonDeserialize(as = ImmutableSetProperties.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableSetProperties.class)
   interface SetProperties extends IcebergMetadataUpdate {
     @JsonAlias({"updates", "updated"})
     Map<String, String> updates();
@@ -700,7 +744,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("set-snapshot-ref")
   @JsonSerialize(as = ImmutableSetSnapshotRef.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableSetSnapshotRef.class)
   @JsonDeserialize(as = ImmutableSetSnapshotRef.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableSetSnapshotRef.class)
   interface SetSnapshotRef extends IcebergMetadataUpdate {
     String refName();
 
@@ -740,7 +786,9 @@ public interface IcebergMetadataUpdate {
   @NessieImmutable
   @JsonTypeName("remove-snapshot-ref")
   @JsonSerialize(as = ImmutableRemoveSnapshotRef.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableRemoveSnapshotRef.class)
   @JsonDeserialize(as = ImmutableRemoveSnapshotRef.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableRemoveSnapshotRef.class)
   interface RemoveSnapshotRef extends IcebergMetadataUpdate {
 
     String refName();

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergRegisterTableRequest.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergRegisterTableRequest.java
@@ -24,8 +24,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergRegisterTableRequest.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergRegisterTableRequest.class)
 @JsonDeserialize(as = ImmutableIcebergRegisterTableRequest.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergRegisterTableRequest.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergRegisterTableRequest {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergRenameTableRequest.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergRenameTableRequest.java
@@ -25,8 +25,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergRenameTableRequest.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergRenameTableRequest.class)
 @JsonDeserialize(as = ImmutableIcebergRenameTableRequest.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergRenameTableRequest.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergRenameTableRequest {
   IcebergTableIdentifier source();

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergS3SignRequest.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergS3SignRequest.java
@@ -29,8 +29,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergS3SignRequest.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergS3SignRequest.class)
 @JsonDeserialize(as = ImmutableIcebergS3SignRequest.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergS3SignRequest.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergS3SignRequest {
   String region();

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergS3SignResponse.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergS3SignResponse.java
@@ -27,8 +27,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergS3SignResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergS3SignResponse.class)
 @JsonDeserialize(as = ImmutableIcebergS3SignResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergS3SignResponse.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergS3SignResponse {
   String uri();

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergStorageCredential.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergStorageCredential.java
@@ -25,8 +25,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergStorageCredential.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergStorageCredential.class)
 @JsonDeserialize(as = ImmutableIcebergStorageCredential.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergStorageCredential.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergStorageCredential {
   /**

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergUpdateNamespacePropertiesRequest.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergUpdateNamespacePropertiesRequest.java
@@ -26,8 +26,14 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergUpdateNamespacePropertiesRequest.class)
+@tools.jackson.databind.annotation.JsonSerialize(
+    as = ImmutableIcebergUpdateNamespacePropertiesRequest.class)
 @JsonDeserialize(as = ImmutableIcebergUpdateNamespacePropertiesRequest.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    as = ImmutableIcebergUpdateNamespacePropertiesRequest.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergUpdateNamespacePropertiesRequest {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergUpdateNamespacePropertiesResponse.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergUpdateNamespacePropertiesResponse.java
@@ -26,8 +26,14 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergUpdateNamespacePropertiesResponse.class)
+@tools.jackson.databind.annotation.JsonSerialize(
+    as = ImmutableIcebergUpdateNamespacePropertiesResponse.class)
 @JsonDeserialize(as = ImmutableIcebergUpdateNamespacePropertiesResponse.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    as = ImmutableIcebergUpdateNamespacePropertiesResponse.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergUpdateNamespacePropertiesResponse {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergUpdateRequirement.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergUpdateRequirement.java
@@ -40,6 +40,8 @@ import org.projectnessie.model.ContentKey;
 import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
@@ -112,7 +114,9 @@ public interface IcebergUpdateRequirement {
   @NessieImmutable
   @JsonTypeName("assert-table-uuid")
   @JsonSerialize(as = ImmutableAssertTableUUID.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableAssertTableUUID.class)
   @JsonDeserialize(as = ImmutableAssertTableUUID.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableAssertTableUUID.class)
   interface AssertTableUUID extends AssertUUID {
 
     @Override
@@ -125,7 +129,9 @@ public interface IcebergUpdateRequirement {
   @NessieImmutable
   @JsonTypeName("assert-view-uuid")
   @JsonSerialize(as = ImmutableAssertViewUUID.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableAssertViewUUID.class)
   @JsonDeserialize(as = ImmutableAssertViewUUID.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableAssertViewUUID.class)
   interface AssertViewUUID extends AssertUUID {
 
     @Override
@@ -138,7 +144,9 @@ public interface IcebergUpdateRequirement {
   @NessieImmutable
   @JsonTypeName("assert-create")
   @JsonSerialize(as = ImmutableAssertCreate.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableAssertCreate.class)
   @JsonDeserialize(as = ImmutableAssertCreate.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableAssertCreate.class)
   interface AssertCreate extends IcebergUpdateRequirement {
     static AssertCreate assertTableDoesNotExist() {
       return ImmutableAssertCreate.builder().build();
@@ -165,7 +173,9 @@ public interface IcebergUpdateRequirement {
   @NessieImmutable
   @JsonTypeName("assert-ref-snapshot-id")
   @JsonSerialize(as = ImmutableAssertRefSnapshotId.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableAssertRefSnapshotId.class)
   @JsonDeserialize(as = ImmutableAssertRefSnapshotId.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableAssertRefSnapshotId.class)
   interface AssertRefSnapshotId extends IcebergUpdateRequirement {
     String ref();
 
@@ -206,7 +216,9 @@ public interface IcebergUpdateRequirement {
   @NessieImmutable
   @JsonTypeName("assert-last-assigned-field-id")
   @JsonSerialize(as = ImmutableAssertLastAssignedFieldId.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableAssertLastAssignedFieldId.class)
   @JsonDeserialize(as = ImmutableAssertLastAssignedFieldId.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableAssertLastAssignedFieldId.class)
   interface AssertLastAssignedFieldId extends IcebergUpdateRequirement {
     int lastAssignedFieldId();
 
@@ -226,7 +238,9 @@ public interface IcebergUpdateRequirement {
   @NessieImmutable
   @JsonTypeName("assert-current-schema-id")
   @JsonSerialize(as = ImmutableAssertCurrentSchemaId.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableAssertCurrentSchemaId.class)
   @JsonDeserialize(as = ImmutableAssertCurrentSchemaId.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableAssertCurrentSchemaId.class)
   interface AssertCurrentSchemaId extends IcebergUpdateRequirement {
     int currentSchemaId();
 
@@ -256,7 +270,11 @@ public interface IcebergUpdateRequirement {
   @NessieImmutable
   @JsonTypeName("assert-last-assigned-partition-id")
   @JsonSerialize(as = ImmutableAssertLastAssignedPartitionId.class)
+  @tools.jackson.databind.annotation.JsonSerialize(
+      as = ImmutableAssertLastAssignedPartitionId.class)
   @JsonDeserialize(as = ImmutableAssertLastAssignedPartitionId.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(
+      as = ImmutableAssertLastAssignedPartitionId.class)
   interface AssertLastAssignedPartitionId extends IcebergUpdateRequirement {
     int lastAssignedPartitionId();
 
@@ -276,7 +294,9 @@ public interface IcebergUpdateRequirement {
   @NessieImmutable
   @JsonTypeName("assert-default-spec-id")
   @JsonSerialize(as = ImmutableAssertDefaultSpecId.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableAssertDefaultSpecId.class)
   @JsonDeserialize(as = ImmutableAssertDefaultSpecId.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableAssertDefaultSpecId.class)
   interface AssertDefaultSpecId extends IcebergUpdateRequirement {
     int defaultSpecId();
 
@@ -300,7 +320,9 @@ public interface IcebergUpdateRequirement {
   @NessieImmutable
   @JsonTypeName("assert-default-sort-order-id")
   @JsonSerialize(as = ImmutableAssertDefaultSortOrderId.class)
+  @tools.jackson.databind.annotation.JsonSerialize(as = ImmutableAssertDefaultSortOrderId.class)
   @JsonDeserialize(as = ImmutableAssertDefaultSortOrderId.class)
+  @tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableAssertDefaultSortOrderId.class)
   interface AssertDefaultSortOrderId extends IcebergUpdateRequirement {
     int defaultSortOrderId();
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergUpdateTableRequest.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergUpdateTableRequest.java
@@ -27,8 +27,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergUpdateTableRequest.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergUpdateTableRequest.class)
 @JsonDeserialize(as = ImmutableIcebergUpdateTableRequest.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergUpdateTableRequest.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergUpdateTableRequest extends IcebergUpdateEntityRequest {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergListType.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergListType.java
@@ -30,8 +30,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergListType.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergListType.class)
 @JsonDeserialize(as = ImmutableIcebergListType.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergListType.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName(IcebergListType.TYPE_NAME)
 public interface IcebergListType extends IcebergComplexType {

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergMapType.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergMapType.java
@@ -33,8 +33,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergMapType.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergMapType.class)
 @JsonDeserialize(as = ImmutableIcebergMapType.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergMapType.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName(IcebergMapType.TYPE_NAME)
 public interface IcebergMapType extends IcebergComplexType {

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergPrimitiveType.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergPrimitiveType.java
@@ -25,8 +25,17 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
     as = String.class,
     using = IcebergTypes.IcebergPrimitiveSerializer.class,
     typing = JsonSerialize.Typing.DYNAMIC)
+@tools.jackson.databind.annotation.JsonSerialize(
+    as = String.class,
+    using = IcebergTypes.IcebergPrimitiveSerializer3.class,
+    typing = tools.jackson.databind.annotation.JsonSerialize.Typing.DYNAMIC)
 @JsonDeserialize(as = String.class, using = IcebergTypes.IcebergPrimitiveDeserializer.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    as = String.class,
+    using = IcebergTypes.IcebergPrimitiveDeserializer3.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class IcebergPrimitiveType implements IcebergType {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergStructType.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergStructType.java
@@ -36,8 +36,12 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 
 @NessieImmutable
 @JsonSerialize(as = ImmutableIcebergStructType.class)
+@tools.jackson.databind.annotation.JsonSerialize(as = ImmutableIcebergStructType.class)
 @JsonDeserialize(as = ImmutableIcebergStructType.class)
+@tools.jackson.databind.annotation.JsonDeserialize(as = ImmutableIcebergStructType.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName(IcebergStructType.TYPE_NAME)
 public interface IcebergStructType extends IcebergComplexType {

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergType.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergType.java
@@ -26,8 +26,13 @@ import org.apache.avro.Schema;
 import org.projectnessie.catalog.formats.iceberg.meta.IcebergNestedField;
 
 @JsonSerialize(using = IcebergTypes.IcebergTypeSerializer.class)
+@tools.jackson.databind.annotation.JsonSerialize(using = IcebergTypes.IcebergTypeSerializer3.class)
 @JsonDeserialize(using = IcebergTypes.IcebergTypeDeserializer.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    using = IcebergTypes.IcebergTypeDeserializer3.class)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface IcebergType {
 

--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergTypes.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/types/IcebergTypes.java
@@ -140,4 +140,56 @@ final class IcebergTypes {
       }
     }
   }
+
+  static final class IcebergPrimitiveSerializer3
+      extends tools.jackson.databind.ValueSerializer<IcebergPrimitiveType> {
+    @Override
+    public void serialize(
+        IcebergPrimitiveType value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers)
+        throws tools.jackson.core.JacksonException {
+      gen.writeString(value.type());
+    }
+  }
+
+  static final class IcebergPrimitiveDeserializer3
+      extends tools.jackson.databind.ValueDeserializer<IcebergPrimitiveType> {
+    @Override
+    public IcebergPrimitiveType deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+        throws tools.jackson.core.JacksonException {
+      return primitiveFromString(p.getValueAsString());
+    }
+  }
+
+  static final class IcebergTypeDeserializer3
+      extends tools.jackson.databind.ValueDeserializer<IcebergType> {
+    @Override
+    public IcebergType deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt)
+        throws tools.jackson.core.JacksonException {
+      return switch (p.currentToken()) {
+        case VALUE_STRING -> primitiveFromString(p.getValueAsString());
+        case START_OBJECT -> p.readValueAs(IcebergComplexType.class);
+        default -> throw new IllegalArgumentException("unexpected token " + p.currentToken());
+      };
+    }
+  }
+
+  static final class IcebergTypeSerializer3
+      extends tools.jackson.databind.ValueSerializer<IcebergType> {
+    @Override
+    public void serialize(
+        IcebergType value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers)
+        throws tools.jackson.core.JacksonException {
+      if (value instanceof IcebergPrimitiveType) {
+        gen.writeString(value.type());
+      } else {
+        gen.writePOJO(value);
+      }
+    }
+  }
 }

--- a/catalog/format/iceberg/src/testJackson3/java/org/projectnessie/catalog/formats/iceberg/TestJackson3IcebergCompatibility.java
+++ b/catalog/format/iceberg/src/testJackson3/java/org/projectnessie/catalog/formats/iceberg/TestJackson3IcebergCompatibility.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2026 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.formats.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.projectnessie.catalog.formats.iceberg.meta.IcebergNestedField.nestedField;
+import static org.projectnessie.catalog.formats.iceberg.meta.IcebergPartitionField.partitionField;
+import static org.projectnessie.catalog.formats.iceberg.meta.IcebergPartitionSpec.partitionSpec;
+import static org.projectnessie.catalog.formats.iceberg.meta.IcebergSortField.sortField;
+import static org.projectnessie.catalog.formats.iceberg.meta.IcebergSortOrder.sortOrder;
+import static org.projectnessie.catalog.formats.iceberg.types.IcebergType.fixedType;
+import static org.projectnessie.catalog.formats.iceberg.types.IcebergType.listType;
+import static org.projectnessie.catalog.formats.iceberg.types.IcebergType.longType;
+import static org.projectnessie.catalog.formats.iceberg.types.IcebergType.stringType;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.catalog.formats.iceberg.meta.IcebergNamespace;
+import org.projectnessie.catalog.formats.iceberg.meta.IcebergSchema;
+import org.projectnessie.catalog.formats.iceberg.meta.IcebergTableIdentifier;
+import org.projectnessie.catalog.formats.iceberg.meta.IcebergTableMetadata;
+import org.projectnessie.catalog.formats.iceberg.metrics.IcebergCommitReport;
+import org.projectnessie.catalog.formats.iceberg.metrics.IcebergMetricsReport;
+import org.projectnessie.catalog.formats.iceberg.rest.IcebergConfigResponse;
+import org.projectnessie.catalog.formats.iceberg.rest.IcebergCreateNamespaceRequest;
+import org.projectnessie.catalog.formats.iceberg.rest.IcebergEndpoint;
+import org.projectnessie.catalog.formats.iceberg.rest.IcebergMetadataUpdate;
+import org.projectnessie.catalog.formats.iceberg.rest.IcebergUpdateRequirement;
+import org.projectnessie.catalog.formats.iceberg.rest.IcebergUpdateTableRequest;
+import org.projectnessie.catalog.model.schema.NessieNullOrder;
+import org.projectnessie.catalog.model.schema.NessieSortDirection;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+class TestJackson3IcebergCompatibility {
+  private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+
+  private static IcebergSchema schema() {
+    return IcebergSchema.schema(
+        42,
+        List.of(1),
+        List.of(
+            nestedField(1, "id", true, longType(), null),
+            nestedField(2, "tags", false, listType(3, stringType(), true), "tag list"),
+            nestedField(4, "fixed", true, fixedType(16), null)));
+  }
+
+  @Test
+  void icebergTypesRoundTrip() throws Exception {
+    assertThat(MAPPER.writeValueAsString(longType())).isEqualTo("\"long\"");
+    assertThat(
+            MAPPER.readValue(
+                "\"long\"", org.projectnessie.catalog.formats.iceberg.types.IcebergType.class))
+        .isEqualTo(longType());
+
+    var listType = listType(44, stringType(), true);
+    String json = MAPPER.writeValueAsString(listType);
+    assertThat(MAPPER.readValue(json, JsonNode.class).get("element-id").intValue()).isEqualTo(44);
+    assertThat(
+            MAPPER.readValue(
+                json, org.projectnessie.catalog.formats.iceberg.types.IcebergType.class))
+        .isEqualTo(listType);
+  }
+
+  @Test
+  void metadataRoundTrip() throws Exception {
+    IcebergTableMetadata metadata =
+        IcebergTableMetadata.builder()
+            .formatVersion(2)
+            .tableUuid("table-uuid")
+            .location("file:///warehouse/ns/table")
+            .lastSequenceNumber(7L)
+            .lastUpdatedMs(123L)
+            .lastColumnId(4)
+            .currentSchemaId(42)
+            .defaultSpecId(3)
+            .lastPartitionId(1000)
+            .defaultSortOrderId(2)
+            .addSchema(schema())
+            .addPartitionSpec(
+                partitionSpec(3, List.of(partitionField("id_bucket", "bucket[16]", 1, 1000))))
+            .addSortOrder(
+                sortOrder(
+                    2,
+                    List.of(
+                        sortField(
+                            "identity", 1, NessieSortDirection.ASC, NessieNullOrder.NULLS_FIRST))))
+            .putProperty("owner", "nessie")
+            .build();
+
+    String json = MAPPER.writeValueAsString(metadata);
+    JsonNode node = MAPPER.readValue(json, JsonNode.class);
+    assertThat(node.get("format-version").intValue()).isEqualTo(2);
+    assertThat(node.get("last-sequence-number").longValue()).isEqualTo(7L);
+    assertThat(
+            node.get("schemas").get(0).get("fields").get(1).get("type").get("element").asString())
+        .isEqualTo("string");
+
+    assertThat(MAPPER.readValue(json, IcebergTableMetadata.class)).isEqualTo(metadata);
+  }
+
+  @Test
+  void restPayloadsRoundTrip() throws Exception {
+    IcebergConfigResponse config =
+        IcebergConfigResponse.builder()
+            .putDefault("warehouse", "s3://bucket")
+            .putOverride("client.region", "eu-central-1")
+            .addEndpoint(IcebergEndpoint.icebergEndpoint("GET", "/v1/config"))
+            .build();
+
+    String configJson = MAPPER.writeValueAsString(config);
+    JsonNode configNode = MAPPER.readValue(configJson, JsonNode.class);
+    assertThat(configNode.get("endpoints").get(0).asString()).isEqualTo("GET /v1/config");
+    assertThat(MAPPER.readValue(configJson, IcebergConfigResponse.class)).isEqualTo(config);
+
+    IcebergCreateNamespaceRequest createNamespace =
+        IcebergCreateNamespaceRequest.builder()
+            .namespace(IcebergNamespace.icebergNamespace(List.of("a", "b")))
+            .putProperty("owner", "nessie")
+            .build();
+    String namespaceJson = MAPPER.writeValueAsString(createNamespace);
+    assertThat(MAPPER.readValue(namespaceJson, JsonNode.class).get("namespace").get(0).asString())
+        .isEqualTo("a");
+    assertThat(MAPPER.readValue(namespaceJson, IcebergCreateNamespaceRequest.class))
+        .isEqualTo(createNamespace);
+  }
+
+  @Test
+  void metadataUpdateAndRequirementPolymorphism() throws Exception {
+    String updateJson = "{\"action\":\"assign-uuid\",\"uuid\":\"table-uuid\"}";
+    IcebergMetadataUpdate update = MAPPER.readValue(updateJson, IcebergMetadataUpdate.class);
+    assertThat(update).isInstanceOf(IcebergMetadataUpdate.AssignUUID.class);
+    assertThat(
+            MAPPER
+                .readValue(MAPPER.writeValueAsString(update), JsonNode.class)
+                .get("action")
+                .asString())
+        .isEqualTo("assign-uuid");
+
+    String requirementJson = "{\"type\":\"assert-table-uuid\",\"uuid\":\"table-uuid\"}";
+    IcebergUpdateRequirement requirement =
+        MAPPER.readValue(requirementJson, IcebergUpdateRequirement.class);
+    assertThat(requirement).isInstanceOf(IcebergUpdateRequirement.AssertTableUUID.class);
+    assertThat(
+            MAPPER
+                .readValue(MAPPER.writeValueAsString(requirement), JsonNode.class)
+                .get("type")
+                .asString())
+        .isEqualTo("assert-table-uuid");
+
+    IcebergUpdateTableRequest request =
+        IcebergUpdateTableRequest.builder()
+            .identifier(
+                IcebergTableIdentifier.icebergTableIdentifier(
+                    IcebergNamespace.icebergNamespace(List.of("ns")), "table"))
+            .addRequirement(requirement)
+            .addUpdate(update)
+            .build();
+    assertThat(
+            MAPPER.readValue(MAPPER.writeValueAsString(request), IcebergUpdateTableRequest.class))
+        .isEqualTo(request);
+  }
+
+  @Test
+  void metricsRoundTrip() throws Exception {
+    String json =
+        """
+        {
+          "report-type": "commit-report",
+          "table-name": "ns.table",
+          "snapshot-id": 12,
+          "sequence-number": 3,
+          "operation": "append",
+          "metrics": {
+            "total-duration": {
+              "count": 1,
+              "time-unit": "nanoseconds",
+              "total-duration": 42
+            },
+            "added-records": {
+              "unit": "count",
+              "value": 2
+            }
+          },
+          "metadata": {
+            "iceberg-version": "test"
+          }
+        }
+        """;
+
+    IcebergMetricsReport deserialized = MAPPER.readValue(json, IcebergMetricsReport.class);
+    assertThat(deserialized).isInstanceOf(IcebergCommitReport.class);
+    IcebergCommitReport report = (IcebergCommitReport) deserialized;
+    assertThat(report.metrics().totalDuration().timeUnit()).isEqualTo(TimeUnit.NANOSECONDS);
+
+    json = MAPPER.writeValueAsString(report);
+    JsonNode node = MAPPER.readValue(json, JsonNode.class);
+    assertThat(node.get("report-type").asString()).isEqualTo("commit-report");
+    assertThat(node.get("metrics").get("total-duration").get("time-unit").asString())
+        .isEqualTo("nanoseconds");
+
+    assertThat(MAPPER.readValue(json, IcebergMetricsReport.class)).isEqualTo(report);
+  }
+}

--- a/catalog/model/build.gradle.kts
+++ b/catalog/model/build.gradle.kts
@@ -37,6 +37,12 @@ dependencies {
   implementation("com.fasterxml.jackson.core:jackson-annotations")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-guava")
 
+  compileOnly(platform(libs.jackson3.bom))
+  compileOnly("tools.jackson.core:jackson-core")
+  compileOnly("tools.jackson.core:jackson-databind")
+  runtimeOnly(platform(libs.jackson3.bom))
+  runtimeOnly("tools.jackson.core:jackson-databind")
+
   compileOnly(libs.jakarta.ws.rs.api)
   compileOnly(libs.jakarta.enterprise.cdi.api)
   compileOnly(libs.jakarta.validation.api)

--- a/catalog/model/src/main/java/org/projectnessie/catalog/model/schema/NessieNullOrder.java
+++ b/catalog/model/src/main/java/org/projectnessie/catalog/model/schema/NessieNullOrder.java
@@ -29,6 +29,10 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 @NessieImmutable
 @JsonSerialize(using = NessieNullOrder.NessieNullOrderSerializer.class)
 @JsonDeserialize(using = NessieNullOrder.NessieNullOrderDeserializer.class)
+@tools.jackson.databind.annotation.JsonSerialize(
+    using = NessieNullOrder.NessieNullOrderSerializer3.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    using = NessieNullOrder.NessieNullOrderDeserializer3.class)
 public interface NessieNullOrder {
   String name();
 
@@ -52,6 +56,30 @@ public interface NessieNullOrder {
     public NessieNullOrder deserialize(JsonParser p, DeserializationContext ctxt)
         throws IOException {
       String text = p.getText();
+      return switch (text) {
+        case NULLS_FIRST_VALUE -> NULLS_FIRST;
+        case NULLS_LAST_VALUE -> NULLS_LAST;
+        default -> ImmutableNessieNullOrder.of(text, text);
+      };
+    }
+  }
+
+  class NessieNullOrderSerializer3 extends tools.jackson.databind.ValueSerializer<NessieNullOrder> {
+    @Override
+    public void serialize(
+        NessieNullOrder value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers) {
+      gen.writeString(value.jsonValue());
+    }
+  }
+
+  class NessieNullOrderDeserializer3
+      extends tools.jackson.databind.ValueDeserializer<NessieNullOrder> {
+    @Override
+    public NessieNullOrder deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt) {
+      String text = p.getString();
       return switch (text) {
         case NULLS_FIRST_VALUE -> NULLS_FIRST;
         case NULLS_LAST_VALUE -> NULLS_LAST;

--- a/catalog/model/src/main/java/org/projectnessie/catalog/model/schema/NessieSortDirection.java
+++ b/catalog/model/src/main/java/org/projectnessie/catalog/model/schema/NessieSortDirection.java
@@ -29,6 +29,10 @@ import org.projectnessie.nessie.immutables.NessieImmutable;
 @NessieImmutable
 @JsonSerialize(using = NessieSortDirection.NessieSortDirectionSerializer.class)
 @JsonDeserialize(using = NessieSortDirection.NessieSortDirectionDeserializer.class)
+@tools.jackson.databind.annotation.JsonSerialize(
+    using = NessieSortDirection.NessieSortDirectionSerializer3.class)
+@tools.jackson.databind.annotation.JsonDeserialize(
+    using = NessieSortDirection.NessieSortDirectionDeserializer3.class)
 public interface NessieSortDirection {
   String name();
 
@@ -53,6 +57,31 @@ public interface NessieSortDirection {
     public NessieSortDirection deserialize(JsonParser p, DeserializationContext ctxt)
         throws IOException {
       String text = p.getText();
+      return switch (text) {
+        case ASC_VALUE -> ASC;
+        case DESC_VALUE -> DESC;
+        default -> ImmutableNessieSortDirection.of(text, text);
+      };
+    }
+  }
+
+  class NessieSortDirectionSerializer3
+      extends tools.jackson.databind.ValueSerializer<NessieSortDirection> {
+    @Override
+    public void serialize(
+        NessieSortDirection value,
+        tools.jackson.core.JsonGenerator gen,
+        tools.jackson.databind.SerializationContext serializers) {
+      gen.writeString(value.jsonValue());
+    }
+  }
+
+  class NessieSortDirectionDeserializer3
+      extends tools.jackson.databind.ValueDeserializer<NessieSortDirection> {
+    @Override
+    public NessieSortDirection deserialize(
+        tools.jackson.core.JsonParser p, tools.jackson.databind.DeserializationContext ctxt) {
+      String text = p.getString();
       return switch (text) {
         case ASC_VALUE -> ASC;
         case DESC_VALUE -> DESC;

--- a/gradle/built-uber-dists/LICENSE-BINARY-DIST
+++ b/gradle/built-uber-dists/LICENSE-BINARY-DIST
@@ -706,6 +706,8 @@ software.amazon.awssdk:url-connection-client
 software.amazon.awssdk:utils
 software.amazon.awssdk:utils-lite
 software.amazon.eventstream:eventstream
+tools.jackson.core:jackson-core
+tools.jackson.core:jackson-databind
 
 ---
 


### PR DESCRIPTION
This change adds support for Jackson 3, so API facing types can be (de)serialized with both Jackson 2 and Jackson 3.