### PR TITLE
Make nessie-protobuf-relocated produce a "proper" runtime-elements

### DIFF
--- a/servers/store-proto/build.gradle.kts
+++ b/servers/store-proto/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 
 publishingHelper { mavenName = "Nessie - Server - Store (Proto)" }
 
-dependencies { api(project(path = ":nessie-protobuf-relocated", configuration = "shadow")) }
+dependencies { api(project(":nessie-protobuf-relocated")) }
 
 // *.proto files taken from https://github.com/googleapis/googleapis/ repo, available as a git
 // submodule

--- a/tools/protobuf-relocated/build.gradle.kts
+++ b/tools/protobuf-relocated/build.gradle.kts
@@ -25,18 +25,38 @@ publishingHelper { mavenName = "Nessie - Relocated Protobuf ${libs.protobuf.java
 
 dependencies { compileOnly(libs.protobuf.java) }
 
-val shadowJar = tasks.named<ShadowJar>("shadowJar")
-
-shadowJar.configure {
-  relocate("com.google.protobuf", "org.projectnessie.nessie.relocated.protobuf")
-  manifest {
-    attributes["Specification-Title"] = "Google Protobuf"
-    attributes["Specification-Version"] = libs.protobuf.java.get().version
+val shadowJar =
+  tasks.named<ShadowJar>("shadowJar") {
+    relocate("com.google.protobuf", "org.projectnessie.nessie.relocated.protobuf")
+    manifest {
+      attributes["Specification-Title"] = "Google Protobuf"
+      attributes["Specification-Version"] = libs.protobuf.java.get().version
+    }
+    configurations = listOf(project.configurations.getByName("compileClasspath"))
+    dependencies { include(dependency(libs.protobuf.java.get())) }
   }
-  configurations = listOf(project.configurations.getByName("compileClasspath"))
-  dependencies { include(dependency(libs.protobuf.java.get())) }
-}
 
 tasks.named("compileJava").configure { finalizedBy(shadowJar) }
 
 tasks.named("processResources").configure { finalizedBy(shadowJar) }
+
+shadow {
+  addShadowVariantIntoJavaComponent = false
+}
+
+listOf("shadowRuntimeElements").forEach { configurationName ->
+  configurations.named(configurationName) {
+    isCanBeConsumed = false
+  }
+}
+
+listOf("apiElements", "runtimeElements").forEach { configurationName ->
+  configurations.named(configurationName) {
+    outgoing.artifacts.clear()
+    outgoing.artifact(shadowJar)
+    outgoing.variants.removeAll { true }
+    attributes {
+      attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.SHADOWED))
+    }
+  }
+}

--- a/versioned/spi/build.gradle.kts
+++ b/versioned/spi/build.gradle.kts
@@ -20,7 +20,7 @@ publishingHelper { mavenName = "Nessie - Versioned Store SPI" }
 
 dependencies {
   implementation(project(":nessie-model"))
-  api(project(path = ":nessie-protobuf-relocated", configuration = "shadow"))
+  api(project(":nessie-protobuf-relocated"))
   compileOnly(project(":nessie-immutables-std"))
   annotationProcessor(project(":nessie-immutables-std", configuration = "processor"))
   compileOnly(libs.microprofile.openapi)

--- a/versioned/storage/batching/build.gradle.kts
+++ b/versioned/storage/batching/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
 
   testImplementation(project(":nessie-versioned-storage-common-tests"))
   testImplementation(project(":nessie-versioned-storage-inmemory"))
-  testImplementation(project(path = ":nessie-protobuf-relocated", configuration = "shadow"))
+  testImplementation(project(":nessie-protobuf-relocated"))
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.bundles.junit.testing)
   testRuntimeOnly(libs.logback.classic)

--- a/versioned/storage/cleanup/build.gradle.kts
+++ b/versioned/storage/cleanup/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
   testImplementation(project(":nessie-versioned-storage-store"))
   testImplementation(project(":nessie-versioned-tests"))
   testImplementation(project(":nessie-server-store"))
-  testImplementation(project(path = ":nessie-protobuf-relocated", configuration = "shadow"))
+  testImplementation(project(":nessie-protobuf-relocated"))
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.bundles.junit.testing)
   testRuntimeOnly(libs.logback.classic)

--- a/versioned/storage/common-proto/build.gradle.kts
+++ b/versioned/storage/common-proto/build.gradle.kts
@@ -27,7 +27,7 @@ publishingHelper { mavenName = "Nessie - Storage - Common proto" }
 
 description = "Protobuf definition for the serialization for storage objects."
 
-dependencies { api(project(path = ":nessie-protobuf-relocated", configuration = "shadow")) }
+dependencies { api(project(":nessie-protobuf-relocated")) }
 
 // *.proto files taken from https://github.com/googleapis/googleapis/ repo, available as a git
 // submodule

--- a/versioned/storage/common/build.gradle.kts
+++ b/versioned/storage/common/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
   compileOnly(libs.errorprone.annotations)
   implementation(libs.agrona)
   implementation(libs.guava)
-  implementation(project(path = ":nessie-protobuf-relocated", configuration = "shadow"))
+  implementation(project(":nessie-protobuf-relocated"))
   implementation(libs.slf4j.api)
 
   compileOnly(project(":nessie-immutables-std"))

--- a/versioned/storage/inmemory/build.gradle.kts
+++ b/versioned/storage/inmemory/build.gradle.kts
@@ -22,7 +22,7 @@ description = "Storage implementation using in-memory maps, not persisting."
 
 dependencies {
   implementation(project(":nessie-versioned-storage-common"))
-  implementation(project(path = ":nessie-protobuf-relocated", configuration = "shadow"))
+  implementation(project(":nessie-protobuf-relocated"))
 
   compileOnly(libs.jakarta.validation.api)
   compileOnly(libs.jakarta.annotation.api)

--- a/versioned/transfer-proto/build.gradle.kts
+++ b/versioned/transfer-proto/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 
 publishingHelper { mavenName = "Nessie - Export/Import - Serialization (Proto)" }
 
-dependencies { api(project(path = ":nessie-protobuf-relocated", configuration = "shadow")) }
+dependencies { api(project(":nessie-protobuf-relocated")) }
 
 extensions.configure<ProtobufExtension> {
   // Configure the protoc executable


### PR DESCRIPTION
Removes the hack to refer to a Gradle configuration.