### PR TITLE
Docs: clarify S3-compatible endpoint in Iceberg REST config

### DIFF
--- a/site/docs/guides/iceberg-rest.md
+++ b/site/docs/guides/iceberg-rest.md
@@ -43,6 +43,13 @@ nessie.catalog.service.s3.buckets.sales.region=us-east-1
 See [Server configuration Reference](../nessie-latest/index.md).
 
 !!! note
+    Nessie's S3 support works with any S3-compatible object store. For Amazon S3 the `endpoint`
+    can be left unset so the AWS SDK resolves the regional endpoint automatically. For a compatible
+    object store such as Backblaze B2, Cloudflare R2, or MinIO, set
+    `nessie.catalog.service.s3.default-options.endpoint` to that provider's S3 API endpoint (for
+    example `https://s3.example.com`) and enable `path-style-access` if the store requires it.
+
+!!! note
     Up to Nessie including version 0.91.2 the above property names had to be specified without the
     `default-options.` part.
 


### PR DESCRIPTION
The S3 snippet in the Iceberg REST guide sets `default-options.endpoint` to a localhost value and only mentions non-AWS S3 in an inline comment, so it is easy to copy the block without noticing that the endpoint is what points Nessie at a given object store, and that Amazon S3 does not need it set at all.

Adds a note after the snippet: Nessie's S3 support works with any S3-compatible object store; for Amazon S3 the `endpoint` can be left unset so the AWS SDK resolves the regional endpoint, and for a compatible store the provider's S3 API endpoint goes into `nessie.catalog.service.s3.default-options.endpoint`, with `path-style-access` enabled when the store requires it. Docs only, no configuration or behavior change.
