### PR TITLE
Fix incorrect CLI command descriptions

### DIFF
--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/AlterNamespaceCommand.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/AlterNamespaceCommand.java
@@ -88,7 +88,7 @@ public class AlterNamespaceCommand extends NessieCommittingCommand<AlterNamespac
 
   @Override
   public String description() {
-    return "Changes a new namespace.";
+    return "Update an existing namespace.";
   }
 
   @Override

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/RevertContentCommand.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/commands/RevertContentCommand.java
@@ -187,7 +187,7 @@ public class RevertContentCommand extends NessieCommittingCommand<RevertContentC
 
   @Override
   public String description() {
-    return "Create a new namespace.";
+    return "Revert content keys to a previous state.";
   }
 
   @Override


### PR DESCRIPTION
## Summary
- `RevertContentCommand.description()` previously returned `"Create a new namespace."` (copy-pasted from `CREATE NAMESPACE`). It now says `"Revert content keys to a previous state."`, matching `RevertContentStatement.help.txt`.
- `AlterNamespaceCommand.description()` previously returned `"Changes a new namespace."` It now says `"Update an existing namespace."`, matching `AlterNamespaceStatement.help.txt`.

These strings are what `HELP` prints in the command listing.

## Test plan
- [x] Confirmed no CLI tests assert the old HELP one-liners (no golden/snapshot to regenerate)
- [x] `./gradlew spotlessApply`
- [x] `./gradlew sAp compileAll jar codeChecks`
