### PR TITLE
test: cover cloud secrets with floci emulators

### DIFF
--- a/catalog/secrets/azure/build.gradle.kts
+++ b/catalog/secrets/azure/build.gradle.kts
@@ -43,8 +43,6 @@ dependencies {
   intTestImplementation(platform(libs.testcontainers.bom))
   intTestImplementation("org.testcontainers:testcontainers")
   intTestImplementation("org.testcontainers:testcontainers-junit-jupiter")
-  intTestImplementation(libs.lowkey.vault.testcontainers)
-  intTestImplementation(libs.lowkey.vault.client)
   intTestImplementation(project(":nessie-container-spec-helper"))
   intTestRuntimeOnly(libs.logback.classic)
 }

--- a/catalog/secrets/azure/src/intTest/java/org/projectnessie/catalog/secrets/azure/ITAzureSecretsProvider.java
+++ b/catalog/secrets/azure/src/intTest/java/org/projectnessie/catalog/secrets/azure/ITAzureSecretsProvider.java
@@ -20,11 +20,19 @@ import static org.projectnessie.catalog.secrets.BasicCredentials.basicCredential
 import static org.projectnessie.catalog.secrets.KeySecret.keySecret;
 import static org.projectnessie.catalog.secrets.TokenSecret.tokenSecret;
 
+import com.azure.core.credential.AccessToken;
+import com.azure.core.http.HttpPipelineCallContext;
+import com.azure.core.http.HttpPipelineNextPolicy;
+import com.azure.core.http.HttpResponse;
+import com.azure.core.http.policy.HttpPipelinePolicy;
 import com.azure.security.keyvault.secrets.SecretAsyncClient;
