### PR TITLE
test: replace aws secrets localstack with floci

### DIFF
--- a/catalog/secrets/aws/build.gradle.kts
+++ b/catalog/secrets/aws/build.gradle.kts
@@ -43,8 +43,8 @@ dependencies {
 
   intTestCompileOnly(project(":nessie-immutables"))
   intTestImplementation(platform(libs.testcontainers.bom))
+  intTestImplementation(libs.floci.testcontainers)
   intTestImplementation("org.testcontainers:testcontainers")
-  intTestImplementation("org.testcontainers:testcontainers-localstack")
   intTestImplementation("org.testcontainers:testcontainers-junit-jupiter")
   intTestImplementation(project(":nessie-container-spec-helper"))
   intTestRuntimeOnly(libs.logback.classic)

--- a/catalog/secrets/aws/src/intTest/java/org/projectnessie/catalog/secrets/aws/ITAwsSecretsProvider.java
+++ b/catalog/secrets/aws/src/intTest/java/org/projectnessie/catalog/secrets/aws/ITAwsSecretsProvider.java
@@ -20,6 +20,7 @@ import static org.projectnessie.catalog.secrets.BasicCredentials.basicCredential
 import static org.projectnessie.catalog.secrets.KeySecret.keySecret;
 import static org.projectnessie.catalog.secrets.TokenSecret.tokenSecret;
 
+import io.floci.testcontainers.FlociContainer;
 import java.net.URI;
 import java.time.Instant;
 import org.assertj.core.api.SoftAssertions;
@@ -36,7 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.localstack.LocalStackContainer;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -51,28 +51,26 @@ public class ITAwsSecretsProvider {
   @InjectSoftAssertions SoftAssertions soft;
 
   @Container
-  static LocalStackContainer localstack =
-      new LocalStackContainer(
+  static FlociContainer floci =
+      new FlociContainer(
               ContainerSpecHelper.builder()
-                  .name("localstack")
+                  .name("floci")
                   .containerClass(ITAwsSecretsProvider.class)
                   .build()
                   .dockerImageName(null)
-                  .asCompatibleSubstituteFor("localstack/localstack"))
-          .withLogConsumer(c -> LOGGER.info("[LOCALSTACK] {}", c.getUtf8StringWithoutLineEnding()))
-          .withServices("secretsmanager");
+                  .asCompatibleSubstituteFor("floci/floci"))
+          .withLogConsumer(c -> LOGGER.info("[FLOCI] {}", c.getUtf8StringWithoutLineEnding()));
 
   @Test
   public void awsSecretsManager() {
-    URI secretsManagerEndpoint = localstack.getEndpoint();
+    URI secretsManagerEndpoint = URI.create(floci.getEndpoint());
     try (SecretsManagerClient client =
         SecretsManagerClient.builder()
             .endpointOverride(secretsManagerEndpoint)
-            .region(Region.of(localstack.getRegion()))
+            .region(Region.of(floci.getRegion()))
             .credentialsProvider(
                 StaticCredentialsProvider.create(
-                    AwsBasicCredentials.create(
-                        localstack.getAccessKey(), localstack.getSecretKey())))
+                    AwsBasicCredentials.create(floci.getAccessKey(), floci.getSecretKey())))
             .build()) {
 
       String instantStr = "2024-06-05T20:38:16Z";

--- a/catalog/secrets/aws/src/intTest/resources/org/projectnessie/catalog/secrets/aws/Dockerfile-floci-version
+++ b/catalog/secrets/aws/src/intTest/resources/org/projectnessie/catalog/secrets/aws/Dockerfile-floci-version
@@ -1,3 +1,3 @@
 # Dockerfile to provide the image name and tag to a test.
 # Version is managed by Renovate - do not edit.
-FROM docker.io/localstack/localstack:4.14.0
+FROM docker.io/floci/floci:1.5.33

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ errorprone-annotations = { module = "com.google.errorprone:error_prone_annotatio
 errorprone-core = { module = "com.google.errorprone:error_prone_core", version.ref = "errorprone" }
 errorprone-slf4j = { module = "jp.skypencil.errorprone.slf4j:errorprone-slf4j", version.ref = "errorproneSlf4j" }
 findbugs-jsr305 = { module = "com.google.code.findbugs:jsr305", version = "3.0.2" }
+floci-testcontainers = { module = "io.floci:testcontainers-floci", version = "2.11.0" }
 gatling-charts-highcharts = { module = "io.gatling.highcharts:gatling-charts-highcharts", version.ref = "gatling" }
 google-cloud-bigdataoss-gcs-connector = { module = "com.google.cloud.bigdataoss:gcs-connector", version.ref = "googleCloudBigdataoss" }
 google-cloud-bigdataoss-gcsio = { module = "com.google.cloud.bigdataoss:gcsio", version.ref = "googleCloudBigdataoss" }

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -146,9 +146,9 @@ dependencies {
   testFixturesApi(testFixtures(project(":nessie-quarkus-common")))
 
   testFixturesApi(platform(libs.testcontainers.bom))
+  testFixturesApi(libs.floci.testcontainers)
   testFixturesApi("org.testcontainers:testcontainers")
   testFixturesApi(project(":nessie-keycloak-testcontainer"))
-  testFixturesApi("org.testcontainers:testcontainers-localstack")
   testFixturesApi("org.testcontainers:testcontainers-vault")
   testFixturesApi(project(":nessie-azurite-testcontainer"))
   testFixturesApi(project(":nessie-gcs-testcontainer"))

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/secrets/TestSecretsAWS.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/secrets/TestSecretsAWS.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 @QuarkusTest // because the tests need @Inject'd fields
-@WithTestResource(LocalstackTestResourceLifecycleManager.class)
+@WithTestResource(FlociAwsSecretsTestResourceLifecycleManager.class)
 @DisabledOnOs(OS.MAC) // test doesn't work on MacOS
 public class TestSecretsAWS extends AbstractSecretsSuppliers {
   @Override

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/secrets/FlociAwsSecretsTestResourceLifecycleManager.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/secrets/FlociAwsSecretsTestResourceLifecycleManager.java
@@ -17,6 +17,7 @@ package org.projectnessie.server.secrets;
 
 import static java.lang.String.format;
 
+import io.floci.testcontainers.FlociContainer;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager.TestInjector.AnnotatedAndMatchesType;
 import java.lang.annotation.ElementType;
@@ -34,7 +35,6 @@ import org.projectnessie.nessie.testing.containerspec.ContainerSpecHelper;
 import org.projectnessie.quarkus.config.QuarkusSecretsConfig.ExternalSecretsManagerType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.localstack.LocalStackContainer;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -42,13 +42,14 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
 
-public class LocalstackTestResourceLifecycleManager implements QuarkusTestResourceLifecycleManager {
+public class FlociAwsSecretsTestResourceLifecycleManager
+    implements QuarkusTestResourceLifecycleManager {
   private static final Logger LOGGER =
-      LoggerFactory.getLogger(LocalstackTestResourceLifecycleManager.class);
+      LoggerFactory.getLogger(FlociAwsSecretsTestResourceLifecycleManager.class);
 
   public static final String NESSIE_SECRETS_PATH = "nessie.secrets";
 
-  private volatile LocalStackContainer localstack;
+  private volatile FlociContainer floci;
   private volatile SecretsManagerClient secretsManagerClient;
 
   @Target(ElementType.FIELD)
@@ -69,43 +70,40 @@ public class LocalstackTestResourceLifecycleManager implements QuarkusTestResour
 
   @Override
   public Map<String, String> start() {
-    localstack =
-        new LocalStackContainer(
+    floci =
+        new FlociContainer(
                 ContainerSpecHelper.builder()
-                    .name("localstack")
-                    .containerClass(LocalstackTestResourceLifecycleManager.class)
+                    .name("floci")
+                    .containerClass(FlociAwsSecretsTestResourceLifecycleManager.class)
                     .build()
                     .dockerImageName(null)
-                    .asCompatibleSubstituteFor("localstack/localstack"))
-            .withLogConsumer(
-                c -> LOGGER.info("[LOCALSTACK] {}", c.getUtf8StringWithoutLineEnding()))
-            .withServices("secretsmanager");
+                    .asCompatibleSubstituteFor("floci/floci"))
+            .withLogConsumer(c -> LOGGER.info("[FLOCI] {}", c.getUtf8StringWithoutLineEnding()));
 
-    localstack.start();
+    floci.start();
 
-    URI secretsManagerEndpoint = localstack.getEndpoint();
+    URI secretsManagerEndpoint = URI.create(floci.getEndpoint());
 
     try {
       secretsManagerClient =
           SecretsManagerClient.builder()
               .endpointOverride(secretsManagerEndpoint)
-              .region(Region.of(localstack.getRegion()))
+              .region(Region.of(floci.getRegion()))
               .credentialsProvider(
                   StaticCredentialsProvider.create(
-                      AwsBasicCredentials.create(
-                          localstack.getAccessKey(), localstack.getSecretKey())))
+                      AwsBasicCredentials.create(floci.getAccessKey(), floci.getSecretKey())))
               .build();
 
       return ImmutableMap.<String, String>builder()
           .put("quarkus.secretsmanager.endpoint-override", secretsManagerEndpoint.toString())
-          .put("quarkus.secretsmanager.aws.region", localstack.getRegion())
+          .put("quarkus.secretsmanager.aws.region", floci.getRegion())
           .put("quarkus.secretsmanager.aws.credentials.type", "static")
           .put(
               "quarkus.secretsmanager.aws.credentials.static-provider.access-key-id",
-              localstack.getAccessKey())
+              floci.getAccessKey())
           .put(
               "quarkus.secretsmanager.aws.credentials.static-provider.secret-access-key",
-              localstack.getSecretKey())
+              floci.getSecretKey())
           .put("nessie.secrets.type", ExternalSecretsManagerType.AMAZON)
           .put("nessie.secrets.path", NESSIE_SECRETS_PATH)
           .build();
@@ -129,11 +127,11 @@ public class LocalstackTestResourceLifecycleManager implements QuarkusTestResour
     } finally {
       secretsManagerClient = null;
 
-      if (localstack != null) {
+      if (floci != null) {
         try {
-          localstack.stop();
+          floci.stop();
         } finally {
-          localstack = null;
+          floci = null;
         }
       }
     }
@@ -169,16 +167,16 @@ public class LocalstackTestResourceLifecycleManager implements QuarkusTestResour
   @Override
   public void inject(TestInjector testInjector) {
     testInjector.injectIntoFields(
-        localstack.getEndpoint(),
+        URI.create(floci.getEndpoint()),
         new AnnotatedAndMatchesType(AwsSecretsManagerEndpoint.class, URI.class));
     testInjector.injectIntoFields(
-        localstack.getRegion(),
+        floci.getRegion(),
         new AnnotatedAndMatchesType(AwsSecretsManagerRegion.class, String.class));
     testInjector.injectIntoFields(
-        localstack.getAccessKey(),
+        floci.getAccessKey(),
         new AnnotatedAndMatchesType(AwsSecretsManagerAccessKey.class, String.class));
     testInjector.injectIntoFields(
-        localstack.getSecretKey(),
+        floci.getSecretKey(),
         new AnnotatedAndMatchesType(AwsSecretsManagerSecretAccessKey.class, String.class));
     testInjector.injectIntoFields(
         (SecretsUpdateHandler) this::updateSecrets,

--- a/servers/quarkus-server/src/testFixtures/resources/org/projectnessie/server/secrets/Dockerfile-floci-version
+++ b/servers/quarkus-server/src/testFixtures/resources/org/projectnessie/server/secrets/Dockerfile-floci-version
@@ -1,3 +1,3 @@
 # Dockerfile to provide the image name and tag to a test.
 # Version is managed by Renovate - do not edit.
-FROM docker.io/localstack/localstack:4.14.0
+FROM docker.io/floci/floci:1.5.33


### PR DESCRIPTION
Use the official Floci Testcontainers wrapper and the pinned Floci AWS image for AWS Secrets Manager integration coverage.

This removes the LocalStack dependency from the AWS secrets tests and keeps the Quarkus AWS secrets test resource on the same emulator path as the catalog secrets adapter.