### PR TITLE
Catalog/GCS: fix down-scoped credentials failing on every request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Upgrade notes
 
+- Catalog/GCS: Down-scoped credentials, enabled via
+  `nessie.catalog.service.gcs.default-options.downscoped-credentials.enable`, were not functional and
+  failed every credential-vending request. They work now. Vended credentials are scoped to a table's
+  location, so they do not cover tables using `write.object-storage.enabled=true`, which writes data
+  files under a randomized prefix that Credential Access Boundary conditions cannot express. Do not
+  enable down-scoped credentials for warehouses whose tables use that layout.
+
 ### Breaking changes
 
 ### New Features
@@ -19,6 +26,14 @@ as necessary. Empty sections will not end in the release notes.
 ### Deprecations
 
 ### Fixes
+
+- Catalog/GCS: Fix down-scoped credentials, which failed for every request. The source credential was
+  not scoped, so Google's token exchange rejected it with `invalid_scope`, and the generated Credential
+  Access Boundary conditions used CEL `matches()`, which Google's IAM CEL implementation does not
+  support.
+- Catalog/GCS: Vended credentials scoped to a table location no longer grant access to sibling
+  locations whose name starts with the same characters, for example a credential for
+  `warehouse/orders` granting access to `warehouse/orders2`.
 
 ### Commits
 

--- a/SECURITY_THREAT_MODEL.md
+++ b/SECURITY_THREAT_MODEL.md
@@ -238,6 +238,18 @@ available for S3 and GCS. Operators must account for that weaker granularity whe
 delegation.
 `(documented)`
 
+GCS credential vending scopes down-scoped tokens by object-name prefix. Credential Access Boundary
+conditions support only prefix, suffix, and equality comparisons, so a location is matched as a path
+prefix terminated by `/` and object access is limited to objects below that location. Object listing
+additionally permits the location itself as a list prefix, which can reveal the names of sibling
+locations sharing that prefix but does not grant read access to them. `(documented)`
+
+Tables with `write.object-storage.enabled=true` write data files under a randomized prefix that
+precedes the table path. Credential Access Boundary conditions cannot express that shape, so
+down-scoped GCS credentials do not cover those data files and clients are denied access to them.
+Operators must not enable GCS down-scoped credentials for warehouses whose tables use that layout.
+`(documented)`
+
 ## Secrets And Credential Configuration
 
 Server-side secrets can be supplied through Quarkus configuration mechanisms and supported external

--- a/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/GcsDownscopedCredentials.java
+++ b/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/GcsDownscopedCredentials.java
@@ -33,6 +33,11 @@ public interface GcsDownscopedCredentials {
    *
    * <p>The current default is to not enable short-lived and scoped-down credentials, but the
    * default may change to enable in the future.
+   *
+   * <p>Credentials are scoped to a table's location. Tables using {@code
+   * write.object-storage.enabled=true} write their data files under a randomized prefix that
+   * precedes the table path, which cannot be expressed as a scope, so clients are denied access to
+   * those data files.
    */
   Optional<Boolean> enable();
 

--- a/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/GcsDownscopedCredentials.java
+++ b/catalog/files/api/src/main/java/org/projectnessie/catalog/files/config/GcsDownscopedCredentials.java
@@ -38,6 +38,11 @@ public interface GcsDownscopedCredentials {
    * write.object-storage.enabled=true} write their data files under a randomized prefix that
    * precedes the table path, which cannot be expressed as a scope, so clients are denied access to
    * those data files.