-import com.github.nagyesta.lowkeyvault.testcontainers.LowkeyVaultContainer;
-import com.github.nagyesta.lowkeyvault.testcontainers.LowkeyVaultContainerBuilder;
+import com.azure.security.keyvault.secrets.SecretClientBuilder;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
@@ -38,33 +46,36 @@ import org.projectnessie.catalog.secrets.TokenSecret;
 import org.projectnessie.nessie.testing.containerspec.ContainerSpecHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import reactor.core.publisher.Mono;
 
 @Testcontainers
 @ExtendWith(SoftAssertionsExtension.class)
 public class ITAzureSecretsProvider {
   private static final Logger LOGGER = LoggerFactory.getLogger(ITAzureSecretsProvider.class);
+  private static final int FLOCI_AZ_PORT = 4577;
+  private static final String ACCOUNT = "devstoreaccount1";
 
   @InjectSoftAssertions SoftAssertions soft;
 
   @Container
-  static LowkeyVaultContainer lowkeyVault =
-      LowkeyVaultContainerBuilder.lowkeyVault(
+  static GenericContainer<?> flociAz =
+      new GenericContainer<>(
               ContainerSpecHelper.builder()
-                  .name("lowkey-vault")
+                  .name("floci-az")
                   .containerClass(ITAzureSecretsProvider.class)
                   .build()
-                  .dockerImageName(null)
-                  .asCompatibleSubstituteFor("nagyesta/lowkey-vault"))
-          .build()
-          .withLogConsumer(
-              c -> LOGGER.info("[LOWKEY-VAULT] {}", c.getUtf8StringWithoutLineEnding()));
+                  .dockerImageName(null))
+          .withExposedPorts(FLOCI_AZ_PORT)
+          .waitingFor(Wait.forHttp("/_floci/health").forPort(FLOCI_AZ_PORT))
+          .withLogConsumer(c -> LOGGER.info("[FLOCI-AZ] {}", c.getUtf8StringWithoutLineEnding()));
 
   @Test
   public void azureSecrets() {
-    final SecretAsyncClient client =
-        lowkeyVault.getClientFactory().getSecretClientBuilderForDefaultVault().buildAsyncClient();
+    final SecretAsyncClient client = secretClient();
 
     String instantStr = "2024-06-05T20:38:16Z";
     Instant instant = Instant.parse(instantStr);
@@ -108,5 +119,43 @@ public class ITAzureSecretsProvider {
         .isEmpty();
     soft.assertThat(secretsProvider.getSecret("nope", SecretType.BASIC, BasicCredentials.class))
         .isEmpty();
+  }
+
+  private static SecretAsyncClient secretClient() {
+    String vaultUrl =
+        "https://"
+            + flociAz.getHost()
+            + ':'
+            + flociAz.getMappedPort(FLOCI_AZ_PORT)
+            + '/'
+            + ACCOUNT
+            + "-keyvault";
+    return new SecretClientBuilder()
+        .vaultUrl(vaultUrl)
+        .credential(
+            request ->
+                Mono.just(
+                    new AccessToken("fake-token", OffsetDateTime.now(ZoneOffset.UTC).plusHours(1))))
+        .addPolicy(new ForceHttpPolicy())
+        .disableChallengeResourceVerification()
+        .buildAsyncClient();
+  }
+
+  static final class ForceHttpPolicy implements HttpPipelinePolicy {
+    @Override
+    public Mono<HttpResponse> process(
+        HttpPipelineCallContext context, HttpPipelineNextPolicy next) {
+      URL url = context.getHttpRequest().getUrl();
+      if ("https".equals(url.getProtocol())) {
+        try {
+          context
+              .getHttpRequest()
+              .setUrl(new URL("http", url.getHost(), url.getPort(), url.getFile()));
+        } catch (MalformedURLException e) {
+          return Mono.error(e);
+        }
+      }
+      return next.process();
+    }
   }
 }

--- a/catalog/secrets/azure/src/intTest/resources/org/projectnessie/catalog/secrets/azure/Dockerfile-floci-az-version
+++ b/catalog/secrets/azure/src/intTest/resources/org/projectnessie/catalog/secrets/azure/Dockerfile-floci-az-version
@@ -1,0 +1,3 @@
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM docker.io/floci/floci-az:0.9.0

--- a/catalog/secrets/gcs/build.gradle.kts
+++ b/catalog/secrets/gcs/build.gradle.kts
@@ -37,4 +37,11 @@ dependencies {
 
   testFixturesApi(platform(libs.junit.bom))
   testFixturesApi(libs.bundles.junit.testing)
+
+  intTestCompileOnly(project(":nessie-immutables"))
+  intTestImplementation(platform(libs.testcontainers.bom))
+  intTestImplementation("org.testcontainers:testcontainers")
+  intTestImplementation("org.testcontainers:testcontainers-junit-jupiter")
+  intTestImplementation(project(":nessie-container-spec-helper"))
+  intTestRuntimeOnly(libs.logback.classic)
 }

--- a/catalog/secrets/gcs/src/intTest/java/org/projectnessie/catalog/secrets/gcs/ITGcsSecretsProvider.java
+++ b/catalog/secrets/gcs/src/intTest/java/org/projectnessie/catalog/secrets/gcs/ITGcsSecretsProvider.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2026 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.secrets.gcs;
+
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.projectnessie.catalog.secrets.BasicCredentials.basicCredentials;
+import static org.projectnessie.catalog.secrets.KeySecret.keySecret;
+import static org.projectnessie.catalog.secrets.TokenSecret.tokenSecret;
+
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.GrpcTransportChannel;
+import com.google.api.gax.rpc.FixedTransportChannelProvider;
+import com.google.cloud.secretmanager.v1.AddSecretVersionRequest;
+import com.google.cloud.secretmanager.v1.CreateSecretRequest;
+import com.google.cloud.secretmanager.v1.ProjectName;
+import com.google.cloud.secretmanager.v1.Replication;
+import com.google.cloud.secretmanager.v1.Secret;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceSettings;
+import com.google.cloud.secretmanager.v1.SecretName;
+import com.google.cloud.secretmanager.v1.SecretPayload;
+import com.google.protobuf.ByteString;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import java.time.Duration;
+import java.time.Instant;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.catalog.secrets.BasicCredentials;
+import org.projectnessie.catalog.secrets.KeySecret;
+import org.projectnessie.catalog.secrets.SecretType;
+import org.projectnessie.catalog.secrets.TokenSecret;
+import org.projectnessie.nessie.testing.containerspec.ContainerSpecHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@ExtendWith(SoftAssertionsExtension.class)
+public class ITGcsSecretsProvider {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ITGcsSecretsProvider.class);
+  private static final int FLOCI_GCP_PORT = 4588;
+  private static final String PROJECT_ID = "floci-local";
+  private static final String SECRET_PREFIX = "projects/" + PROJECT_ID + "/secrets/";
+
+  @InjectSoftAssertions SoftAssertions soft;
+
+  @Container
+  static GenericContainer<?> flociGcp =
+      new GenericContainer<>(
+              ContainerSpecHelper.builder()
+                  .name("floci-gcp")
+                  .containerClass(ITGcsSecretsProvider.class)
+                  .build()
+                  .dockerImageName(null))
+          .withExposedPorts(FLOCI_GCP_PORT)
+          .withLogConsumer(c -> LOGGER.info("[FLOCI-GCP] {}", c.getUtf8StringWithoutLineEnding()));
+
+  @Test
+  public void gcsSecretsManager() throws Exception {
+    ManagedChannel channel =
+        ManagedChannelBuilder.forAddress(flociGcp.getHost(), flociGcp.getMappedPort(FLOCI_GCP_PORT))
+            .usePlaintext()
+            .build();
+    try (SecretManagerServiceClient client = secretManagerClient(channel)) {
+      String instantStr = "2024-06-05T20:38:16Z";
+      Instant instant = Instant.parse(instantStr);
+
+      KeySecret keySecret = keySecret("secret-foo");
+      BasicCredentials basicCred = basicCredentials("bar-name", "bar-secret");
+      TokenSecret tokenSec = tokenSecret("the-token", instant);
+
+      createSecretVersion(client, "key", "secret-foo");
+      createSecretVersion(client, "basic", "{\"name\": \"bar-name\", \"secret\": \"bar-secret\"}");
+      createSecretVersion(
+          client, "tok", "{\"token\": \"the-token\", \"expiresAt\": \"" + instantStr + "\"}");
+
+      GcsSecretsManager secretsProvider =
+          new GcsSecretsManager(client, SECRET_PREFIX, Duration.ofMinutes(1));
+
+      soft.assertThat(
+              secretsProvider.getSecret("key/versions/latest", SecretType.KEY, KeySecret.class))
+          .get()
+          .asInstanceOf(type(KeySecret.class))
+          .extracting(KeySecret::key)
+          .isEqualTo(keySecret.key());
+      soft.assertThat(
+              secretsProvider.getSecret(
+                  "basic/versions/latest", SecretType.BASIC, BasicCredentials.class))
+          .get()
+          .asInstanceOf(type(BasicCredentials.class))
+          .extracting(BasicCredentials::name, BasicCredentials::secret)
+          .containsExactly(basicCred.name(), basicCred.secret());
+      soft.assertThat(
+              secretsProvider.getSecret(
+                  "tok/versions/latest", SecretType.EXPIRING_TOKEN, TokenSecret.class))
+          .get()
+          .asInstanceOf(type(TokenSecret.class))
+          .extracting(TokenSecret::token, TokenSecret::expiresAt)
+          .containsExactly(tokenSec.token(), tokenSec.expiresAt());
+
+      soft.assertThat(
+              secretsProvider.getSecret(
+                  "not-there/versions/latest", SecretType.KEY, KeySecret.class))
+          .isEmpty();
+      soft.assertThat(
+              secretsProvider.getSecret(
+                  "nope/versions/latest", SecretType.BASIC, BasicCredentials.class))
+          .isEmpty();
+    } finally {
+      channel.shutdownNow();
+    }
+  }
+
+  private static SecretManagerServiceClient secretManagerClient(ManagedChannel channel)
+      throws Exception {
+    SecretManagerServiceSettings settings =
+        SecretManagerServiceSettings.newBuilder()
+            .setTransportChannelProvider(
+                FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel)))
+            .setCredentialsProvider(NoCredentialsProvider.create())
+            .build();
+    return SecretManagerServiceClient.create(settings);
+  }
+
+  private static void createSecretVersion(
+      SecretManagerServiceClient client, String secretId, String value) {
+    client.createSecret(
+        CreateSecretRequest.newBuilder()
+            .setParent(ProjectName.of(PROJECT_ID).toString())
+            .setSecretId(secretId)
+            .setSecret(
+                Secret.newBuilder()
+                    .setReplication(
+                        Replication.newBuilder()
+                            .setAutomatic(Replication.Automatic.newBuilder().build())
+                            .build())
+                    .build())
+            .build());
+    client.addSecretVersion(
+        AddSecretVersionRequest.newBuilder()
+            .setParent(SecretName.of(PROJECT_ID, secretId).toString())
+            .setPayload(SecretPayload.newBuilder().setData(ByteString.copyFromUtf8(value)).build())
+            .build());
+  }
+}

