### PR TITLE
Fix Spark artifacts in NMCP aggregation

### DIFF
--- a/build-logic/src/main/kotlin/Utilities.kt
+++ b/build-logic/src/main/kotlin/Utilities.kt
@@ -354,8 +354,6 @@ fun Project.getSparkScalaVersionsForProject(): SparkScalaVersions {
   val sparkMajorVersion = if (sparkScala[0][0].isDigit()) sparkScala[0] else "3.5"
   val scalaMajorVersion = sparkScala[1]
 
-  project.layout.buildDirectory.set(layout.buildDirectory.dir(scalaMajorVersion).get())
-
   return useSparkScalaVersionsForProject(sparkMajorVersion, scalaMajorVersion)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,10 @@ tasks.named("nmcpPublishAggregationToCentralPortal") {
   dependsOn(checkNmcpAggregationSparkArtifacts)
 }
 
+tasks.named("nmcpPublishAggregationToCentralPortalSnapshots") {
+  dependsOn(checkNmcpAggregationSparkArtifacts)
+}
+
 val buildToolIntegrationGradle =
   tasks.register<Exec>("buildToolIntegrationGradle") {
     group = "Verification"

--- a/nessie-iceberg/settings.gradle.kts
+++ b/nessie-iceberg/settings.gradle.kts
@@ -69,6 +69,13 @@ projectPathToGroupId[":"] = groupIdIntegrations
 gradle.beforeProject {
   version = baseVersion
   group = checkNotNull(projectPathToGroupId[path]) { "No groupId for project $path" }
+
+  if (name.startsWith("nessie-spark-extensions")) {
+    // The Scala variants share project directories, so isolate their outputs before plugins derive
+    // locations from the build directory.
+    val scalaMajorVersion = name.substringAfterLast('_')
+    layout.buildDirectory.set(layout.projectDirectory.dir("build/$scalaMajorVersion"))
+  }
 }
 
 fun nessieProject(name: String, groupId: String, directory: File): ProjectDescriptor {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -164,6 +164,13 @@ val allLoadedProjects = mutableListOf<ProjectDescriptor>()
 gradle.beforeProject {
   version = baseVersion
   group = checkNotNull(projectPathToGroupId[path]) { "No groupId for project $path" }
+
+  if (name.startsWith("nessie-spark-extensions")) {
+    // The Scala variants share project directories, so isolate their outputs before plugins such
+    // as NMCP derive locations from the build directory.
+    val scalaMajorVersion = name.substringAfterLast('_')
+    layout.buildDirectory.set(layout.projectDirectory.dir("build/$scalaMajorVersion"))
+  }
 }
 
 fun nessieProject(name: String, groupId: String, directory: File): ProjectDescriptor {


### PR DESCRIPTION
The NMCP settings plugin configures publication repositories before the Spark projects change their build directories. NMCP therefore published into `build/nmcp/m2`, while aggregation looked in the Scala-specific `build/<scala>/nmcp/m2` directories.

Move the Scala-specific build-directory setup into the settings `beforeProject` hooks, before project plugins are applied. Apply the same setup to the standalone `nessie-iceberg` build.

Also run the Spark artifact check before snapshot publication, so incomplete snapshot bundles fail locally instead of being uploaded.