### PR TITLE
test: run dynamodb storage tests on floci

### DIFF
--- a/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/DynamoTestResourceLifecycleManager.java
+++ b/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/DynamoTestResourceLifecycleManager.java
@@ -38,7 +38,7 @@ public class DynamoTestResourceLifecycleManager
     dynamo = new DynamoDB2BackendTestFactory();
 
     try {
-      // Only start the Docker container (local Dynamo-compatible).
+      // Only start the Floci-backed DynamoDB test container.
       dynamo.start(containerNetworkId);
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/versioned/storage/dynamodb-tests/src/main/java/org/projectnessie/versioned/storage/dynamodbtests/DynamoDBBackendTestFactory.java
+++ b/versioned/storage/dynamodb-tests/src/main/java/org/projectnessie/versioned/storage/dynamodbtests/DynamoDBBackendTestFactory.java
@@ -38,7 +38,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 public class DynamoDBBackendTestFactory implements BackendTestFactory {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DynamoDBBackendTestFactory.class);
-  public static final int DYNAMODB_PORT = 8000;
+  public static final int DYNAMODB_PORT = 4566;
 
   private GenericContainer<?> container;
   private String endpointURI;
@@ -66,7 +66,7 @@ public class DynamoDBBackendTestFactory implements BackendTestFactory {
   public DynamoDbClient buildNewClient() {
     return DynamoClientProducer.builder()
         .endpointURI(endpointURI)
-        .region("US_WEST_2")
+        .region(US_WEST_2.id())
         .credentialsProvider(
             StaticCredentialsProvider.create(AwsBasicCredentials.create("xxx", "xxx")))
         .build()
@@ -82,7 +82,7 @@ public class DynamoDBBackendTestFactory implements BackendTestFactory {
 
     DockerImageName dockerImage =
         ContainerSpecHelper.builder()
-            .name("dynamodb-local")
+            .name("floci")
             .containerClass(DynamoDBBackendTestFactory.class)
             .build()
             .dockerImageName(null);
@@ -91,8 +91,7 @@ public class DynamoDBBackendTestFactory implements BackendTestFactory {
       GenericContainer<?> c =
           new GenericContainer<>(dockerImage)
               .withLogConsumer(new Slf4jLogConsumer(LOGGER))
-              .withExposedPorts(DYNAMODB_PORT)
-              .withCommand("-jar", "DynamoDBLocal.jar", "-inMemory", "-sharedDb");
+              .withExposedPorts(DYNAMODB_PORT);
       containerNetworkId.ifPresent(c::withNetworkMode);
       try {
         c.start();

--- a/versioned/storage/dynamodb-tests/src/main/resources/org/projectnessie/versioned/storage/dynamodbtests/Dockerfile-floci-version
+++ b/versioned/storage/dynamodb-tests/src/main/resources/org/projectnessie/versioned/storage/dynamodbtests/Dockerfile-floci-version
@@ -1,3 +1,3 @@
 # Dockerfile to provide the image name and tag to a test.
 # Version is managed by Renovate - do not edit.
-FROM docker.io/amazon/dynamodb-local:3.3.0
+FROM docker.io/floci/floci:1.5.33

--- a/versioned/storage/dynamodb2-tests/src/main/java/org/projectnessie/versioned/storage/dynamodbtests2/DynamoDB2BackendTestFactory.java
+++ b/versioned/storage/dynamodb2-tests/src/main/java/org/projectnessie/versioned/storage/dynamodbtests2/DynamoDB2BackendTestFactory.java
@@ -38,7 +38,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 public class DynamoDB2BackendTestFactory implements BackendTestFactory {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DynamoDB2BackendTestFactory.class);
-  public static final int DYNAMODB_PORT = 8000;
+  public static final int DYNAMODB_PORT = 4566;
 
   private GenericContainer<?> container;
   private String endpointURI;
@@ -65,7 +65,7 @@ public class DynamoDB2BackendTestFactory implements BackendTestFactory {
   public DynamoDbClient buildNewClient() {
     return DynamoClientProducer.builder()
         .endpointURI(endpointURI)
-        .region("US_WEST_2")
+        .region(US_WEST_2.id())
         .credentialsProvider(
             StaticCredentialsProvider.create(AwsBasicCredentials.create("xxx", "xxx")))
         .build()
@@ -81,7 +81,7 @@ public class DynamoDB2BackendTestFactory implements BackendTestFactory {
 
     DockerImageName dockerImage =
         ContainerSpecHelper.builder()
-            .name("dynamodb-local")
+            .name("floci")
             .containerClass(DynamoDB2BackendTestFactory.class)
             .build()
             .dockerImageName(null);
@@ -90,8 +90,7 @@ public class DynamoDB2BackendTestFactory implements BackendTestFactory {
       GenericContainer<?> c =
           new GenericContainer<>(dockerImage)
               .withLogConsumer(new Slf4jLogConsumer(LOGGER))
-              .withExposedPorts(DYNAMODB_PORT)
-              .withCommand("-jar", "DynamoDBLocal.jar", "-inMemory", "-sharedDb");
+              .withExposedPorts(DYNAMODB_PORT);
       containerNetworkId.ifPresent(c::withNetworkMode);
       try {
         c.start();

--- a/versioned/storage/dynamodb2-tests/src/main/resources/org/projectnessie/versioned/storage/dynamodbtests2/Dockerfile-floci-version
+++ b/versioned/storage/dynamodb2-tests/src/main/resources/org/projectnessie/versioned/storage/dynamodbtests2/Dockerfile-floci-version
@@ -1,3 +1,3 @@
 # Dockerfile to provide the image name and tag to a test.
 # Version is managed by Renovate - do not edit.
-FROM docker.io/amazon/dynamodb-local:3.3.0
+FROM docker.io/floci/floci:1.5.33


### PR DESCRIPTION
Switch both DynamoDB backend test factories from amazon/dynamodb-local to the Floci AWS emulator on port 4566.

This keeps the existing endpoint and shared-network contract used by Quarkus test resources while replacing the DynamoDB Local image marker and startup command with the Floci image.