--- a/catalog/secrets/gcs/src/intTest/resources/org/projectnessie/catalog/secrets/gcs/Dockerfile-floci-gcp-version
+++ b/catalog/secrets/gcs/src/intTest/resources/org/projectnessie/catalog/secrets/gcs/Dockerfile-floci-gcp-version
@@ -1,3 +1,3 @@
 # Dockerfile to provide the image name and tag to a test.
 # Version is managed by Renovate - do not edit.
-FROM docker.io/nagyesta/lowkey-vault:7.3.37
+FROM docker.io/floci/floci-gcp:0.5.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,8 +102,6 @@ junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
 junit-platform-reporting = { module = "org.junit.platform:junit-platform-reporting" }
 kafka-clients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafka" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
-lowkey-vault-client = { module = "com.github.nagyesta.lowkey-vault:lowkey-vault-client", version = "7.3.37" }
-lowkey-vault-testcontainers = { module = "com.github.nagyesta.lowkey-vault:lowkey-vault-testcontainers", version = "7.3.37" }
 keycloak-admin-client = { module = "org.keycloak:keycloak-admin-client", version.ref = "keycloak" }
 keycloak-client-common-synced = { module = "org.keycloak:keycloak-client-common-synced", version.ref = "keycloak" }
 mariadb-java-client = { module = "org.mariadb.jdbc:mariadb-java-client", version = "3.5.9" }

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -211,7 +211,6 @@ dependencies {
   intTestImplementation(enforcedPlatform(libs.testcontainers.bom))
   intTestImplementation("io.quarkus:quarkus-test-keycloak-server")
   intTestImplementation(project(":nessie-keycloak-testcontainer"))
-  intTestImplementation(libs.lowkey.vault.testcontainers)
 
   intTestImplementation(platform(libs.awssdk.bom))
   intTestImplementation("software.amazon.awssdk:s3")


### PR DESCRIPTION
Move Azure Key Vault secrets coverage from Lowkey Vault to floci-az and add Google Secret Manager coverage against floci-gcp.

The Google test uses the Secret Manager gRPC client against the emulator, while the Azure test keeps the production adapter path and only swaps the test backend. This also removes the now-unused Lowkey dependencies.