### PR TITLE
add spark4.1 extension

### DIFF
--- a/build-logic/src/main/kotlin/Utilities.kt
+++ b/build-logic/src/main/kotlin/Utilities.kt
@@ -62,6 +62,7 @@ val noSourceCheckProjects =
     ":nessie-spark-extensions-3.5_2.12",
     ":nessie-spark-extensions-3.5_2.13",
     ":nessie-spark-extensions-4.0_2.13",
+    ":nessie-spark-extensions-4.1_2.13",
   )
 
 fun Project.libs(): VersionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
@@ -412,7 +413,8 @@ fun javaVersionForSpark(sparkMajorVersion: String): Int {
     "3.3",
     "3.4",
     "3.5",
-    "4.0" -> 17
+    "4.0",
+    "4.1" -> 17
     else ->
       throw IllegalArgumentException(
         "Do not know which Java version Spark $sparkMajorVersion supports"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -148,6 +148,7 @@ spark-sql-v34-v213 = { module = "org.apache.spark:spark-sql_2_13", version = { s
 spark-sql-v35-v212 = { module = "org.apache.spark:spark-sql_2_12", version = { strictly = "[3.5, 3.6[", prefer = "3.5.3"}}
 spark-sql-v35-v213 = { module = "org.apache.spark:spark-sql_2_13", version = { strictly = "[3.5, 3.6[", prefer = "3.5.3"}}
 spark-sql-v40-v213 = { module = "org.apache.spark:spark-sql_2_13", version = { strictly = "[4.0, 4.1[", prefer = "4.0.1"}}
+spark-sql-v41-v213 = { module = "org.apache.spark:spark-sql_2_13", version = { strictly = "[4.1, 4.2[", prefer = "4.1.3"}}
 testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version = "2.0.5" }
 testcontainers-keycloak = { module = "com.github.dasniko:testcontainers-keycloak", version = "4.3.1" }
 threeten-extra = { module = "org.threeten:threeten-extra", version = "1.10.0" }

--- a/integrations/spark-scala.properties
+++ b/integrations/spark-scala.properties
@@ -20,9 +20,9 @@
 # appear as a project in IntelliJ.
 
 # Note: the order here defines the order on https://projectnessie.org/guides/sql/
-sparkVersions=4.0,3.5,3.4
+sparkVersions=4.1,4.0,3.5,3.4
 
 sparkVersion-3.4-scalaVersions=2.13,2.12
 sparkVersion-3.5-scalaVersions=2.13,2.12
-sparkVersion-3.5-scalaVersions=2.13,2.12
 sparkVersion-4.0-scalaVersions=2.13
+sparkVersion-4.1-scalaVersions=2.13


### PR DESCRIPTION
Add Spark 4.1 (Scala 2.13, Java 17) integration test module mirroring the existing v4.0 structure.

Changes:

integrations/spark-scala.properties: register 4.1 with Scala 2.13
gradle/libs.versions.toml: add spark-sql-v40-v213 version catalog entry (strictly [4.1, 4.2[, prefer 4.1.3)
build-logic/Utilities.kt: map Spark 4.1 to Java toolchain 17 in javaVersionForSpark()
spark-extensions/v4.1/: new integration test sources

Closes https://github.com/projectnessie/nessie/issues/12919