### PR TITLE
Ensure that both Apache HTTP Client v4 and v5 are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Fixes
 
+- GC: Nessie GC was missing an explicit dependency to Apache HTTP client v4, which is required for Iceberg.
+  The AWSSDK update to 2.46.0 in 0.107.9 changed the default to Apache client v5, so v4 was missing.
+
 ### Commits
 
 ## [0.108.3] Release (2026-07-23)

--- a/gc/gc-iceberg-files/build.gradle.kts
+++ b/gc/gc-iceberg-files/build.gradle.kts
@@ -76,7 +76,11 @@ dependencies {
   testFixturesApi(platform(libs.awssdk.bom))
   testFixturesApi("software.amazon.awssdk:s3")
   testFixturesRuntimeOnly("software.amazon.awssdk:sts")
-  testFixturesRuntimeOnly(libs.hadoop.aws)
+  testFixturesRuntimeOnly("software.amazon.awssdk:kms")
+  testFixturesRuntimeOnly(libs.hadoop.aws) {
+    exclude("software.amazon.awssdk", "bundle")
+  }
+  testFixturesRuntimeOnly("software.amazon.awssdk:apache-client")
 
   testFixturesRuntimeOnly(platform(libs.google.cloud.storage.bom))
   testFixturesRuntimeOnly(platform(libs.google.cloud.libraries.bom))

--- a/gc/gc-iceberg-files/src/test/java/org/projectnessie/gc/iceberg/files/TestIcebergS3Files.java
+++ b/gc/gc-iceberg-files/src/test/java/org/projectnessie/gc/iceberg/files/TestIcebergS3Files.java
@@ -37,7 +37,6 @@ public class TestIcebergS3Files extends AbstractFiles {
     props.put("s3.endpoint", server.getS3BaseUri().toString());
     // must enforce path-style access because S3Resource has the bucket name in its path
     props.put("s3.path-style-access", "true");
-    props.put("http-client.type", "urlconnection");
 
     return props;
   }

--- a/gc/gc-iceberg-inttest/build.gradle.kts
+++ b/gc/gc-iceberg-inttest/build.gradle.kts
@@ -100,16 +100,18 @@ dependencies {
   )
 
   intTestRuntimeOnly(libs.hadoop.client)
-  intTestRuntimeOnly(libs.hadoop.aws)
-  intTestRuntimeOnly("software.amazon.awssdk:sts")
+  intTestRuntimeOnly(libs.hadoop.aws) {
+    exclude("software.amazon.awssdk", "bundle")
+  }
 
   intTestImplementation(platform(libs.awssdk.bom))
   intTestImplementation("software.amazon.awssdk:s3")
-  runtimeOnly("software.amazon.awssdk:url-connection-client")
-  // TODO those are needed, because Spark serializes some configuration stuff (Spark broadcast)
+  intTestRuntimeOnly("software.amazon.awssdk:s3-transfer-manager")
   intTestRuntimeOnly("software.amazon.awssdk:dynamodb")
   intTestRuntimeOnly("software.amazon.awssdk:glue")
   intTestRuntimeOnly("software.amazon.awssdk:kms")
+  intTestRuntimeOnly("software.amazon.awssdk:sts")
+  intTestRuntimeOnly("software.amazon.awssdk:apache-client")
 
   intTestImplementation(platform(libs.google.cloud.storage.bom))
   intTestRuntimeOnly(platform(libs.google.cloud.libraries.bom))

--- a/gc/gc-tool-inttest/build.gradle.kts
+++ b/gc/gc-tool-inttest/build.gradle.kts
@@ -93,7 +93,9 @@ dependencies {
   )
 
   intTestRuntimeOnly(libs.hadoop.client)
-  intTestRuntimeOnly(libs.hadoop.aws)
+  intTestRuntimeOnly(libs.hadoop.aws) {
+    exclude("software.amazon.awssdk", "bundle")
+  }
   intTestRuntimeOnly("software.amazon.awssdk:sts")
 
   intTestRuntimeOnly(platform(libs.awssdk.bom))

--- a/gc/gc-tool/build.gradle.kts
+++ b/gc/gc-tool/build.gradle.kts
@@ -71,6 +71,8 @@ dependencies {
 
   implementation(platform(libs.awssdk.bom))
   runtimeOnly("software.amazon.awssdk:s3")
+  runtimeOnly("software.amazon.awssdk:apache-client")
+  runtimeOnly("software.amazon.awssdk:apache5-client")
   runtimeOnly("software.amazon.awssdk:url-connection-client")
   runtimeOnly("software.amazon.awssdk:sts")
   runtimeOnly("software.amazon.awssdk:kms")

--- a/integrations/spark-extensions/build.gradle.kts
+++ b/integrations/spark-extensions/build.gradle.kts
@@ -51,11 +51,19 @@ dependencies {
   testFixturesImplementation("org.apache.iceberg:iceberg-spark-extensions-${sparkScala.sparkMajorVersion}_${sparkScala.scalaMajorVersion}:$versionIceberg")
   testFixturesImplementation("org.apache.iceberg:iceberg-hive-metastore:$versionIceberg")
   testFixturesImplementation("org.apache.iceberg:iceberg-aws:$versionIceberg")
-  testFixturesImplementation("org.apache.iceberg:iceberg-aws-bundle:$versionIceberg")
   intTestRuntimeOnly(libs.hadoop.client) {
     exclude("org.slf4j", "slf4j-reload4j")
   }
-  intTestRuntimeOnly(libs.hadoop.aws)
+  intTestRuntimeOnly(libs.hadoop.aws) {
+    exclude("software.amazon.awssdk", "bundle")
+  }
+  intTestRuntimeOnly(platform(libs.awssdk.bom))
+  intTestRuntimeOnly("software.amazon.awssdk:apache-client")
+  intTestRuntimeOnly("software.amazon.awssdk:s3-transfer-manager")
+  intTestRuntimeOnly("software.amazon.awssdk:dynamodb")
+  intTestRuntimeOnly("software.amazon.awssdk:glue")
+  intTestRuntimeOnly("software.amazon.awssdk:kms")
+  intTestRuntimeOnly("software.amazon.awssdk:sts")
 
   testFixturesRuntimeOnly(libs.logback.classic)
   testFixturesImplementation(libs.slf4j.log4j.over.slf4j) {

--- a/testing/floci-s3-container/src/intTest/java/org/projectnessie/testing/floci/s3/ITFlociS3Extension.java
+++ b/testing/floci-s3-container/src/intTest/java/org/projectnessie/testing/floci/s3/ITFlociS3Extension.java
@@ -50,7 +50,7 @@ public class ITFlociS3Extension {
         .containsEntry("s3.access-key-id", flociS3.accessKey())
         .containsEntry("s3.secret-access-key", flociS3.secretKey())
         .containsEntry("s3.endpoint", flociS3.s3endpoint())
-        .containsKey("http-client.type");
+        .doesNotContainKey("http-client.type");
 
     soft.assertThat(flociS3.hadoopConfig())
         .isNotNull()

--- a/testing/floci-s3-container/src/main/java/org/projectnessie/testing/floci/s3/FlociS3Container.java
+++ b/testing/floci-s3-container/src/main/java/org/projectnessie/testing/floci/s3/FlociS3Container.java
@@ -136,7 +136,6 @@ public final class FlociS3Container extends FlociContainer implements FlociS3Acc
     props.put("s3.secret-access-key", secretKey());
     props.put("s3.endpoint", s3endpoint());
     props.put("s3.path-style-access", "true");
-    props.put("http-client.type", "urlconnection");
     return props;
   }
 


### PR DESCRIPTION
Since the dependency update of the AWSSDK to 2.46.0 (with Nessie 0.107.9), Nessie GC may have failed to run due to the Apache HTTP Client v4 was missing since then.

This change ensures that both Apache HTTP client versions are present.

Relevant tests have been adopted to ensure the test-fixture specific default to the AWSSDK URL-connection-client is removed. Some `*bundle` dependencies have been replaced with explicit dependencies to ensure that the v4 client doesn't accidentally leak into the tests, so we test the explicit dependencies.

Fixes #12821