### PR TITLE
Fix Maven publication

### DIFF
--- a/build-logic/src/main/kotlin/PublishingHelperPlugin.kt
+++ b/build-logic/src/main/kotlin/PublishingHelperPlugin.kt
@@ -58,7 +58,6 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
         ) {
           val publishingHelper = extensions.getByType<PublishingHelperExtension>()
           val projectName = project.name
-          val projectDescription = project.description
           val projectVersion = project.version.toString()
           val isRootProject = project == rootProject
           val parentGroup = project.parent?.group?.toString()
@@ -70,7 +69,6 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
 
           pom {
             name.set(publishingHelper.mavenName.orElse(projectName))
-            description.set(projectDescription)
 
             if (isRootProject) {
               val repoUrl =
@@ -182,6 +180,9 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
       configureSigning(publication.get())
 
       tasks.named("generatePomFileForMavenPublication", GenerateMavenPom::class.java).configure {
+        // Project build scripts assign their descriptions after applying the convention plugins.
+        pom.description.set(project.description)
+
         if (project == rootProject) {
           inputs
             .file(layout.projectDirectory.file("gradle/developers.csv"))
@@ -314,12 +315,12 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
     }
     // Sonatype requires the javadoc and sources jar to be present, but the
     // Shadow extension does not publish those.
-    project.configurations.findByName("javadocElements")?.let {
-      component.addVariantsFromConfiguration(it) {}
-    }
-    project.configurations.findByName("sourcesElements")?.let {
-      component.addVariantsFromConfiguration(it) {}
-    }
+    // Those configurations can be created after the Shadow plugin has been applied.
+    project.configurations
+      .matching { it.name == "javadocElements" || it.name == "sourcesElements" }
+      .configureEach {
+        component.addVariantsFromConfiguration(this) {}
+      }
     mavenPublication.from(component)
 
     // This a replacement to add dependencies to the pom, if necessary. Equivalent to

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,12 +73,28 @@ val checkNmcpAggregationSparkArtifacts =
     version.set(project.version.toString())
   }
 
+val checkNmcpAggregationPublishingRequirements =
+  tasks.register<CheckNmcpAggregationPublishingRequirements>(
+    "checkNmcpAggregationPublishingRequirements"
+  ) {
+    group = "Verification"
+    description =
+      "Checks that the NMCP aggregation zip satisfies Maven Central publishing requirements."
+
+    dependsOn("nmcpZipAggregation")
+    aggregationZip.set(layout.buildDirectory.file("nmcp/zip/aggregation.zip"))
+    artifactsRequiringClassifiers.set(listOf("nessie-gc-tool"))
+    version.set(project.version.toString())
+  }
+
 tasks.named("nmcpPublishAggregationToCentralPortal") {
   dependsOn(checkNmcpAggregationSparkArtifacts)
+  dependsOn(checkNmcpAggregationPublishingRequirements)
 }
 
 tasks.named("nmcpPublishAggregationToCentralPortalSnapshots") {
   dependsOn(checkNmcpAggregationSparkArtifacts)
+  dependsOn(checkNmcpAggregationPublishingRequirements)
 }
 
 val buildToolIntegrationGradle =
@@ -255,6 +271,88 @@ abstract class CheckNmcpAggregationSparkArtifacts : DefaultTask() {
       Regex(
         Regex.escape("$artifactId-${version.removeSuffix("-SNAPSHOT")}-") +
           """\d{8}\.\d{6}-\d+\.jar"""
+      )
+
+    return entry.startsWith(artifactDir) &&
+      (fileName == expectedReleaseFileName ||
+        (version.endsWith("-SNAPSHOT") && expectedSnapshotFileName.matches(fileName)))
+  }
+}
+
+abstract class CheckNmcpAggregationPublishingRequirements : DefaultTask() {
+  @get:InputFile abstract val aggregationZip: RegularFileProperty
+
+  @get:Input abstract val artifactsRequiringClassifiers: ListProperty<String>
+
+  @get:Input abstract val version: Property<String>
+
+  @TaskAction
+  fun checkAggregationZip() {
+    val resolvedVersion = version.get()
+
+    ZipFile(aggregationZip.get().asFile).use { zip ->
+      val entries = zip.entries().asSequence().toList()
+      val entryNames = entries.map { it.name }.toSet()
+      val rootPomDir = "org/projectnessie/nessie/nessie/$resolvedVersion/"
+      val rootPom = entries.singleOrNull {
+        it.name.startsWith(rootPomDir) && it.name.endsWith(".pom")
+      }
+
+      check(rootPom != null) {
+        "NMCP aggregation zip is missing the root POM for version $resolvedVersion"
+      }
+
+      val rootPomText = zip.getInputStream(rootPom).bufferedReader().use { it.readText() }
+      check(Regex("<description>\\s*[^<\\s]").containsMatchIn(rootPomText)) {
+        "NMCP aggregation root POM is missing the project description for version $resolvedVersion"
+      }
+
+      val missingClassifiedArtifacts =
+        artifactsRequiringClassifiers.get().mapNotNull { artifactId ->
+          val artifactDir =
+            entries
+              .asSequence()
+              .map { it.name }
+              .filter { it.endsWith(".pom") }
+              .map { it.substringBeforeLast('/') + "/" }
+              .singleOrNull {
+                it.removeSuffix("/").substringBeforeLast('/').substringAfterLast('/') == artifactId
+              }
+
+          if (artifactDir == null) {
+            "$artifactId (publication)"
+          } else {
+            val missing =
+              listOf("sources", "javadoc").filter { classifier ->
+                entryNames.none {
+                  isJar(it, artifactDir, artifactId, resolvedVersion, classifier)
+                }
+              }
+            if (missing.isEmpty()) null else "$artifactId (${missing.joinToString(", ")})"
+          }
+        }
+
+      check(missingClassifiedArtifacts.isEmpty()) {
+        "NMCP aggregation zip is missing classified artifacts for version $resolvedVersion: " +
+          missingClassifiedArtifacts.joinToString(", ")
+      }
+    }
+  }
+
+  private fun isJar(
+    entry: String,
+    artifactDir: String,
+    artifactId: String,
+    version: String,
+    classifier: String?,
+  ): Boolean {
+    val fileName = entry.substringAfterLast('/')
+    val classifierSuffix = classifier?.let { "-$it" }.orEmpty()
+    val expectedReleaseFileName = "$artifactId-$version$classifierSuffix.jar"
+    val expectedSnapshotFileName =
+      Regex(
+        Regex.escape("$artifactId-${version.removeSuffix("-SNAPSHOT")}-") +
+          """\d{8}\.\d{6}-\d+$classifierSuffix\.jar"""
       )
 
     return entry.startsWith(artifactDir) &&


### PR DESCRIPTION
After the NMCP migration, the root pom.xml misses the mandatory `<description>` element, leading to publication failures.