### PR TITLE
Fix missing '/' in readonly S3 resource ARN in credential vending

### DIFF
--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3IamPolicies.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3IamPolicies.java
@@ -117,7 +117,7 @@ final class S3IamPolicies {
       for (StorageUri location : readonly) {
         String bucket = iamEscapeString(location.requiredAuthority());
         String path = iamEscapeString(location.pathWithoutLeadingTrailingSlash());
-        resources.add(format("arn:aws:s3:::%s%s/*", bucket, path));
+        resources.add(format("arn:aws:s3:::%s/%s/*", bucket, path));
         // For write.object-storage.enabled=true / before Iceberg 1.7.0
         resources.add(format("arn:aws:s3:::%s/*/%s/*", bucket, path));
         // For write.object-storage.enabled=true / since Iceberg 1.7.0

--- a/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/s3/TestS3IamPolicies.java
+++ b/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/s3/TestS3IamPolicies.java
@@ -116,7 +116,7 @@ class TestS3IamPolicies {
               }, {
                 "Effect" : "Allow",
                 "Action" : [ "s3:GetObject", "s3:GetObjectVersion" ],
-                "Resource" : [ "arn:aws:s3:::bucket3read/path/bar/*", "arn:aws:s3:::bucket3/*/read/path/bar/*", "arn:aws:s3:::bucket3/*/*/*/*/read/path/bar/*", "arn:aws:s3:::bucket4read/other/bar/*", "arn:aws:s3:::bucket4/*/read/other/bar/*", "arn:aws:s3:::bucket4/*/*/*/*/read/other/bar/*" ]
+                "Resource" : [ "arn:aws:s3:::bucket3/read/path/bar/*", "arn:aws:s3:::bucket3/*/read/path/bar/*", "arn:aws:s3:::bucket3/*/*/*/*/read/path/bar/*", "arn:aws:s3:::bucket4/read/other/bar/*", "arn:aws:s3:::bucket4/*/read/other/bar/*", "arn:aws:s3:::bucket4/*/*/*/*/read/other/bar/*" ]
               }, {
                 "Effect" : "Deny",
                 "Action" : "s3:*",


### PR DESCRIPTION
Fixes #12703

## Summary

The readonly resource ARN format string in `S3IamPolicies.java` (line ~120) is missing a `/` between the bucket name and path:

```java
// Writeable (correct, line ~100):
resources.add(format("arn:aws:s3:::%s/%s/*", bucket, path));

// Readonly (broken, line ~120):
resources.add(format("arn:aws:s3:::%s%s/*", bucket, path));
```

`StorageUri.pathWithoutLeadingTrailingSlash()` strips the leading `/`, so the readonly ARN becomes `arn:aws:s3:::my-bucketpath/...` instead of `arn:aws:s3:::my-bucket/path/...`. The malformed ARN matches no real S3 objects, so the inline STS session policy is effectively empty — making credential vending completely broken for any user without write access.

## Impact

Every Iceberg REST client (pyiceberg, Spark, Trino, Flink, DuckDB) connecting to a Nessie deployment with S3 client-IAM credential vending enabled is affected when the user's RBAC role lacks `UPDATE_ENTITY`. pyiceberg sends `X-Iceberg-Access-Delegation: vended-credentials` by default, so the broken vended creds override any locally configured AWS credentials.

Users with write access are unaffected — their locations go through the `writeable` set (line ~100) which has the correct format string.

## Fix

One-character change — add the missing `/` to match the writeable format string.

Likely introduced in 547637b (Nov 2024, "Adopt IAM policies to new object-storage layout").