+   *
+   * <p>With {@code auth-type=ACCESS_TOKEN} or {@code auth-type=USER} the configured credential is
+   * used with its existing OAuth scopes and must already have the {@code
+   * https://www.googleapis.com/auth/cloud-platform} scope. Nessie requests that scope for
+   * service-account credentials and for Application Default Credentials that support scoping.
    */
   Optional<Boolean> enable();
 

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsClients.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsClients.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Date;
+import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.projectnessie.catalog.files.config.GcsBucketOptions;
@@ -48,6 +49,11 @@ import org.projectnessie.catalog.secrets.TokenSecret;
 
 public final class GcsClients {
   private GcsClients() {}
+
+  // Required for use as a downscoping source credential in GcsStorageSupplier; unscoped
+  // credentials make Google's STS token exchange fail with "invalid_scope".
+  private static final List<String> CLOUD_PLATFORM_SCOPES =
+      List.of("https://www.googleapis.com/auth/cloud-platform");
 
   public static Storage buildStorage(
       GcsConfig gcsConfig,
@@ -140,13 +146,15 @@ public final class GcsClients {
                   .orElseThrow(() -> new IllegalStateException("auth-credentials-json missing"));
 
           return UserCredentials.fromStream(
-              new ByteArrayInputStream(
-                  secretsProvider
-                      .getSecret(secretName, SecretType.KEY, KeySecret.class)
-                      .orElseThrow(() -> new IllegalStateException("auth-credentials-json missing"))
-                      .key()
-                      .getBytes(UTF_8)),
-              transportFactory);
+                  new ByteArrayInputStream(
+                      secretsProvider
+                          .getSecret(secretName, SecretType.KEY, KeySecret.class)
+                          .orElseThrow(
+                              () -> new IllegalStateException("auth-credentials-json missing"))
+                          .key()
+                          .getBytes(UTF_8)),
+                  transportFactory)
+              .createScoped(CLOUD_PLATFORM_SCOPES);
         } catch (IOException e) {
           throw new RuntimeException(e);
         }
@@ -159,13 +167,15 @@ public final class GcsClients {
                   .orElseThrow(() -> new IllegalStateException("auth-credentials-json missing"));
 
           return ServiceAccountCredentials.fromStream(
-              new ByteArrayInputStream(
-                  secretsProvider
-                      .getSecret(secretName, SecretType.KEY, KeySecret.class)
-                      .orElseThrow(() -> new IllegalStateException("auth-credentials-json missing"))
-                      .key()
-                      .getBytes(UTF_8)),
-              transportFactory);
+                  new ByteArrayInputStream(
+                      secretsProvider
+                          .getSecret(secretName, SecretType.KEY, KeySecret.class)
+                          .orElseThrow(
+                              () -> new IllegalStateException("auth-credentials-json missing"))
+                          .key()
+                          .getBytes(UTF_8)),
+                  transportFactory)
+              .createScoped(CLOUD_PLATFORM_SCOPES);
         } catch (IOException e) {
           throw new RuntimeException(e);
         }
@@ -196,7 +206,7 @@ public final class GcsClients {
       }
       case APPLICATION_DEFAULT -> {
         try {
-          return GoogleCredentials.getApplicationDefault();
+          return GoogleCredentials.getApplicationDefault().createScoped(CLOUD_PLATFORM_SCOPES);
         } catch (IOException e) {
           throw new IllegalArgumentException("Unable to load default credentials", e);
         }

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsClients.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsClients.java
@@ -50,8 +50,6 @@ import org.projectnessie.catalog.secrets.TokenSecret;
 public final class GcsClients {
   private GcsClients() {}
 
-  // Required for use as a downscoping source credential in GcsStorageSupplier; unscoped
-  // credentials make Google's STS token exchange fail with "invalid_scope".
   private static final List<String> CLOUD_PLATFORM_SCOPES =
       List.of("https://www.googleapis.com/auth/cloud-platform");
 

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsStorageSupplier.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsStorageSupplier.java
@@ -16,7 +16,6 @@
 package org.projectnessie.catalog.files.gcs;
 
 import static java.lang.String.format;
-import static java.util.regex.Pattern.quote;
 import static org.projectnessie.catalog.files.gcs.GcsClients.buildCredentials;
 
 import com.google.auth.Credentials;
@@ -52,9 +51,6 @@ import org.slf4j.LoggerFactory;
 
 public final class GcsStorageSupplier {
   private static final Logger LOGGER = LoggerFactory.getLogger(GcsStorageSupplier.class);
-
-  // Suitable for both old object-storage layout (before Iceberg 1.7.0) and new (since 1.7.0)
-  static final String RANDOMIZED_PART = "([A-Za-z0-9=]+/|[01]{4}/[01]{4}/[01]{4}/[01]{8}/)?";
 
   private final HttpTransportFactory httpTransportFactory;
   private final GcsConfig gcsConfig;
@@ -163,26 +159,21 @@ public final class GcsStorageSupplier {
             location -> {
               String bucket = location.requiredAuthority();
               readBuckets.add(bucket);
+              boolean writeable = storageLocations.writeableLocations().contains(location);
+              if (writeable) {
+                writeBuckets.add(bucket);
+              }
+
               String path = location.pathWithoutLeadingTrailingSlash();
               List<String> resourceExpressions =
                   readConditionsMap.computeIfAbsent(bucket, key -> new ArrayList<>());
-
               resourceExpressions.add(resourceNameBucketPathExpression(bucket, path));
+              resourceExpressions.add(objectListPrefixExpression(path));
 
-              // list
-              String listPathExpression =
-                  format(
-                      "api.getAttribute('storage.googleapis.com/objectListPrefix', '').matches('"
-                          + RANDOMIZED_PART
-                          + "%s.*')",
-                      quoteForCelString(path));
-              resourceExpressions.add(listPathExpression);
-
-              if (storageLocations.writeableLocations().contains(location)) {
-                writeBuckets.add(bucket);
-                List<String> writeExpressions =
-                    writeConditionsMap.computeIfAbsent(bucket, key -> new ArrayList<>());
-                writeExpressions.add(resourceNameBucketPathExpression(bucket, path));
+              if (writeable) {
+                writeConditionsMap
+                    .computeIfAbsent(bucket, key -> new ArrayList<>())
+                    .add(resourceNameBucketPathExpression(bucket, path));
               }
             });
 
@@ -212,20 +203,34 @@ public final class GcsStorageSupplier {
   }
 
   static String resourceNameBucketPathExpression(String bucket, String path) {
-    return "resource.name.matches('"
-        + quoteForCelString(format("projects/_/buckets/%s/objects/", bucket))
-        + RANDOMIZED_PART
+    return "resource.name.startsWith('"
+        + quoteForCelString(
+            format("projects/_/buckets/%s/objects/%s", bucket, withTrailingSlash(path)))
+        + "')";
+  }
+
+  private static String objectListPrefixExpression(String path) {
+    String attribute = "api.getAttribute('storage.googleapis.com/objectListPrefix', '')";
+    return attribute
+        + ".startsWith('"
+        + quoteForCelString(withTrailingSlash(path))
+        + "') || "
+        + attribute
+        + " == '"
         + quoteForCelString(path)
-        + ".*')";
+        + "'";
+  }
+
+  private static String withTrailingSlash(String path) {
+    return path.isEmpty() ? path : path + "/";
   }
 
   private static String quoteForCelString(String str) {
-    String quoted = quote(str);
-    StringBuilder sb = new StringBuilder(quoted.length() * 3 / 2);
+    StringBuilder sb = new StringBuilder(str.length() * 3 / 2);
 
-    int l = quoted.length();
+    int l = str.length();
     for (int i = 0; i < l; i++) {
-      char c = quoted.charAt(i);
+      char c = str.charAt(i);
       switch (c) {
         case '\'' -> sb.append("\\'");
         case '\"' -> sb.append("\\\"");

--- a/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/gcs/TestGcsDownscopedCredentials.java
+++ b/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/gcs/TestGcsDownscopedCredentials.java
@@ -19,7 +19,6 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static org.projectnessie.catalog.files.gcs.GcsStorageSupplier.RANDOMIZED_PART;
 
 import com.google.auth.oauth2.CredentialAccessBoundary;
 import com.google.auth.oauth2.CredentialAccessBoundary.AccessBoundaryRule;
@@ -95,6 +94,9 @@ public class TestGcsDownscopedCredentials {
     for (AccessBoundaryRule rule : actual.getAccessBoundaryRules()) {
       String expr = rule.getAvailabilityCondition().getExpression();
 
+      // This local evaluator runs matches()/regex fine, but real IAM CEL rejects it outright.
+      soft.assertThat(expr).describedAs("Script '%s'", expr).doesNotContain(".matches(");
+
       soft.assertThatCode(
               () -> {
                 Script script = CelEval.scriptFor(expr);
@@ -130,8 +132,7 @@ public class TestGcsDownscopedCredentials {
     String bucketNegative = StorageUri.of(negativeCheck).requiredAuthority();
     String pathNegative = StorageUri.of(negativeCheck).pathWithoutLeadingTrailingSlash();
 
-    for (String res :
-        new String[] {resource, resource + "/hello.txt", resource + "/much/deeper/hello.txt"}) {
+    for (String res : new String[] {resource + "/hello.txt", resource + "/much/deeper/hello.txt"}) {
 
       String bucket = StorageUri.of(res).requiredAuthority();
       String path = StorageUri.of(res).pathWithoutLeadingTrailingSlash();
@@ -149,12 +150,19 @@ public class TestGcsDownscopedCredentials {
           .describedAs("positive, resource: %s", res)
           .isEqualTo(true);
 
+      r.setName(format("projects/_/buckets/%s/objects/%s/deadbeef/file.parquet", bucket, path));
+      soft.assertThat(
+              script.execute(
+                  Boolean.class, Map.of("api", new CelEval.ApiInterface(Map.of()), "resource", r)))
+          .describedAs("positive, nested below the location, resource: %s", res)
+          .isEqualTo(true);
+
       r.setName(format("projects/_/buckets/%s/objects/deadbeef/%s", bucket, path));
       soft.assertThat(
               script.execute(
                   Boolean.class, Map.of("api", new CelEval.ApiInterface(Map.of()), "resource", r)))
-          .describedAs("positive, object, resource: %s", res)
-          .isEqualTo(true);
+          .describedAs("negative, location not at the start, resource: %s", res)
+          .isEqualTo(false);
 
       // negative checks
 
@@ -166,13 +174,6 @@ public class TestGcsDownscopedCredentials {
               script.execute(
                   Boolean.class, Map.of("api", new CelEval.ApiInterface(Map.of()), "resource", r)))
           .describedAs("negative, resource: %s", res)
-          .isEqualTo(false);
-
-      r.setName(format("projects/_/buckets/%s/objects/deadbeef/%s", bucket, path));
-      soft.assertThat(
-              script.execute(
-                  Boolean.class, Map.of("api", new CelEval.ApiInterface(Map.of()), "resource", r)))
-          .describedAs("negative, object, resource: %s", res)
           .isEqualTo(false);
     }
   }
@@ -187,7 +188,9 @@ public class TestGcsDownscopedCredentials {
         //
         arguments("gs://buck.et/foo/bar/b.az", "gs://buckxet/foo/bar/bxaz"),
         //
-        arguments("gs://bucket/foo/bar/b.az", "gs://buckxet/foo/bar/bxaz")
+        arguments("gs://bucket/foo/bar/b.az", "gs://buckxet/foo/bar/bxaz"),
+        //
+        arguments("gs://bucket/foo/bar/baz2", "gs://bucket/foo/bar/baz")
         //
         );
   }
@@ -452,20 +455,22 @@ public class TestGcsDownscopedCredentials {
   }
 
   private static String listPrefix(String readOnly) {
-    return "api.getAttribute('storage.googleapis.com/objectListPrefix', '').matches('"
-        + RANDOMIZED_PART
-        + "\\\\Q"
+    String attribute = "api.getAttribute('storage.googleapis.com/objectListPrefix', '')";
+    return attribute
+        + ".startsWith('"
         + readOnly
-        + "\\\\E.*')";
+        + "/') || "
+        + attribute
+        + " == '"
+        + readOnly
+        + "'";
   }
 
   private static String resourceNameMatches(String bucketName, String writeable) {
-    return "resource.name.matches('\\\\Qprojects/_/buckets/"
+    return "resource.name.startsWith('projects/_/buckets/"
         + bucketName
-        + "/objects/\\\\E"
-        + RANDOMIZED_PART
-        + "\\\\Q"
+        + "/objects/"
         + writeable
-        + "\\\\E.*')";
+        + "/')";
   }
 }


### PR DESCRIPTION
## Summary

Down-scoped GCS credentials (`downscoped-credentials.enable=true`) never worked. Two
independent bugs make `GcsStorageSupplier.generateDelegationToken()` fail for every
credential-vending request:

1. `GcsClients.buildCredentials()` returns unscoped credentials. Without an OAuth2 scope,
   google-auth-library signs a self-signed JWT instead of fetching an access token, and
   Google's token exchange rejects it with `invalid_scope`.

2. The generated Credential Access Boundary conditions use CEL `matches()`:

   ```java
   return "resource.name.matches('"
       + quoteForCelString(format("projects/_/buckets/%s/objects/", bucket))
       + RANDOMIZED_PART
       + quoteForCelString(path)
       + ".*')";
   ```

   Google's IAM does not support `matches()` in these conditions, only `startsWith()`,
   `endsWith()` and equality. Every request is rejected with `invalid_request`, whatever the
   pattern contains. `Pattern.quote()` also produces `\Q...\E`, which is Java-specific and
   would not work even if regular expressions were supported.

The conditions are also too broad. A prefix without a trailing `/` matches sibling locations
that start with the same characters, so a credential for `warehouse/orders` also grants access
to `warehouse/orders2`. S3 avoids this because its resource ARN ends in `/*`, which stops the
prefix at a path boundary.

## Impact

Every Iceberg REST client loading a table from a warehouse with GCS down-scoped credentials
enabled gets an HTTP 500. The option is off by default and documented as experimental, so
deployments that never enabled it are unaffected.

Broken since the feature was added in 2b98754 (Aug 2024, #9302).

## Fix

Scope the source credentials to `https://www.googleapis.com/auth/cloud-platform`, and build the
conditions from `startsWith()` with a trailing `/`.

`RANDOMIZED_PART` goes away with the regex. It only existed to match the randomized
object-storage layout, and it did not match that layout anyway: the hash is inserted after
`write.data.path`, which Nessie sets to the warehouse, so those files land under
`<warehouse>/<hash>/<namespace>/<table>/` rather than between the bucket and the table path.

Verified against a real GCS bucket: a vended credential reads its own table (200), is denied a
sibling table (403), and lists the table prefix both with and without a trailing slash (200).

Credentials are scoped to a table's location, so they do not cover tables using
`write.object-storage.enabled=true`, whose data files live under a randomized prefix ahead of
the table path. That shape cannot be expressed with prefix conditions. This is documented on
the `enable()` option and in `SECURITY_THREAT_MODEL.md`.

## Tests

The existing tests asserted the `\Q...\E` expressions and passed, because the CEL evaluator
used in tests accepts `matches()` while Google's does not. They now assert the `startsWith()`
form, and the `validateCelSyntax` test fails if `matches()` reappears.
