### PR TITLE
Add SQL Server dialect for the JDBC2 persist backend

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -116,6 +116,20 @@
       ],
     },
 
+    // SQL Server container EULA can change on image upgrades. Review the EULA before merge.
+    {
+      matchManagers: [
+        'dockerfile',
+        'devcontainer',
+        'docker-compose',
+      ],
+      automerge: false,
+      platformAutomerge: false,
+      matchPackageNames: [
+        'mcr.microsoft.com/mssql/server',
+      ],
+    },
+
     // Dockerfile for google-cloud-cli, basically no minor/patch version, daily major version updates
     {
       matchManagers: [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ as necessary. Empty sections will not end in the release notes.
 
 ### New Features
 
-- JDBC2 persist backend: experimental Microsoft SQL Server dialect, taken from #12288 by @scotchr. Nessie server / Quarkus datasource wiring is not included yet.
-
 ### Changes
 
 ### Deprecations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ as necessary. Empty sections will not end in the release notes.
 
 ### New Features
 
-- JDBC2 version store: experimental persist dialect for Microsoft SQL Server (`jdbc:sqlserver://` URLs). Taken from #12288 by @scotchr.
+- JDBC2 persist backend: experimental Microsoft SQL Server dialect, taken from #12288 by @scotchr. Nessie server / Quarkus datasource wiring is not included yet.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ as necessary. Empty sections will not end in the release notes.
 
 ### New Features
 
+- JDBC2 version store: experimental persist dialect for Microsoft SQL Server (`jdbc:sqlserver://` URLs). Taken from #12288 by @scotchr.
+
 ### Changes
 
 ### Deprecations

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -113,6 +113,7 @@ microprofile-openapi = { module = "org.eclipse.microprofile.openapi:microprofile
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 mongodb-driver-sync = { module = "org.mongodb:mongodb-driver-sync", version = "5.10.0" }
+mssql-jdbc = { module = "com.microsoft.sqlserver:mssql-jdbc", version = "13.4.0.jre11" }
 nessie-runner-common = { module = "org.projectnessie.nessie-runner:nessie-runner-common", version = "0.32.7" }
 nessie-ui = { module = "org.projectnessie.nessie.ui:nessie-ui", version = "0.66.0" }
 netty-bom = { module = "io.netty:netty-bom", version.ref = "netty" }

--- a/versioned/storage/jdbc2-tests/build.gradle.kts
+++ b/versioned/storage/jdbc2-tests/build.gradle.kts
@@ -39,4 +39,5 @@ dependencies {
   implementation("org.testcontainers:testcontainers-cockroachdb")
   implementation("org.testcontainers:testcontainers-mariadb")
   implementation("org.testcontainers:testcontainers-mysql")
+  implementation("org.testcontainers:testcontainers-mssqlserver")
 }

--- a/versioned/storage/jdbc2-tests/src/main/java/org/projectnessie/versioned/storage/jdbc2tests/MssqlBackendTestFactory.java
+++ b/versioned/storage/jdbc2-tests/src/main/java/org/projectnessie/versioned/storage/jdbc2tests/MssqlBackendTestFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.jdbc2tests;
+
+import jakarta.annotation.Nonnull;
+import java.util.Map;
+import org.projectnessie.versioned.storage.jdbc2.Jdbc2BackendFactory;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.mssqlserver.MSSQLServerContainer;
+
+public class MssqlBackendTestFactory extends ContainerBackendTestFactory {
+
+  @Override
+  public String getName() {
+    return Jdbc2BackendFactory.NAME + "-Mssql";
+  }
+
+  @Nonnull
+  @Override
+  @SuppressWarnings("resource")
+  protected JdbcDatabaseContainer<?> createContainer() {
+    return new MSSQLServerContainer(
+            dockerImage("mssql").asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server"))
+        .acceptLicense();
+  }
+
+  @Override
+  public Map<String, String> getQuarkusConfig() {
+    return Map.of(
+        "quarkus.datasource.mssql.jdbc.url",
+        jdbcUrl(),
+        "quarkus.datasource.mssql.username",
+        jdbcUser(),
+        "quarkus.datasource.mssql.password",
+        jdbcPass());
+  }
+}

--- a/versioned/storage/jdbc2-tests/src/main/resources/META-INF/services/org.projectnessie.versioned.storage.testextension.BackendTestFactory
+++ b/versioned/storage/jdbc2-tests/src/main/resources/META-INF/services/org.projectnessie.versioned.storage.testextension.BackendTestFactory
@@ -18,3 +18,4 @@ org.projectnessie.versioned.storage.jdbc2tests.CockroachBackendTestFactory
 org.projectnessie.versioned.storage.jdbc2tests.H2BackendTestFactory
 org.projectnessie.versioned.storage.jdbc2tests.MariaDBBackendTestFactory
 org.projectnessie.versioned.storage.jdbc2tests.MySQLBackendTestFactory
+org.projectnessie.versioned.storage.jdbc2tests.MssqlBackendTestFactory

--- a/versioned/storage/jdbc2-tests/src/main/resources/org/projectnessie/versioned/storage/jdbc2tests/Dockerfile-mssql-version
+++ b/versioned/storage/jdbc2-tests/src/main/resources/org/projectnessie/versioned/storage/jdbc2tests/Dockerfile-mssql-version
@@ -1,0 +1,3 @@
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM mcr.microsoft.com/mssql/server:2022-latest

--- a/versioned/storage/jdbc2-tests/src/main/resources/org/projectnessie/versioned/storage/jdbc2tests/Dockerfile-mssql-version
+++ b/versioned/storage/jdbc2-tests/src/main/resources/org/projectnessie/versioned/storage/jdbc2tests/Dockerfile-mssql-version
@@ -1,3 +1,7 @@
 # Dockerfile to provide the image name and tag to a test.
 # Version is managed by Renovate - do not edit.
-FROM mcr.microsoft.com/mssql/server:2022-latest
+#
+# Microsoft SQL Server container EULA (accepted via MSSQLServerContainer.acceptLicense()):
+# https://go.microsoft.com/fwlink/?linkid=857698
+# Re-check the EULA when bumping this tag. Renovate must not auto-merge this image.
+FROM mcr.microsoft.com/mssql/server:2022-CU26-ubuntu-22.04

--- a/versioned/storage/jdbc2/build.gradle.kts
+++ b/versioned/storage/jdbc2/build.gradle.kts
@@ -21,7 +21,7 @@ plugins { id("nessie-conventions-java17") }
 publishingHelper { mavenName = "Nessie - Storage - JDBC2" }
 
 description =
-  "Storage implementation for JDBC, supports H2, PostgreSQL, CockroachDB, MariaDB and MySQL (via MariaDB Driver)."
+  "Storage implementation for JDBC, supports H2, PostgreSQL, CockroachDB, MariaDB, MySQL (via MariaDB Driver), and Microsoft SQL Server."
 
 dependencies {
   implementation(project(":nessie-versioned-storage-common"))
@@ -48,6 +48,7 @@ dependencies {
   testRuntimeOnly(libs.h2)
   intTestRuntimeOnly(libs.postgresql)
   intTestRuntimeOnly(libs.mariadb.java.client)
+  intTestRuntimeOnly(libs.mssql.jdbc)
   intTestRuntimeOnly(platform(libs.testcontainers.bom))
   intTestRuntimeOnly(libs.docker.java.api)
   testFixturesImplementation(platform(libs.junit.bom))

--- a/versioned/storage/jdbc2/src/intTest/java/org/projectnessie/versioned/storage/jdbc2/ITMssqlPersist.java
+++ b/versioned/storage/jdbc2/src/intTest/java/org/projectnessie/versioned/storage/jdbc2/ITMssqlPersist.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2026 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.jdbc2;
+
+import org.projectnessie.versioned.storage.commontests.AbstractPersistTests;
+import org.projectnessie.versioned.storage.jdbc2tests.MssqlBackendTestFactory;
+import org.projectnessie.versioned.storage.testextension.NessieBackend;
+
+@NessieBackend(MssqlBackendTestFactory.class)
+public class ITMssqlPersist extends AbstractPersistTests {}

--- a/versioned/storage/jdbc2/src/intTest/java/org/projectnessie/versioned/storage/jdbc2/ITMssqlPersist.java
+++ b/versioned/storage/jdbc2/src/intTest/java/org/projectnessie/versioned/storage/jdbc2/ITMssqlPersist.java
@@ -15,9 +15,63 @@
  */
 package org.projectnessie.versioned.storage.jdbc2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.projectnessie.versioned.storage.common.persist.ObjId.randomObjId;
+import static org.projectnessie.versioned.storage.common.persist.Reference.reference;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.versioned.storage.common.persist.Persist;
 import org.projectnessie.versioned.storage.commontests.AbstractPersistTests;
+import org.projectnessie.versioned.storage.commontests.objtypes.SimpleTestObj;
 import org.projectnessie.versioned.storage.jdbc2tests.MssqlBackendTestFactory;
 import org.projectnessie.versioned.storage.testextension.NessieBackend;
+import org.projectnessie.versioned.storage.testextension.NessiePersist;
+import org.projectnessie.versioned.storage.testextension.PersistExtension;
 
 @NessieBackend(MssqlBackendTestFactory.class)
-public class ITMssqlPersist extends AbstractPersistTests {}
+public class ITMssqlPersist extends AbstractPersistTests {
+
+  @Nested
+  @ExtendWith(PersistExtension.class)
+  class SqlServerContracts {
+    @NessiePersist Persist persist;
+
+    @Test
+    void referenceNamesAreCaseSensitive() throws Exception {
+      var foo = reference("Foo", randomObjId(), false, 1L, null);
+      var fooLower = reference("foo", randomObjId(), false, 1L, null);
+      assertEquals(foo, persist.addReference(foo));
+      assertEquals(fooLower, persist.addReference(fooLower));
+      assertEquals(foo, persist.fetchReference("Foo"));
+      assertEquals(fooLower, persist.fetchReference("foo"));
+    }
+
+    @Test
+    void concurrentStoreObjDoesNotThrow() throws Exception {
+      var obj = SimpleTestObj.builder().id(randomObjId()).text("same").build();
+      ExecutorService pool = Executors.newFixedThreadPool(2);
+      try {
+        List<Callable<Boolean>> tasks = new ArrayList<>();
+        tasks.add(() -> persist.storeObj(obj));
+        tasks.add(() -> persist.storeObj(obj));
+        List<Future<Boolean>> futures = pool.invokeAll(tasks);
+        boolean first = futures.get(0).get();
+        boolean second = futures.get(1).get();
+        assertTrue(first ^ second);
+        assertFalse(first && second);
+      } finally {
+        pool.shutdownNow();
+      }
+    }
+  }
+}

--- a/versioned/storage/jdbc2/src/intTest/java/org/projectnessie/versioned/storage/jdbc2/ITMssqlPersist.java
+++ b/versioned/storage/jdbc2/src/intTest/java/org/projectnessie/versioned/storage/jdbc2/ITMssqlPersist.java
@@ -15,63 +15,9 @@
  */
 package org.projectnessie.versioned.storage.jdbc2;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.projectnessie.versioned.storage.common.persist.ObjId.randomObjId;
-import static org.projectnessie.versioned.storage.common.persist.Reference.reference;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.projectnessie.versioned.storage.common.persist.Persist;
 import org.projectnessie.versioned.storage.commontests.AbstractPersistTests;
-import org.projectnessie.versioned.storage.commontests.objtypes.SimpleTestObj;
 import org.projectnessie.versioned.storage.jdbc2tests.MssqlBackendTestFactory;
 import org.projectnessie.versioned.storage.testextension.NessieBackend;
-import org.projectnessie.versioned.storage.testextension.NessiePersist;
-import org.projectnessie.versioned.storage.testextension.PersistExtension;
 
 @NessieBackend(MssqlBackendTestFactory.class)
-public class ITMssqlPersist extends AbstractPersistTests {
-
-  @Nested
-  @ExtendWith(PersistExtension.class)
-  class SqlServerContracts {
-    @NessiePersist Persist persist;
-
-    @Test
-    void referenceNamesAreCaseSensitive() throws Exception {
-      var foo = reference("Foo", randomObjId(), false, 1L, null);
-      var fooLower = reference("foo", randomObjId(), false, 1L, null);
-      assertEquals(foo, persist.addReference(foo));
-      assertEquals(fooLower, persist.addReference(fooLower));
-      assertEquals(foo, persist.fetchReference("Foo"));
-      assertEquals(fooLower, persist.fetchReference("foo"));
-    }
-
-    @Test
-    void concurrentStoreObjDoesNotThrow() throws Exception {
-      var obj = SimpleTestObj.builder().id(randomObjId()).text("same").build();
-      ExecutorService pool = Executors.newFixedThreadPool(2);
-      try {
-        List<Callable<Boolean>> tasks = new ArrayList<>();
-        tasks.add(() -> persist.storeObj(obj));
-        tasks.add(() -> persist.storeObj(obj));
-        List<Future<Boolean>> futures = pool.invokeAll(tasks);
-        boolean first = futures.get(0).get();
-        boolean second = futures.get(1).get();
-        assertTrue(first ^ second);
-        assertFalse(first && second);
-      } finally {
-        pool.shutdownNow();
-      }
-    }
-  }
-}
+public class ITMssqlPersist extends AbstractPersistTests {}

--- a/versioned/storage/jdbc2/src/intTest/java/org/projectnessie/versioned/storage/jdbc2/ITMssqlVersionStore.java
+++ b/versioned/storage/jdbc2/src/intTest/java/org/projectnessie/versioned/storage/jdbc2/ITMssqlVersionStore.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2026 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.jdbc2;
+
+import org.projectnessie.versioned.storage.commontests.AbstractVersionStoreTests;
+import org.projectnessie.versioned.storage.jdbc2tests.MssqlBackendTestFactory;
+import org.projectnessie.versioned.storage.testextension.NessieBackend;
+
+@NessieBackend(MssqlBackendTestFactory.class)
+public class ITMssqlVersionStore extends AbstractVersionStoreTests {}

--- a/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/DatabaseSpecifics.java
+++ b/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/DatabaseSpecifics.java
@@ -55,6 +55,9 @@ public final class DatabaseSpecifics {
 
   public static final DatabaseSpecific MARIADB_DATABASE_SPECIFIC = new MariaDBDatabaseSpecific();
 
+  public static final DatabaseSpecific SQL_SERVER_DATABASE_SPECIFIC =
+      new SqlServerDatabaseSpecific();
+
   public static DatabaseSpecific detect(DataSource dataSource) {
     try (Connection conn = dataSource.getConnection()) {
       return detect(conn);
@@ -82,6 +85,9 @@ public final class DatabaseSpecifics {
         }
         case "mysql", "mariadb" -> {
           return MARIADB_DATABASE_SPECIFIC;
+        }
+        case "microsoft sql server" -> {
+          return SQL_SERVER_DATABASE_SPECIFIC;
         }
         default ->
             throw new IllegalStateException(

--- a/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/SqlServerDatabaseSpecific.java
+++ b/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/SqlServerDatabaseSpecific.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2026 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.jdbc2;
+
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.EnumMap;
+import java.util.Map;
+
+/** SQL Server-specific dialect for the JDBC2 backend. */
+final class SqlServerDatabaseSpecific implements DatabaseSpecific {
+
+  private static final String VARCHAR = "NVARCHAR(255)";
+  private static final String VARBINARY_MAX = "VARBINARY(MAX)";
+
+  /** Max key length for nonclustered index; OBJ_ID is used in PK. */
+  private static final String OBJ_ID = "VARBINARY(900)";
+
+  private static final String MSSQL_CONSTRAINT_VIOLATION_SQL_STATE = "23000";
+  private static final int MSSQL_ALREADY_EXISTS_ERROR = 2714;
+  private static final String MSSQL_ALREADY_EXISTS_STATE_S0001 = "S0001";
+  private static final String MSSQL_ALREADY_EXISTS_STATE_42S01 = "42S01";
+  private static final String MSSQL_DEADLOCK_SQL_STATE = "40001";
+
+  private final Map<Jdbc2ColumnType, String> typeMap;
+  private final Map<Jdbc2ColumnType, Integer> typeIdMap;
+
+  SqlServerDatabaseSpecific() {
+    typeMap = new EnumMap<>(Jdbc2ColumnType.class);
+    typeIdMap = new EnumMap<>(Jdbc2ColumnType.class);
+    typeMap.put(Jdbc2ColumnType.NAME, VARCHAR);
+    typeIdMap.put(Jdbc2ColumnType.NAME, Types.NVARCHAR);
+    typeMap.put(Jdbc2ColumnType.OBJ_ID, OBJ_ID);
+    typeIdMap.put(Jdbc2ColumnType.OBJ_ID, Types.VARBINARY);
+    typeMap.put(Jdbc2ColumnType.BOOL, "BIT");
+    typeIdMap.put(Jdbc2ColumnType.BOOL, Types.BIT);
+    typeMap.put(Jdbc2ColumnType.VARBINARY, VARBINARY_MAX);
+    typeIdMap.put(Jdbc2ColumnType.VARBINARY, Types.VARBINARY);
+    typeMap.put(Jdbc2ColumnType.BIGINT, "BIGINT");
+    typeIdMap.put(Jdbc2ColumnType.BIGINT, Types.BIGINT);
+    typeMap.put(Jdbc2ColumnType.VARCHAR, VARCHAR);
+    typeIdMap.put(Jdbc2ColumnType.VARCHAR, Types.NVARCHAR);
+  }
+
+  @Override
+  public Map<Jdbc2ColumnType, String> columnTypes() {
+    return typeMap;
+  }
+
+  @Override
+  public Map<Jdbc2ColumnType, Integer> columnTypeIds() {
+    return typeIdMap;
+  }
+
+  @Override
+  public boolean isConstraintViolation(SQLException e) {
+    return MSSQL_CONSTRAINT_VIOLATION_SQL_STATE.equals(e.getSQLState())
+        || (e.getErrorCode() == MSSQL_ALREADY_EXISTS_ERROR);
+  }
+
+  @Override
+  public boolean isRetryTransaction(SQLException e) {
+    return MSSQL_DEADLOCK_SQL_STATE.equals(e.getSQLState());
+  }
+
+  @Override
+  public boolean isAlreadyExists(SQLException e) {
+    if (e.getErrorCode() == MSSQL_ALREADY_EXISTS_ERROR) {
+      return true;
+    }
+    String state = e.getSQLState();
+    return MSSQL_ALREADY_EXISTS_STATE_S0001.equals(state)
+        || MSSQL_ALREADY_EXISTS_STATE_42S01.equals(state);
+  }
+
+  @Override
+  public String wrapInsert(String sql) {
+    if (sql.contains(SqlConstants.TABLE_REFS)) {
+      return "MERGE INTO "
+          + SqlConstants.TABLE_REFS
+          + " AS t USING (SELECT ? AS "
+          + SqlConstants.COL_REPO_ID
+          + ", ? AS "
+          + SqlConstants.COL_REFS_NAME
+          + ", ? AS "
+          + SqlConstants.COL_REFS_POINTER
+          + ", ? AS "
+          + SqlConstants.COL_REFS_DELETED
+          + ", ? AS "
+          + SqlConstants.COL_REFS_CREATED_AT
+          + ", ? AS "
+          + SqlConstants.COL_REFS_EXTENDED_INFO
+          + ", ? AS "
+          + SqlConstants.COL_REFS_PREVIOUS
+          + ") AS s ON t."
+          + SqlConstants.COL_REPO_ID
+          + " = s."
+          + SqlConstants.COL_REPO_ID
+          + " AND t."
+          + SqlConstants.COL_REFS_NAME
+          + " = s."
+          + SqlConstants.COL_REFS_NAME
+          + " WHEN NOT MATCHED BY TARGET THEN INSERT ("
+          + SqlConstants.COL_REPO_ID
+          + ", "
+          + SqlConstants.COL_REFS_NAME
+          + ", "
+          + SqlConstants.COL_REFS_POINTER
+          + ", "
+          + SqlConstants.COL_REFS_DELETED
+          + ", "
+          + SqlConstants.COL_REFS_CREATED_AT
+          + ", "
+          + SqlConstants.COL_REFS_EXTENDED_INFO
+          + ", "
+          + SqlConstants.COL_REFS_PREVIOUS
+          + ") VALUES (s."
+          + SqlConstants.COL_REPO_ID
+          + ", s."
+          + SqlConstants.COL_REFS_NAME
+          + ", s."
+          + SqlConstants.COL_REFS_POINTER
+          + ", s."
+          + SqlConstants.COL_REFS_DELETED
+          + ", s."
+          + SqlConstants.COL_REFS_CREATED_AT
+          + ", s."
+          + SqlConstants.COL_REFS_EXTENDED_INFO
+          + ", s."
+          + SqlConstants.COL_REFS_PREVIOUS
+          + ");";
+    }
+    if (sql.contains(SqlConstants.TABLE_OBJS)) {
+      return "MERGE INTO "
+          + SqlConstants.TABLE_OBJS
+          + " AS t USING (SELECT ? AS "
+          + SqlConstants.COL_REPO_ID
+          + ", ? AS "
+          + SqlConstants.COL_OBJ_ID
+          + ", ? AS "
+          + SqlConstants.COL_OBJ_TYPE
+          + ", ? AS "
+          + SqlConstants.COL_OBJ_VERS
+          + ", ? AS "
+          + SqlConstants.COL_OBJ_VALUE
+          + ", ? AS "
+          + SqlConstants.COL_OBJ_REFERENCED
+          + ") AS s ON t."
+          + SqlConstants.COL_REPO_ID
+          + " = s."
+          + SqlConstants.COL_REPO_ID
+          + " AND t."
+          + SqlConstants.COL_OBJ_ID
+          + " = s."
+          + SqlConstants.COL_OBJ_ID
+          + " WHEN NOT MATCHED BY TARGET THEN INSERT ("
+          + SqlConstants.COL_REPO_ID
+          + ", "
+          + SqlConstants.COLS_OBJS_ALL_NAMES
+          + ") VALUES (s."
+          + SqlConstants.COL_REPO_ID
+          + ", s."
+          + SqlConstants.COL_OBJ_ID
+          + ", s."
+          + SqlConstants.COL_OBJ_TYPE
+          + ", s."
+          + SqlConstants.COL_OBJ_VERS
+          + ", s."
+          + SqlConstants.COL_OBJ_VALUE
+          + ", s."
+          + SqlConstants.COL_OBJ_REFERENCED
+          + ");";
+    }
+    return sql;
+  }
+
+  @Override
+  public String primaryKeyCol(String col, Jdbc2ColumnType columnType) {
+    return col;
+  }
+}

--- a/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/SqlServerDatabaseSpecific.java
+++ b/versioned/storage/jdbc2/src/main/java/org/projectnessie/versioned/storage/jdbc2/SqlServerDatabaseSpecific.java
@@ -23,7 +23,7 @@ import java.util.Map;
 /** SQL Server-specific dialect for the JDBC2 backend. */
 final class SqlServerDatabaseSpecific implements DatabaseSpecific {
 
-  private static final String VARCHAR = "NVARCHAR(255)";
+  private static final String VARCHAR = "NVARCHAR(255) COLLATE Latin1_General_100_BIN2";
   private static final String VARBINARY_MAX = "VARBINARY(MAX)";
 
   /** Max key length for nonclustered index; OBJ_ID is used in PK. */
@@ -91,7 +91,7 @@ final class SqlServerDatabaseSpecific implements DatabaseSpecific {
     if (sql.contains(SqlConstants.TABLE_REFS)) {
       return "MERGE INTO "
           + SqlConstants.TABLE_REFS
-          + " AS t USING (SELECT ? AS "
+          + " WITH (HOLDLOCK) AS t USING (SELECT ? AS "
           + SqlConstants.COL_REPO_ID
           + ", ? AS "
           + SqlConstants.COL_REFS_NAME
@@ -146,7 +146,7 @@ final class SqlServerDatabaseSpecific implements DatabaseSpecific {
     if (sql.contains(SqlConstants.TABLE_OBJS)) {
       return "MERGE INTO "
           + SqlConstants.TABLE_OBJS
-          + " AS t USING (SELECT ? AS "
+          + " WITH (HOLDLOCK) AS t USING (SELECT ? AS "
           + SqlConstants.COL_REPO_ID
           + ", ? AS "
           + SqlConstants.COL_OBJ_ID

--- a/versioned/storage/jdbc2/src/test/java/org/projectnessie/versioned/storage/jdbc2/TestSqlServerDatabaseSpecific.java
+++ b/versioned/storage/jdbc2/src/test/java/org/projectnessie/versioned/storage/jdbc2/TestSqlServerDatabaseSpecific.java
@@ -34,10 +34,14 @@ class TestSqlServerDatabaseSpecific {
 
   @Test
   void columnTypesUseNvarcharVarbinary900AndBit() {
-    assertEquals("NVARCHAR(255)", db.columnTypes().get(Jdbc2ColumnType.NAME));
+    assertEquals(
+        "NVARCHAR(255) COLLATE Latin1_General_100_BIN2",
+        db.columnTypes().get(Jdbc2ColumnType.NAME));
     assertEquals("VARBINARY(900)", db.columnTypes().get(Jdbc2ColumnType.OBJ_ID));
     assertEquals("BIT", db.columnTypes().get(Jdbc2ColumnType.BOOL));
-    assertEquals("VARBINARY(MAX)", db.columnTypes().get(Jdbc2ColumnType.VARBINARY));
+    assertEquals(
+        "NVARCHAR(255) COLLATE Latin1_General_100_BIN2",
+        db.columnTypes().get(Jdbc2ColumnType.VARCHAR));
   }
 
   @Test
@@ -79,7 +83,7 @@ class TestSqlServerDatabaseSpecific {
   @Test
   void wrapInsert_refsBecomesMerge() {
     String merged = db.wrapInsert(ADD_REFERENCE);
-    assertTrue(merged.startsWith("MERGE INTO " + SqlConstants.TABLE_REFS));
+    assertTrue(merged.startsWith("MERGE INTO " + SqlConstants.TABLE_REFS + " WITH (HOLDLOCK)"));
     assertTrue(merged.contains("WHEN NOT MATCHED BY TARGET THEN INSERT"));
     assertTrue(merged.contains("ON t." + COL_REPO_ID + " = s." + COL_REPO_ID));
     assertTrue(
@@ -90,7 +94,7 @@ class TestSqlServerDatabaseSpecific {
   @Test
   void wrapInsert_storeObjBecomesMerge() {
     String merged = db.wrapInsert(STORE_OBJ);
-    assertTrue(merged.startsWith("MERGE INTO " + TABLE_OBJS));
+    assertTrue(merged.startsWith("MERGE INTO " + TABLE_OBJS + " WITH (HOLDLOCK)"));
     assertTrue(merged.contains("WHEN NOT MATCHED BY TARGET THEN INSERT"));
     assertTrue(merged.contains("ON t." + COL_REPO_ID + " = s." + COL_REPO_ID));
     assertTrue(merged.contains("AND t." + COL_OBJ_ID + " = s." + COL_OBJ_ID));

--- a/versioned/storage/jdbc2/src/test/java/org/projectnessie/versioned/storage/jdbc2/TestSqlServerDatabaseSpecific.java
+++ b/versioned/storage/jdbc2/src/test/java/org/projectnessie/versioned/storage/jdbc2/TestSqlServerDatabaseSpecific.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2026 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.jdbc2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.ADD_REFERENCE;
+import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.COL_OBJ_ID;
+import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.COL_REPO_ID;
+import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.STORE_OBJ;
+import static org.projectnessie.versioned.storage.jdbc2.SqlConstants.TABLE_OBJS;
+
+import java.sql.SQLException;
+import java.sql.Types;
+import org.junit.jupiter.api.Test;
+
+class TestSqlServerDatabaseSpecific {
+
+  private final SqlServerDatabaseSpecific db = new SqlServerDatabaseSpecific();
+
+  @Test
+  void columnTypesUseNvarcharVarbinary900AndBit() {
+    assertEquals("NVARCHAR(255)", db.columnTypes().get(Jdbc2ColumnType.NAME));
+    assertEquals("VARBINARY(900)", db.columnTypes().get(Jdbc2ColumnType.OBJ_ID));
+    assertEquals("BIT", db.columnTypes().get(Jdbc2ColumnType.BOOL));
+    assertEquals("VARBINARY(MAX)", db.columnTypes().get(Jdbc2ColumnType.VARBINARY));
+  }
+
+  @Test
+  void columnTypeIdsMatchJdbcTypes() {
+    assertEquals(Types.NVARCHAR, db.columnTypeIds().get(Jdbc2ColumnType.NAME));
+    assertEquals(Types.VARBINARY, db.columnTypeIds().get(Jdbc2ColumnType.OBJ_ID));
+    assertEquals(Types.BIT, db.columnTypeIds().get(Jdbc2ColumnType.BOOL));
+  }
+
+  @Test
+  void isConstraintViolation_sqlState23000() {
+    assertTrue(db.isConstraintViolation(new SQLException("x", "23000", 0)));
+  }
+
+  @Test
+  void isConstraintViolation_error2714() {
+    assertTrue(db.isConstraintViolation(new SQLException("x", "01000", 2714)));
+  }
+
+  @Test
+  void isConstraintViolation_other() {
+    assertFalse(db.isConstraintViolation(new SQLException("x", "01000", 0)));
+  }
+
+  @Test
+  void isRetryTransaction_deadlock() {
+    assertTrue(db.isRetryTransaction(new SQLException("deadlock", "40001", 0)));
+    assertFalse(db.isRetryTransaction(new SQLException("x", "01000", 0)));
+  }
+
+  @Test
+  void isAlreadyExists() {
+    assertTrue(db.isAlreadyExists(new SQLException("x", "S0001", 0)));
+    assertTrue(db.isAlreadyExists(new SQLException("x", "42S01", 0)));
+    assertTrue(db.isAlreadyExists(new SQLException("x", "01000", 2714)));
+    assertFalse(db.isAlreadyExists(new SQLException("x", "01000", 0)));
+  }
+
+  @Test
+  void wrapInsert_refsBecomesMerge() {
+    String merged = db.wrapInsert(ADD_REFERENCE);
+    assertTrue(merged.startsWith("MERGE INTO " + SqlConstants.TABLE_REFS));
+    assertTrue(merged.contains("WHEN NOT MATCHED BY TARGET THEN INSERT"));
+    assertTrue(merged.contains("ON t." + COL_REPO_ID + " = s." + COL_REPO_ID));
+    assertTrue(
+        merged.contains(
+            "AND t." + SqlConstants.COL_REFS_NAME + " = s." + SqlConstants.COL_REFS_NAME));
+  }
+
+  @Test
+  void wrapInsert_storeObjBecomesMerge() {
+    String merged = db.wrapInsert(STORE_OBJ);
+    assertTrue(merged.startsWith("MERGE INTO " + TABLE_OBJS));
+    assertTrue(merged.contains("WHEN NOT MATCHED BY TARGET THEN INSERT"));
+    assertTrue(merged.contains("ON t." + COL_REPO_ID + " = s." + COL_REPO_ID));
+    assertTrue(merged.contains("AND t." + COL_OBJ_ID + " = s." + COL_OBJ_ID));
+    assertTrue(merged.contains("? AS " + SqlConstants.COL_OBJ_TYPE));
+    assertTrue(merged.contains("? AS " + SqlConstants.COL_OBJ_VALUE));
+  }
+
+  @Test
+  void primaryKeyColUnmodified() {
+    assertEquals("obj_id", db.primaryKeyCol("obj_id", Jdbc2ColumnType.OBJ_ID));
+  }
+
+  @Test
+  void wrapInsert_unrelatedSqlUnchanged() {
+    assertEquals("SELECT 1", db.wrapInsert("SELECT 1"));
+  }
+}

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferences.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferences.java
@@ -253,6 +253,20 @@ public abstract class AbstractReferences extends AbstractNestedVersionStore {
   }
 
   @Test
+  void referenceNamesAreCaseSensitive() throws Exception {
+    BranchName foo = BranchName.of("Foo");
+    BranchName fooLower = BranchName.of("foo");
+    Hash fooHash = store().create(foo, Optional.empty()).getHash();
+    Hash fooLowerHash = store().create(fooLower, Optional.empty()).getHash();
+    soft.assertThat(store().getNamedRef("Foo", GetNamedRefsParams.DEFAULT))
+        .extracting(ReferenceInfo::getHash, ReferenceInfo::getNamedRef)
+        .containsExactly(fooHash, foo);
+    soft.assertThat(store().getNamedRef("foo", GetNamedRefsParams.DEFAULT))
+        .extracting(ReferenceInfo::getHash, ReferenceInfo::getNamedRef)
+        .containsExactly(fooLowerHash, fooLower);
+  }
+
+  @Test
   void listBranchesOrTags() throws Exception {
     // Generate branches + tags with "interleaving" names
     Set<NamedRef> branches = new HashSet<>();


### PR DESCRIPTION
## Summary

SQL Server JDBC2 persist dialect, taken from @scotchr's [#12288](https://github.com/projectnessie/nessie/pull/12288) (dimas-b LGTM'd in April; the branch has been conflicting since). This is a new PR so that work can land on current `main`. Full credit stays with scotchr.

This is the persist-only slice, the same split MariaDB used in #8483 then #8544. JDBC1 is omitted (obsolete). Server/Quarkus wiring, GC driver, Helm, and `LICENSE-BINARY-DIST` are follow-ups.

**From #12288:** `DatabaseSpecifics.detect()` for `microsoft sql server`, `SqlServerDatabaseSpecific` (`VARBINARY(900)` / `BIT` / `VARBINARY(MAX)`, `MERGE` `wrapInsert` because SQL Server has no `ON CONFLICT` / `INSERT IGNORE`), Testcontainers `MssqlBackendTestFactory`, `ITMssqlPersist`.

**What this PR adds on top of that rebase:**

* Dropped jdbc1.
* `NVARCHAR(255) COLLATE Latin1_General_100_BIN2` so reference names are case-sensitive (Postgres uses `ucs_basic`, MariaDB `utf8mb4_bin`). Bare `NVARCHAR` is `CI_AS` and would treat `Foo` and `foo` as the same PK. Covered by `AbstractReferences.referenceNamesAreCaseSensitive`.
* `MERGE … WITH (HOLDLOCK)` so concurrent `storeObj` matches insert-ignore instead of throwing `UnsupportedOperationException`. SQL Server persist inserts use `MERGE … WITH (HOLDLOCK)` so concurrent store and add-ref match Postgres `ON CONFLICT DO NOTHING` and MariaDB `INSERT IGNORE`, at the cost of serializable key-range locks on `refs2` and `objs2` for the statement (concurrent writers can block or deadlock-retry).
* `ITMssqlVersionStore` (parity with the other JDBC2 dialects).
* Microsoft JDBC driver `13.4.0.jre11` (current GA; #12288 used `12.6.3.jre11`), `intTestRuntimeOnly` only.
* Testcontainers image pinned to `mcr.microsoft.com/mssql/server:2022-CU26-ubuntu-22.04`. Renovate will not auto-merge that image.

Supersedes #12288. Please close that PR if this one is the path forward.

## Test plan

* [x] `./gradlew sAp compileAll jar codeChecks`
* [x] `./gradlew :nessie-versioned-storage-jdbc2:test`: 1436 tests, 0 failures (115 skipped)
* [x] `./gradlew :nessie-versioned-storage-jdbc2:intTest`: 3720 tests, 0 failures (13 skipped, pre-existing). Five persist backends including MSSQL Testcontainers (`mcr.microsoft.com/mssql/server:2022-CU26-ubuntu-22.04`). `AbstractReferences.referenceNamesAreCaseSensitive` passed on ITMssqlVersionStore.

Needs Docker. No cloud credentials.

