### PR TITLE
GC: handle Iceberg files outside the table's declared location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Fixes
 
+- GC: Nessie GC no longer fails with `Path must be relative` when Iceberg content references files
+  that are not located under the location declared in the table's metadata, for example data files
+  written via `write.data.path` or files kept from a previous table location (#10817). Such files
+  are now tracked by their absolute URIs: they are recognized as live while sweeping the content's
+  base locations and are never deleted when they are outside all base locations.
+
 ### Commits
 
 ## [0.107.6] Release (2026-05-27)

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/expire/PerContentDeleteExpired.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/expire/PerContentDeleteExpired.java
@@ -70,7 +70,19 @@ public abstract class PerContentDeleteExpired {
           }
         };
 
-    long identifiedLiveFiles = identifyLiveFiles(filter, addBaseLocation);
+    LiveFilesStats liveFilesStats = identifyLiveFiles(filter, addBaseLocation);
+    long identifiedLiveFiles = liveFilesStats.liveFiles;
+
+    boolean matchAbsolutePaths = liveFilesStats.absolutePaths > 0;
+    if (matchAbsolutePaths) {
+      LOGGER.warn(
+          "live-set#{} content#{}: {} live files are referenced via absolute URIs outside the "
+              + "content's base locations. Those files are matched by their absolute URIs during "
+              + "expiry, files outside all base locations are never deleted.",
+          expireParameters().liveContentSet().id(),
+          contentId(),
+          liveFilesStats.absolutePaths);
+    }
 
     double expectedFpp = filter.expectedFpp();
     long approximateElementCount = filter.approximateElementCount();
