### PR TITLE
Prepare for making NMCP setup work with config-cache

### DIFF
--- a/compatibility/jersey/build.gradle.kts
+++ b/compatibility/jersey/build.gradle.kts
@@ -47,9 +47,7 @@ dependencies {
   implementation("org.glassfish.jersey.ext.cdi:jersey-cdi1x")
   implementation("org.glassfish.jersey.ext.cdi:jersey-cdi-rs-inject")
   implementation("org.glassfish.jersey.ext.cdi:jersey-weld2-se")
-  implementation(
-    platform("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-bundle")
-  )
+  implementation(platform(libs.jersey.test.framework.provider.bundle))
   implementation("org.glassfish.jersey.test-framework:jersey-test-framework-core")
   implementation("org.glassfish.jersey.test-framework:jersey-test-framework-util")
   implementation(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,6 +90,7 @@ javax-validation-api = { module = "javax.validation:validation-api", version = "
 javax-ws-rs = { module = "javax.ws.rs:javax.ws.rs-api", version = "2.1.1" }
 jaxb-impl = { module = "com.sun.xml.bind:jaxb-impl", version = "4.0.9" }
 jersey-bom = { module = "org.glassfish.jersey:jersey-bom", version = "4.0.2" }
+jersey-test-framework-provider-bundle = { module = "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-bundle", version = "4.0.2" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.1.0" }
 jetty-bom = { module = "org.eclipse.jetty:jetty-bom", version = "12.1.11" }
 jline = { module = "org.jline:jline", version = "4.3.1" }

--- a/servers/jax-rs-testextension/build.gradle.kts
+++ b/servers/jax-rs-testextension/build.gradle.kts
@@ -49,9 +49,7 @@ dependencies {
   api("org.glassfish.jersey.ext.cdi:jersey-cdi-rs-inject")
   api("org.glassfish.jersey.ext.cdi:jersey-weld2-se")
 
-  api(
-    platform("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-bundle")
-  )
+  api(platform(libs.jersey.test.framework.provider.bundle))
   api("org.glassfish.jersey.test-framework:jersey-test-framework-core")
   api("org.glassfish.jersey.test-framework:jersey-test-framework-util")
   api("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2")


### PR DESCRIPTION
Currently we inspect all Gradle projects for the NCMP plugin, which is not a good fit for Gradle configuration cache.

To eventually use NMCP's Gradle _settings_ plugin, we need to adopt the `PublishingHelperPlugin` as well, which adds missing Maven `version` elements. There's only one usage, the dependency affected by this change.