### PR TITLE
fix: Support custom S3 virtual-host request signing

### DIFF
--- a/SECURITY_THREAT_MODEL.md
+++ b/SECURITY_THREAT_MODEL.md
@@ -224,6 +224,11 @@ a missing-table or future-location fallback. Missing content may be handled as a
 case where the signer endpoint was already minted for that location; authorization and unexpected
 lookup failures are fail-closed conditions. `(documented)`
 
+S3 request signing may recognize custom virtual-host endpoints that do not use AWS-style `s3`
+hostnames. This recognition is anchored to a bucket derived from the signer-authorized warehouse,
+write, or read locations; it does not widen the table paths permitted by current-location,
+historical-location, metadata-file, or object-storage-layout checks. `(documented)`
+
 Object-store credentials or temporary access material exposed through catalog features are in scope only
 for configured credential-vending or request-signing modes. Operators are responsible for cloud IAM
 policy scope, role trust policies, external IDs, token/session duration, and bucket or filesystem

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3Signer.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3Signer.java
@@ -71,9 +71,13 @@ public class S3Signer implements RequestSigner {
             .method(SdkHttpMethod.fromValue(clientRequest.method()))
             .headers(clientRequest.headers());
 
-    S3BucketOptions bucketOptions =
-        s3Options.resolveOptionsForUri(
-            StorageUri.of(S3Utils.asS3Location(clientRequest.uri().toString())));
+    String uriString = uri.toString();
+    String s3Location =
+        clientRequest
+            .bucket()
+            .map(bucket -> S3Utils.asS3Location(uriString, bucket))
+            .orElseGet(() -> S3Utils.asS3Location(uriString));
+    S3BucketOptions bucketOptions = s3Options.resolveOptionsForUri(StorageUri.of(s3Location));
     AwsCredentialsProvider credentialsProvider =
         S3Clients.serverCredentialsProvider(bucketOptions, s3sessions, secretsProvider);
     AwsCredentialsIdentity credentials = credentialsProvider.resolveCredentials();

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3Utils.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3Utils.java
@@ -101,6 +101,14 @@ public final class S3Utils {
   }
 
   public static String asS3Location(String uri) {
+    return asS3Location(uri, Optional.empty());
+  }
+
+  public static String asS3Location(String uri, String bucketHint) {
+    return asS3Location(uri, Optional.of(requireNonNull(bucketHint, "Bucket hint missing")));
+  }
+
+  private static String asS3Location(String uri, Optional<String> bucketHint) {
     URI httpUri = URI.create(uri);
     checkArgument(httpUri.getScheme() != null, "No scheme in URI: '%s'", httpUri);
     checkArgument(httpUri.getHost() != null, "No host in URI: '%s'", httpUri);
@@ -111,9 +119,15 @@ public final class S3Utils {
     String bucket;
     String key;
     Matcher matcher = S3_HOST_PATTERN.matcher(httpUri.getHost());
+    Optional<String> customVirtualHostedBucket =
+        bucketHint.filter(hint -> httpUri.getHost().startsWith(hint + "."));
     if (matcher.matches() && matcher.group(2) != null) {
       // virtual-hosted style
       bucket = matcher.group(2);
+      key = httpUri.getPath();
+    } else if (customVirtualHostedBucket.isPresent()) {
+      // virtual-hosted style with a caller-provided bucket for custom S3 endpoints
+      bucket = customVirtualHostedBucket.get();
       key = httpUri.getPath();
     } else {
       // path-style access style

--- a/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/s3/TestS3Utils.java
+++ b/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/s3/TestS3Utils.java
@@ -111,6 +111,22 @@ class TestS3Utils {
     assertThat(S3Utils.asS3Location(location)).isEqualTo(expected);
   }
 
+  @ParameterizedTest
+  @CsvSource({
+    "https://example-bucket.obs.example.com/mydir/myfile, example-bucket,"
+        + " s3://example-bucket/mydir/myfile",
+    "https://example-bucket.s3.amazonaws.com/mydir/myfile, example-bucket,"
+        + " s3://example-bucket/mydir/myfile",
+    "https://example-bucket.other.s3.amazonaws.com/mydir/myfile, example-bucket,"
+        + " s3://example-bucket.other/mydir/myfile",
+    "https://obs.example.com/example-bucket/mydir/myfile, example-bucket,"
+        + " s3://example-bucket/mydir/myfile",
+    "https://not-example-bucket.obs.example.com/mydir/myfile, example-bucket, s3://mydir/myfile",
+  })
+  void asS3LocationWithBucketHint(String location, String bucket, String expected) {
+    assertThat(S3Utils.asS3Location(location, bucket)).isEqualTo(expected);
+  }
+
   @Test
   void asS3LocationErrors() {
     assertThatThrownBy(() -> S3Utils.asS3Location("ftp://localhost:9000/mybucket/mydir/myfile"))
@@ -125,5 +141,17 @@ class TestS3Utils {
     assertThatThrownBy(() -> S3Utils.asS3Location("https://s3.us-east-1.amazonaws.com"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid S3 URI: 'https://s3.us-east-1.amazonaws.com'");
+
+    assertThatThrownBy(
+            () ->
+                S3Utils.asS3Location("ftp://example-bucket.obs.example.com/key", "example-bucket"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Unsupported URI scheme: 'ftp'");
+    assertThatThrownBy(() -> S3Utils.asS3Location("http:///key", "example-bucket"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("No host in URI: 'http:///key'");
+    assertThatThrownBy(() -> S3Utils.asS3Location("https://obs.example.com/", "example-bucket"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid S3 URI: 'https://obs.example.com/'");
   }
 }

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergS3SignParams.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergS3SignParams.java
@@ -17,7 +17,6 @@ package org.projectnessie.catalog.service.rest;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
-import static org.projectnessie.catalog.files.s3.S3Utils.extractBucketName;
 import static org.projectnessie.catalog.files.s3.S3Utils.normalizeS3Scheme;
 import static org.projectnessie.catalog.formats.iceberg.nessie.CatalogOps.CATALOG_S3_SIGN;
 import static org.projectnessie.catalog.formats.iceberg.rest.IcebergError.icebergError;
@@ -102,10 +101,37 @@ abstract class IcebergS3SignParams {
         "locations must be S3 URIs");
   }
 
-  @Value.Lazy
   String requestedS3Uri() {
-    return S3Utils.asS3Location(request().uri());
+    return requestedLocation().uri();
   }
+
+  Optional<String> requestedBucket() {
+    return requestedLocation().bucket();
+  }
+
+  @Value.Lazy
+  RequestedLocation requestedLocation() {
+    return Stream.concat(
+            Stream.of(warehouseLocation()),
+            Stream.concat(writeLocations().stream(), readLocations().stream()))
+        .map(URI::create)
+        .filter(uri -> S3Utils.isS3scheme(uri.getScheme()))
+        .map(S3Utils::extractBucketName)
+        .flatMap(Optional::stream)
+        .distinct()
+        .map(
+            bucket ->
+                new RequestedLocation(
+                    S3Utils.asS3Location(request().uri(), bucket), Optional.of(bucket)))
+        .filter(
+            location ->
+                location.bucket().orElseThrow().equals(URI.create(location.uri()).getAuthority()))
+        .findFirst()
+        .orElseGet(
+            () -> new RequestedLocation(S3Utils.asS3Location(request().uri()), Optional.empty()));
+  }
+
+  record RequestedLocation(String uri, Optional<String> bucket) {}
 
   @Value.Lazy
   boolean write() {
@@ -275,12 +301,16 @@ abstract class IcebergS3SignParams {
 
   private IcebergS3SignResponse sign(String uriToSign) {
     URI uri = URI.create(uriToSign);
-    Optional<String> bucket = extractBucketName(uri);
     Optional<String> body = Optional.ofNullable(request().body());
 
     SigningRequest signingRequest =
         SigningRequest.signingRequest(
-            uri, request().method(), request().region(), bucket, body, request().headers());
+            uri,
+            request().method(),
+            request().region(),
+            requestedBucket(),
+            body,
+            request().headers());
 
     SigningResponse signed = signer().sign(signingRequest);
 
@@ -297,7 +327,8 @@ abstract class IcebergS3SignParams {
                 List.of()));
     String s3Uri = requestedS3Uri();
     LOGGER.warn(
-        "Unauthorized signing request: key: {}, ref: {}, s3-uri: {}, request uri: {}, request method: {}, warehouse: {}, writeable locations: {}, readable locations: {}",
+        "Unauthorized signing request: key: {}, ref: {}, s3-uri: {}, request uri: {}, request"
+            + " method: {}, warehouse: {}, writeable locations: {}, readable locations: {}",
         key(),
         ref(),
         s3Uri,

--- a/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergS3SignParams.java
+++ b/catalog/service/rest/src/main/java/org/projectnessie/catalog/service/rest/IcebergS3SignParams.java
@@ -58,6 +58,7 @@ import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IcebergContent;
+import org.projectnessie.storage.uri.StorageUri;
 import org.projectnessie.versioned.RequestMeta.RequestMetaBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,10 +115,10 @@ abstract class IcebergS3SignParams {
     return Stream.concat(
             Stream.of(warehouseLocation()),
             Stream.concat(writeLocations().stream(), readLocations().stream()))
-        .map(URI::create)
-        .filter(uri -> S3Utils.isS3scheme(uri.getScheme()))
-        .map(S3Utils::extractBucketName)
-        .flatMap(Optional::stream)
+        .map(StorageUri::of)
+        .filter(uri -> S3Utils.isS3scheme(uri.scheme()))
+        .map(StorageUri::authority)
+        .flatMap(Stream::ofNullable)
         .distinct()
         .map(
             bucket ->
@@ -125,7 +126,7 @@ abstract class IcebergS3SignParams {
                     S3Utils.asS3Location(request().uri(), bucket), Optional.of(bucket)))
         .filter(
             location ->
-                location.bucket().orElseThrow().equals(URI.create(location.uri()).getAuthority()))
+                location.bucket().orElseThrow().equals(StorageUri.of(location.uri()).authority()))
         .findFirst()
         .orElseGet(
             () -> new RequestedLocation(S3Utils.asS3Location(request().uri()), Optional.empty()));

--- a/catalog/service/rest/src/test/java/org/projectnessie/catalog/service/rest/TestIcebergS3SignParams.java
+++ b/catalog/service/rest/src/test/java/org/projectnessie/catalog/service/rest/TestIcebergS3SignParams.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.projectnessie.catalog.service.rest.IcebergApiV1ResourceBase.ICEBERG_V1;
@@ -43,11 +44,13 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.projectnessie.api.v2.params.ParsedReference;
 import org.projectnessie.catalog.files.api.ImmutableSigningResponse;
 import org.projectnessie.catalog.files.api.RequestSigner;
+import org.projectnessie.catalog.files.api.SigningRequest;
 import org.projectnessie.catalog.files.api.SigningResponse;
 import org.projectnessie.catalog.formats.iceberg.nessie.CatalogOps;
 import org.projectnessie.catalog.formats.iceberg.rest.IcebergException;
@@ -101,6 +104,12 @@ class TestIcebergS3SignParams {
       "https://old-bucket.s3.amazonaws.com/ns/table1/data/file1.parquet";
 
   static final String metadataJsonUri = s3BucketAws + locationPart + "/metadata/metadata.json";
+  static final String customWarehouseLocation = "s3://example-bucket/warehouse/";
+  static final String customBaseLocation = customWarehouseLocation + locationPart;
+  static final String customVirtualHostBaseUri =
+      "https://example-bucket.obs.example.com/warehouse/";
+  static final String customDataFileUri =
+      customVirtualHostBaseUri + locationPart + "/data/file1.parquet";
 
   final IcebergS3SignRequest writeRequest =
       IcebergS3SignRequest.builder()
@@ -255,6 +264,73 @@ class TestIcebergS3SignParams {
             .build();
     Uni<IcebergS3SignResponse> response = icebergSigner.verifyAndSign();
     expectSuccess(response);
+  }
+
+  @Test
+  void verifyAndSignSuccessCustomVirtualHostRead() throws Exception {
+    when(catalogService.retrieveSnapshot(
+            any(), eq(key), isNull(), eq(expectedApiRead(key)), eq(ICEBERG_V1)))
+        .thenReturn(CompletableFuture.completedStage(customVirtualHostSnapshotResponse()));
+    when(signer.sign(any())).thenReturn(signingResponse);
+    IcebergS3SignParams icebergSigner =
+        newBuilder()
+            .request(
+                IcebergS3SignRequest.builder()
+                    .from(readRequest)
+                    .uri(customDataFileUri)
+                    .method("GET")
+                    .build())
+            .warehouseLocation(customWarehouseLocation)
+            .writeLocations(List.of(customBaseLocation))
+            .build();
+
+    expectSuccess(icebergSigner.verifyAndSign());
+
+    ArgumentCaptor<SigningRequest> signingRequest = ArgumentCaptor.forClass(SigningRequest.class);
+    verify(signer).sign(signingRequest.capture());
+    soft.assertThat(signingRequest.getValue().bucket()).contains("example-bucket");
+  }
+
+  @Test
+  void verifyAndSignSuccessCustomVirtualHostWrite() throws Exception {
+    when(catalogService.retrieveSnapshot(
+            any(), eq(key), isNull(), eq(expectedApiWrite(key)), eq(ICEBERG_V1)))
+        .thenReturn(CompletableFuture.completedStage(customVirtualHostSnapshotResponse()));
+    when(signer.sign(any())).thenReturn(signingResponse);
+    IcebergS3SignParams icebergSigner =
+        newBuilder()
+            .request(
+                IcebergS3SignRequest.builder().from(writeRequest).uri(customDataFileUri).build())
+            .warehouseLocation(customWarehouseLocation)
+            .writeLocations(List.of(customBaseLocation))
+            .build();
+
+    expectSuccess(icebergSigner.verifyAndSign());
+
+    ArgumentCaptor<SigningRequest> signingRequest = ArgumentCaptor.forClass(SigningRequest.class);
+    verify(signer).sign(signingRequest.capture());
+    soft.assertThat(signingRequest.getValue().bucket()).contains("example-bucket");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "https://other-bucket.obs.example.com/warehouse/ns/table1_cafebabe/data/file1.parquet",
+        "https://example-bucket.obs.example.com/outside/ns/table1_cafebabe/data/file1.parquet"
+      })
+  void verifyAndSignFailureCustomVirtualHostNotAllowed(String uri) throws Exception {
+    when(catalogService.retrieveSnapshot(
+            any(), eq(key), isNull(), eq(expectedApiWrite(key)), eq(ICEBERG_V1)))
+        .thenReturn(CompletableFuture.completedStage(customVirtualHostSnapshotResponse()));
+    IcebergS3SignParams icebergSigner =
+        newBuilder()
+            .request(IcebergS3SignRequest.builder().from(writeRequest).uri(uri).build())
+            .warehouseLocation(customWarehouseLocation)
+            .writeLocations(List.of(customBaseLocation))
+            .build();
+
+    expectFailure(icebergSigner.verifyAndSign(), "URI not allowed for signing: " + uri);
+    verifyNoInteractions(signer);
   }
 
   @Test
@@ -433,6 +509,26 @@ class TestIcebergS3SignParams {
             .build();
     Uni<IcebergS3SignResponse> response = icebergSigner.verifyAndSign();
     expectFailure(response, "URI not allowed for signing: " + dataFileUri);
+  }
+
+  private SnapshotResponse customVirtualHostSnapshotResponse() {
+    Content customTable =
+        IcebergTable.of(customBaseLocation + "/metadata/metadata.json", 1, 1, 1, 1);
+    NessieTableSnapshot customSnapshot =
+        NessieTableSnapshot.builder()
+            .id(NessieId.randomNessieId())
+            .entity(nessieTable)
+            .icebergLocation(customBaseLocation)
+            .lastUpdatedTimestamp(Instant.now())
+            .build();
+    return SnapshotResponse.forEntity(
+        Branch.of("main", "12345678"),
+        customTable,
+        "metadata.json",
+        "application/json",
+        key,
+        customTable,
+        customSnapshot);
   }
 
   private ImmutableIcebergS3SignParams.Builder newBuilder() {

--- a/catalog/service/rest/src/test/java/org/projectnessie/catalog/service/rest/TestIcebergS3SignParams.java
+++ b/catalog/service/rest/src/test/java/org/projectnessie/catalog/service/rest/TestIcebergS3SignParams.java
@@ -266,6 +266,32 @@ class TestIcebergS3SignParams {
     expectSuccess(response);
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"warehouse", "write", "read"})
+  void requestedLocationWithSpecialCharacters(String locationSource) {
+    String location = "s3://example-bucket/warehouse with space/table[1]%";
+    ImmutableIcebergS3SignParams.Builder builder =
+        newBuilder()
+            .request(
+                IcebergS3SignRequest.builder()
+                    .from(readRequest)
+                    .uri(
+                        "https://example-bucket.obs.example.com/"
+                            + "warehouse%20with%20space/table%5B1%5D%25/data/file.parquet")
+                    .build())
+            .writeLocations(List.of());
+    switch (locationSource) {
+      case "warehouse" -> builder.warehouseLocation(location);
+      case "write" -> builder.addWriteLocations(location);
+      case "read" -> builder.addReadLocations(location);
+      default -> throw new IllegalArgumentException(locationSource);
+    }
+    IcebergS3SignParams icebergSigner = builder.build();
+
+    soft.assertThat(icebergSigner.requestedS3Uri()).isEqualTo(location + "/data/file.parquet");
+    soft.assertThat(icebergSigner.requestedBucket()).contains("example-bucket");
+  }
+
   @Test
   void verifyAndSignSuccessCustomVirtualHostRead() throws Exception {
     when(catalogService.retrieveSnapshot(


### PR DESCRIPTION
Extend `S3Utils` with a bucket-aware HTTP-to-S3 conversion path: when a caller supplies a bucket already derived from an authorized S3 location, recognize `<bucket>.<endpoint-host>` as virtual-host style without requiring an `s3` hostname marker; otherwise preserve the existing AWS virtual-host and path-style parsing behavior. In `IcebergS3SignParams`, derive candidate bucket identities only from the signed warehouse/write/read location set, use a matching candidate to normalize the requested URI before the existing current/historical location checks, and pass the verified bucket through `SigningRequest` rather than re-extracting it from the custom HTTP hostname. Update `S3Signer` to use that bucket hint when reconstructing the storage URI used for per-bucket option and credential resolution, while retaining the legacy conversion fallback for callers without a hint. Nessie's HTTP-to-S3 location conversion recognizes virtual-host-style requests only when the hostname matches its AWS-shaped `s3` pattern. A request such as `https://example-bucket.obs.example.com/key` is therefore interpreted as path style, producing the wrong bucket and failing the table-location authorization check even when Nessie advertised `s3.path-style-access=false`. The same conversion is used later by `S3Signer` to resolve per-bucket credentials, so changing only the authorization comparison would still select storage options from the wrong location. This makes remote signing unusable for S3-compatible services such as SberCloud OBS that require virtual-host addressing and do not offer STS credentials vending.

Testing: Convert AWS virtual-host URLs and custom-endpoint path-style URLs exactly as before, and convert an OBS-shaped `https://example-bucket.obs.example.com/key` URL to `s3://example-bucket/key` only when `example-bucket` is supplied as the bucket hint; Preserve URI validation failures for unsupported schemes, missing hosts, and malformed path-style requests; do not treat a hostname that lacks the exact `<authorized-bucket>.` prefix as the hinted bucket.

Fixes #12854