@@ -93,7 +105,8 @@ public abstract class PerContentDeleteExpired {
     return baseLocations.stream()
         .map(
             baseLocation -> {
-              try (Stream<FileReference> fileObjects = identifyExpiredFiles(filter, baseLocation)) {
+              try (Stream<FileReference> fileObjects =
+                  identifyExpiredFiles(filter, baseLocation, matchAbsolutePaths)) {
                 return expireParameters().fileDeleter().deleteMultiple(baseLocation, fileObjects);
               } catch (Exception e) {
                 String msg = "Failed to expire objects in base location " + baseLocation;
@@ -109,7 +122,7 @@ public abstract class PerContentDeleteExpired {
    * Content} objects.
    */
   @SuppressWarnings("UnstableApiUsage")
-  private long identifyLiveFiles(
+  private LiveFilesStats identifyLiveFiles(
       BloomFilter<StorageUri> filter, Consumer<StorageUri> addBaseLocation) {
     LOGGER.debug(
         "live-set#{} content#{}: Start collecting files and base locations, max file modification time: {}.",
@@ -117,7 +130,7 @@ public abstract class PerContentDeleteExpired {
         contentId(),
         expireParameters().maxFileModificationTime());
 
-    long liveFileCount;
+    LiveFilesStats liveFilesStats = new LiveFilesStats();
     try (Stream<FileReference> contents =
         expireParameters()
             .liveContentSet()
@@ -128,12 +141,17 @@ public abstract class PerContentDeleteExpired {
                   Stream<FileReference> r = expireParameters().contentToFiles().extractFiles(c);
                   return r;
                 })) {
-      liveFileCount =
-          contents
-              .peek(f -> addBaseLocation.accept(f.base()))
-              .map(FileReference::path)
-              .peek(filter::put)
-              .count();
+      contents
+          .peek(f -> addBaseLocation.accept(f.base()))
+          .map(FileReference::path)
+          .forEach(
+              path -> {
+                if (path.isAbsolute()) {
+                  liveFilesStats.absolutePaths++;
+                }
+                filter.put(path);
+                liveFilesStats.liveFiles++;
+              });
     }
 
     LOGGER.debug(
@@ -141,22 +159,28 @@ public abstract class PerContentDeleteExpired {
             + "false-positive-probability of {} (configured: {}).",
         expireParameters().liveContentSet().id(),
         contentId(),
-        liveFileCount,
+        liveFilesStats.liveFiles,
         expireParameters().expectedFileCount(),
         filter.expectedFpp(),
         expireParameters().falsePositiveProbability());
 
-    return liveFileCount;
+    return liveFilesStats;
   }
 
   /**
    * Second part of {@link #expire()} to walk all base locations and identify the files that are not
    * referenced by any live content object.
+   *
+   * <p>If {@code matchAbsolutePaths} is {@code true}, the live-files bloom filter contains at least
+   * one absolute URI for a file outside the content's base locations, so listed files are also
+   * matched by their absolute URIs, in case such a file is located under another base location of
+   * the same content, for example an older table location.
    */
   @SuppressWarnings("UnstableApiUsage")
   @MustBeClosed
   private Stream<FileReference> identifyExpiredFiles(
-      BloomFilter<StorageUri> filter, StorageUri baseLocation) throws NessieFileIOException {
+      BloomFilter<StorageUri> filter, StorageUri baseLocation, boolean matchAbsolutePaths)
+      throws NessieFileIOException {
     ExpireStats expireStats = new ExpireStats();
     long maxFileTime = expireParameters().maxFileModificationTime().toEpochMilli();
 
@@ -171,7 +195,8 @@ public abstract class PerContentDeleteExpired {
     return list.filter(
             f -> {
               expireStats.totalFiles++;
-              if (filter.mightContain(f.path())) {
+              if (filter.mightContain(f.path())
+                  || (matchAbsolutePaths && filter.mightContain(f.absolutePath()))) {
                 expireStats.liveFiles++;
                 return false;
               }
@@ -203,6 +228,11 @@ public abstract class PerContentDeleteExpired {
     long expiredFiles = 0;
     long liveFiles = 0;
     long newFiles = 0;
+  }
+
+  private static final class LiveFilesStats {
+    long liveFiles = 0;
+    long absolutePaths = 0;
   }
 
   @SuppressWarnings("UnstableApiUsage")

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/expire/PerContentDeleteExpired.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/expire/PerContentDeleteExpired.java
@@ -73,8 +73,7 @@ public abstract class PerContentDeleteExpired {
     LiveFilesStats liveFilesStats = identifyLiveFiles(filter, addBaseLocation);
     long identifiedLiveFiles = liveFilesStats.liveFiles;
 
-    boolean matchAbsolutePaths = liveFilesStats.absolutePaths > 0;
-    if (matchAbsolutePaths) {
+    if (liveFilesStats.absolutePaths > 0) {
       LOGGER.warn(
           "live-set#{} content#{}: {} live files are referenced via absolute URIs outside the "
               + "content's base locations. Those files are matched by their absolute URIs during "
@@ -105,8 +104,7 @@ public abstract class PerContentDeleteExpired {
     return baseLocations.stream()
         .map(
             baseLocation -> {
-              try (Stream<FileReference> fileObjects =
-                  identifyExpiredFiles(filter, baseLocation, matchAbsolutePaths)) {
+              try (Stream<FileReference> fileObjects = identifyExpiredFiles(filter, baseLocation)) {
                 return expireParameters().fileDeleter().deleteMultiple(baseLocation, fileObjects);
               } catch (Exception e) {
                 String msg = "Failed to expire objects in base location " + baseLocation;
@@ -146,11 +144,11 @@ public abstract class PerContentDeleteExpired {
           .map(FileReference::path)
           .forEach(
               path -> {
+                filter.put(path);
+                liveFilesStats.liveFiles++;
                 if (path.isAbsolute()) {
                   liveFilesStats.absolutePaths++;
                 }
-                filter.put(path);
-                liveFilesStats.liveFiles++;
               });
     }
 
@@ -171,16 +169,15 @@ public abstract class PerContentDeleteExpired {
    * Second part of {@link #expire()} to walk all base locations and identify the files that are not
    * referenced by any live content object.
    *
-   * <p>If {@code matchAbsolutePaths} is {@code true}, the live-files bloom filter contains at least
-   * one absolute URI for a file outside the content's base locations, so listed files are also
-   * matched by their absolute URIs, in case such a file is located under another base location of
+   * <p>Listed files are matched by their path relative to the base location and by their absolute
+   * URI: files outside the content's base locations are referenced by their absolute URI in the
+   * live-files bloom filter, and such a file can still be located under another base location of
    * the same content, for example an older table location.
    */
   @SuppressWarnings("UnstableApiUsage")
   @MustBeClosed
   private Stream<FileReference> identifyExpiredFiles(
-      BloomFilter<StorageUri> filter, StorageUri baseLocation, boolean matchAbsolutePaths)
-      throws NessieFileIOException {
+      BloomFilter<StorageUri> filter, StorageUri baseLocation) throws NessieFileIOException {
     ExpireStats expireStats = new ExpireStats();
     long maxFileTime = expireParameters().maxFileModificationTime().toEpochMilli();
 
@@ -195,8 +192,7 @@ public abstract class PerContentDeleteExpired {
     return list.filter(
             f -> {
               expireStats.totalFiles++;
-              if (filter.mightContain(f.path())
-                  || (matchAbsolutePaths && filter.mightContain(f.absolutePath()))) {
+              if (filter.mightContain(f.path()) || filter.mightContain(f.absolutePath())) {
                 expireStats.liveFiles++;
                 return false;
               }

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/files/FileReference.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/files/FileReference.java
@@ -20,11 +20,21 @@ import static com.google.common.base.Preconditions.checkArgument;
 import org.immutables.value.Value;
 import org.projectnessie.storage.uri.StorageUri;
 
-/** References a file using a {@link #base()} URI plus a relative {@link #path()}. */
+/**
+ * References a file using a {@link #base()} URI plus a {@link #path()}, which is usually relative
+ * to {@link #base()}.
+ *
+ * <p>The {@link #path()} is absolute for files that are not located under {@link #base()}, for
+ * example Iceberg data files that live outside the location declared in the table's metadata (via
+ * {@code write.data.path}, {@code write.metadata.path}, a changed table location or the like).
+ */
 @Value.Immutable
 public interface FileReference {
 
-  /** URI to the file/directory relative to {@link #base()}. */
+  /**
+   * URI to the file/directory, relative to {@link #base()} if the file is located under {@link
+   * #base()}, otherwise the absolute URI of the file.
+   */
   @Value.Parameter(order = 1)
   StorageUri path();
 
@@ -38,7 +48,8 @@ public interface FileReference {
   long modificationTimeMillisEpoch();
 
   /**
-   * Absolute path to the file/directory. Virtually equivalent to {@code base().resolve(path())}.
+   * Absolute path to the file/directory. Virtually equivalent to {@code base().resolve(path())},
+   * which yields {@link #path()} itself, if {@link #path()} is absolute.
    */
   @Value.Lazy
   default StorageUri absolutePath() {
@@ -48,7 +59,6 @@ public interface FileReference {
   @Value.Check
   default void check() {
     checkArgument(base().isAbsolute(), "Base location must be absolute: %s", base());
-    checkArgument(!path().isAbsolute(), "Path must be relative: %s", path());
   }
 
   static ImmutableFileReference.Builder builder() {

--- a/gc/gc-base/src/test/java/org/projectnessie/gc/expire/TestExpireAbsolutePaths.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/gc/expire/TestExpireAbsolutePaths.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2026 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.expire;
+
+import static org.projectnessie.gc.contents.ContentReference.icebergContent;
+import static org.projectnessie.model.Content.Type.ICEBERG_TABLE;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.gc.contents.LiveContentSet;
+import org.projectnessie.gc.contents.inmem.InMemoryPersistenceSpi;
+import org.projectnessie.gc.expire.local.DefaultLocalExpire;
+import org.projectnessie.gc.files.DeleteResult;
+import org.projectnessie.gc.files.DeleteSummary;
+import org.projectnessie.gc.files.FileDeleter;
+import org.projectnessie.gc.files.FileReference;
+import org.projectnessie.gc.files.FilesLister;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.storage.uri.StorageUri;
+
+/**
+ * Verifies that expiry can handle live files that are referenced via absolute URIs, because they
+ * are not located under the content's base location, see <a
+ * href="https://github.com/projectnessie/nessie/issues/10817">issue #10817</a>.
+ */
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestExpireAbsolutePaths {
+  @InjectSoftAssertions SoftAssertions soft;
+
+  static final StorageUri BASE = StorageUri.of("mock://bucket/table/");
+  static final String CONTENT_ID = "cid-1";
+
+  @Test
+  public void absolutePathsSurviveExpiry() throws Exception {
+    Instant now = Instant.now();
+    Instant maxFileModificationTime = now.minus(1, ChronoUnit.SECONDS);
+    long oldMillis = maxFileModificationTime.toEpochMilli() - 10_000L;
+
+    InMemoryPersistenceSpi storage = new InMemoryPersistenceSpi();
+    UUID id = UUID.randomUUID();
+    storage.startIdentifyLiveContents(id, now);
+    storage.addIdentifiedLiveContent(
+        id,
+        Stream.of(
+            icebergContent(
+                ICEBERG_TABLE,
+                CONTENT_ID,
+                "12345678",
+                ContentKey.of("foo", "bar"),
+                BASE.resolve("metadata-1").toString(),
+                42L)));
+    storage.finishedIdentifyLiveContents(id, now, null);
+    LiveContentSet liveContentSet = storage.getLiveContentSet(id);
+
+    // Live files referenced by the content:
+    // * "metadata-1" is a regular file under the content's base location
+    // * "abs-live.parquet" is referenced via an absolute URI, but happens to be located under the
+    //   base location, so the sweep phase sees it while listing
+    // * "other.parquet" is referenced via an absolute URI outside the base location, it is never
+    //   listed and must not cause expiry to fail
+    ContentToFiles contentToFiles =
+        contentReference ->
+            Stream.of(
+                FileReference.of(StorageUri.of("metadata-1"), BASE, -1L),
+                FileReference.of(BASE.resolve("abs-live.parquet"), BASE, -1L),
+                FileReference.of(StorageUri.of("mock://elsewhere/other.parquet"), BASE, -1L));
+
+    FilesLister lister =
+        path -> {
+          soft.assertThat(path).isEqualTo(BASE);
+          return Stream.of(
+              FileReference.of(StorageUri.of("metadata-1"), path, oldMillis),
+              FileReference.of(StorageUri.of("abs-live.parquet"), path, oldMillis),
+              FileReference.of(StorageUri.of("unused-1"), path, oldMillis),
+              FileReference.of(
+                  StorageUri.of("too-new"), path, maxFileModificationTime.toEpochMilli() + 1));
+        };
+
+    Set<StorageUri> deleted = ConcurrentHashMap.newKeySet();
+    FileDeleter deleter =
+        fileObject -> {
+          deleted.add(fileObject.absolutePath());
+          return DeleteResult.SUCCESS;
+        };
+
+    DefaultLocalExpire localExpire =
+        DefaultLocalExpire.builder()
+            .expireParameters(
+                ExpireParameters.builder()
+                    .liveContentSet(liveContentSet)
+                    .filesLister(lister)
+                    .fileDeleter(deleter)
+                    .expectedFileCount(100)
+                    .contentToFiles(contentToFiles)
+                    .maxFileModificationTime(maxFileModificationTime)
+                    .build())
+            .build();
+
+    DeleteSummary deleteSummary = localExpire.expire();
+
+    soft.assertThat(deleteSummary)
+        .extracting(DeleteSummary::deleted, DeleteSummary::failures)
+        .containsExactly(1L, 0L);
+    soft.assertThat(deleted).containsExactly(BASE.resolve("unused-1"));
+
+    try (Stream<StorageUri> baseLocations = liveContentSet.fetchBaseLocations(CONTENT_ID)) {
+      soft.assertThat(baseLocations).containsExactly(BASE);
+    }
+  }
+}

--- a/gc/gc-base/src/test/java/org/projectnessie/gc/files/TestFileReference.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/gc/files/TestFileReference.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.files;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.storage.uri.StorageUri;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestFileReference {
+  @InjectSoftAssertions SoftAssertions soft;
+
+  @Test
+  public void relativePath() {
+    StorageUri base = StorageUri.of("s3://bucket/warehouse/table/");
+    FileReference ref = FileReference.of(StorageUri.of("data/file-1.parquet"), base, -1L);
+
+    soft.assertThat(ref.absolutePath())
+        .isEqualTo(StorageUri.of("s3://bucket/warehouse/table/data/file-1.parquet"));
+  }
+
+  @Test
+  public void absolutePathOutsideBase() {
+    // Files outside the content's base location, see
+    // https://github.com/projectnessie/nessie/issues/10817
+    StorageUri base = StorageUri.of("s3://bucket/warehouse/table/");
+    StorageUri file = StorageUri.of("s3://other-bucket/elsewhere/file-1.parquet");
+    FileReference ref = FileReference.of(file, base, -1L);
+
+    soft.assertThat(ref.path()).isEqualTo(file);
+    soft.assertThat(ref.absolutePath()).isEqualTo(file);
+  }
+
+  @Test
+  public void relativeBaseRejected() {
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                FileReference.of(
+                    StorageUri.of("data/file-1.parquet"), StorageUri.of("warehouse/table/"), -1L))
+        .withMessageStartingWith("Base location must be absolute");
+  }
+}

--- a/gc/gc-iceberg/src/main/java/org/projectnessie/gc/iceberg/IcebergContentToFiles.java
+++ b/gc/gc-iceberg/src/main/java/org/projectnessie/gc/iceberg/IcebergContentToFiles.java
@@ -89,6 +89,13 @@ public abstract class IcebergContentToFiles implements ContentToFiles {
    * Provides a {@link Stream} with the {@link FileReference}s referencing the table-metadata, the
    * {@link Snapshot#manifestListLocation() manifest-list}, all {@link ManifestFile manifest-files}
    * and all {@link org.apache.iceberg.DataFile data files}.
+   *
+   * <p>Files that are located under the content's base location (the {@code location} declared in
+   * the table/view metadata) are returned with a path relative to that base location. Files outside
+   * the base location, for example data files written to a different {@code write.data.path} or
+   * files kept from a previous table location, are returned with their absolute {@link
+   * FileReference#path() path}. Such files are matched by their absolute URI during the expire
+   * phase and are never deleted when they are outside all of the content's base locations.
    */
   @Override
   @MustBeClosed
@@ -197,6 +204,8 @@ public abstract class IcebergContentToFiles implements ContentToFiles {
 
   private static Stream<FileReference> extractFilesRelativize(
       Stream<StorageUri> allFiles, StorageUri baseUri) {
+    // StorageUri.relativize() returns the file's URI unchanged, if the file is not located under
+    // 'baseUri', yielding a FileReference with an absolute path.
     return allFiles.map(baseUri::relativize).map(u -> FileReference.of(u, baseUri, -1L));
   }
 

--- a/gc/gc-iceberg/src/test/java/org/projectnessie/gc/iceberg/TestIcebergContentToFiles.java
+++ b/gc/gc-iceberg/src/test/java/org/projectnessie/gc/iceberg/TestIcebergContentToFiles.java
@@ -167,6 +167,52 @@ public class TestIcebergContentToFiles {
     }
   }
 
+  /**
+   * Table metadata whose {@code location} property does not cover the actual files, simulating for
+   * example data files written via {@code write.data.path} or files kept from a previous table
+   * location, see <a href="https://github.com/projectnessie/nessie/issues/10817">issue #10817</a>.
+   * Extraction must not fail, files outside the base location must be returned with their absolute
+   * URIs.
+   */
+  @Test
+  public void filesOutsideBaseLocation() {
+    String tableId = UUID.randomUUID().toString();
+    String tableMetaLocation = tableMetadataLocation(tableId, 0);
+    MockSnapshot tableSnapshot =
+        ImmutableMockSnapshot.builder()
+            .manifestListLocation(manifestListLocation(tableId, 0))
+            .tableUuid(tableId)
+            .build();
+    // The declared table location is different from the location of the metadata, manifest-list,
+    // manifest and data files, so none of the files can be relativized.
+    String declaredLocation = "mock://declared-location/" + tableId;
+    MockTableMetadata tableMetadata =
+        ImmutableMockTableMetadata.builder()
+            .location(declaredLocation)
+            .tableUuid(tableId)
+            .addSnapshots(tableSnapshot)
+            .build();
+    IcebergFileIOMocking fileIO = IcebergFileIOMocking.forSingleSnapshot(tableMetadata);
+    ContentReference contentReference =
+        icebergContent(
+            ICEBERG_TABLE, "cid", "12345678", ContentKey.of("foo", "bar"), tableMetaLocation, 0L);
+    StorageUri base = StorageUri.of(declaredLocation + "/");
+
+    IcebergContentToFiles contentToFiles = IcebergContentToFiles.builder().io(fileIO).build();
+    try (Stream<FileReference> extractFiles = contentToFiles.extractFiles(contentReference)) {
+      assertThat(extractFiles)
+          .allSatisfy(f -> assertThat(f.base()).isEqualTo(base))
+          .allSatisfy(f -> assertThat(f.path().isAbsolute()).isTrue())
+          .allSatisfy(f -> assertThat(f.absolutePath()).isEqualTo(f.path()))
+          .map(FileReference::absolutePath)
+          .containsExactlyInAnyOrder(
+              StorageUri.of(tableMetaLocation),
+              StorageUri.of(manifestListLocation(tableId, 0)),
+              StorageUri.of(manifestFileLocation(tableId, 0, 0)),
+              StorageUri.of(dataFilePath(tableId, 0, 0, 0)));
+    }
+  }
+
   @Test
   public void safeAgainstMissingTableMetadata() {
     InputFile inputFile = mock(InputFile.class);


### PR DESCRIPTION
Fixes #10817

### Problem

Nessie GC fails with `IllegalArgumentException: Path must be relative: s3://...` when an Iceberg snapshot references files that are not located under the `location` declared in the table's metadata — for example data files written via `write.data.path` (common with the object-storage layout, as in the issue report), or files kept from a previous table location. A single such file aborts the whole GC run during the expire phase:

```
Caused by: java.lang.IllegalArgumentException: Path must be relative: s3://bucket/path/to/file.parquet
    at org.projectnessie.gc.files.FileReference.check(FileReference.java:51)
    at org.projectnessie.gc.files.ImmutableFileReference.of(ImmutableFileReference.java:186)
    at org.projectnessie.gc.iceberg.IcebergContentToFiles.lambda$extractFilesRelativize$3(IcebergContentToFiles.java:200)
    ...
    at org.projectnessie.gc.expire.PerContentDeleteExpired.identifyLiveFiles(PerContentDeleteExpired.java:136)
```

We hit this in production against a large repository (the failing content had ~1.7M files); the issue reporter hit the same with pyiceberg + `write.data.path`.

### Change

Such files can never be expressed relative to the content's base location, so they are now tracked by their absolute URI instead of failing:

- **`FileReference`** now allows an absolute `path()` for files outside `base()` (`base()` itself must still be absolute). `absolutePath()` already resolves this case correctly (`StorageUri.resolve` returns an absolute child unchanged), and the file deleters only ever use `absolutePath()`. `IcebergContentToFiles.extractFilesRelativize` needs no code change: `StorageUri.relativize` already passes non-relativizable URIs through unchanged.
- **`PerContentDeleteExpired`** puts those files into the live-files bloom filter under their absolute URI, and — only when at least one such reference exists for the content — the sweep additionally matches listed files by their absolute URI. This keeps a live file that is referenced absolutely but happens to be located under one of the content's swept base locations (e.g. an older table location) from being wrongly deleted. A `WARN` with the per-content count of absolute references is logged.
- Files outside **all** of a content's base locations are never listed, and therefore never deleted — GC completes and expires everything it can reach, instead of aborting.

Deliberately **not** in scope: adding locations declared via table properties (`write.data.path`, `write.metadata.path`) as swept base locations. Such locations can be shared by multiple tables (e.g. an object-storage-layout data path at the bucket root, as in the issue report), and sweeping them with a single content's live set would delete other contents' live files.

### Testing

- `TestFileReference` — relaxed invariant (relative path unchanged, absolute path accepted, relative base still rejected).
- `TestIcebergContentToFiles.filesOutsideBaseLocation` — table metadata whose `location` does not cover the actual files; extraction yields absolute-path references through real metadata/manifest parsing instead of throwing.
- `TestExpireAbsolutePaths` — end-to-end expire: a live file referenced absolutely that is physically under the swept base location is **not** deleted, an unreferenced file still is, and the outside location is not added as a base location. This test fails without the sweep-side absolute-URI match.
- Existing gc-base/gc-iceberg/gc-tool/gc-repository-jdbc unit and integration suites (incl. `ITContentToFilesCrossCheck`, `ITSparkIcebergNessieS3`, `ITSparkIcebergNessieCLI`) pass unchanged.

The same change (applied onto 0.107.5) ships in an internally patched image for the production deployment that hit this failure.
