### PR TITLE
Build: add missing junit-bom platform notions

### DIFF
--- a/catalog/format/iceberg-bench/build.gradle.kts
+++ b/catalog/format/iceberg-bench/build.gradle.kts
@@ -45,6 +45,8 @@ dependencies {
 
   jmhImplementation(libs.guava)
   jmhImplementation(libs.avro)
+
+  implementation(platform(libs.junit.bom))
 }
 
 jmh { jmhVersion.set(libs.versions.jmh.get()) }

--- a/servers/jax-rs-tests/build.gradle.kts
+++ b/servers/jax-rs-tests/build.gradle.kts
@@ -52,5 +52,6 @@ dependencies {
 
   testCompileOnly(libs.microprofile.openapi)
 
+  testImplementation(platform(libs.junit.bom))
   testImplementation(libs.bundles.junit.testing)
 }

--- a/testing/azurite-container/build.gradle.kts
+++ b/testing/azurite-container/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
   compileOnly(platform(libs.junit.bom))
   compileOnly("org.junit.jupiter:junit-jupiter-api")
 
+  intTestImplementation(platform(libs.junit.bom))
   intTestImplementation(libs.bundles.junit.testing)
   intTestRuntimeOnly(libs.logback.classic)
 }

--- a/testing/container-spec-helper/build.gradle.kts
+++ b/testing/container-spec-helper/build.gradle.kts
@@ -26,5 +26,6 @@ dependencies {
   compileOnly(project(":nessie-immutables-std"))
   annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
 
+  testImplementation(platform(libs.junit.bom))
   testImplementation(libs.bundles.junit.testing)
 }

--- a/testing/gcs-container/build.gradle.kts
+++ b/testing/gcs-container/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
   compileOnly(platform(libs.junit.bom))
   compileOnly("org.junit.jupiter:junit-jupiter-api")
 
+  intTestImplementation(platform(libs.junit.bom))
   intTestImplementation(libs.bundles.junit.testing)
   intTestRuntimeOnly(libs.logback.classic)
 }

--- a/testing/minio-container/build.gradle.kts
+++ b/testing/minio-container/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 
   compileOnly(libs.errorprone.annotations)
 
+  intTestImplementation(platform(libs.junit.bom))
   intTestImplementation(libs.bundles.junit.testing)
   intTestRuntimeOnly(libs.logback.classic)
 }

--- a/testing/trino-container/build.gradle.kts
+++ b/testing/trino-container/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
   compileOnly(libs.errorprone.annotations)
   compileOnly(project(":nessie-immutables-std"))
 
+  intTestImplementation(platform(libs.junit.bom))
   intTestImplementation(libs.bundles.junit.testing)
   intTestRuntimeOnly(libs.logback.classic)
 }

--- a/versioned/combined-cs/build.gradle.kts
+++ b/versioned/combined-cs/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
 
   testCompileOnly(libs.microprofile.openapi)
 
+  testImplementation(platform(libs.junit.bom))
   testImplementation(libs.bundles.junit.testing)
   testImplementation(project(":nessie-client-testextension"))
   testCompileOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/versioned/storage/store/build.gradle.kts
+++ b/versioned/storage/store/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
   testImplementation(project(":nessie-versioned-storage-inmemory"))
   testImplementation(project(":nessie-versioned-storage-testextension"))
   testImplementation(project(":nessie-versioned-tests"))
+  testImplementation(platform(libs.junit.bom))
   testImplementation(libs.bundles.junit.testing)
   testRuntimeOnly(libs.logback.classic)
 


### PR DESCRIPTION
This is needed when using a locally built Quarkus installed. No functional change otherwise.